### PR TITLE
Adding the `Rejected` Event Type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "xdm",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Experience Data Models",
   "main": "",
   "config": {
     "aem_user": "packageUser",
     "aem_password": "override me securely",
     "markdown-importer-version": "0.0.4",
-    "schemas": 44
+    "schemas": 45
   },
   "scripts": {
     "clean": "rm -rf docs/reference",

--- a/schemas/common/event/rejected.description.md
+++ b/schemas/common/event/rejected.description.md
@@ -1,8 +1,13 @@
-A `rejected event` follows semantics that are exactly equivalent to the semantics described by the [`reject activity`](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-reject), except for one difference. The `reject activity` can be used in both passive and imperative contexts, however, the `rejected event` can only be used in passive contexts.
+A `rejected event` follows the semantics of the [reject activity in W3C activity streams](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-reject), with one notable difference. 
+The W3C `reject activity` can be used to express two things:
 
-The semantics as defined by the `reject activity` are, that the `actor` is rejecting the `object`. And that the `target` and `origin` typically have no defined meaning.
+1. either an order to reject something
+2. or the observation of a rejection
 
-Some examples of the `rejected event` -
+The XDM `rejected event` is only valid in the latter case, i.e. to express that something (the `object`) has been rejected by someone (the `actor`).
+`target` and `origin` have no specific meaning for rejections.
+
+Some examples of the `rejected event` include:
 1. Changes to an asset were rejected by the editor/approver.
 2. A batch processing job was rejected by a service on account of runtime errors that occurred during processing.
 3. A loan application was rejected by a financial institution.

--- a/schemas/common/event/rejected.description.md
+++ b/schemas/common/event/rejected.description.md
@@ -1,4 +1,4 @@
-A `rejected event` follows semantics that are exactly equivalent to the semantics described by the [`reject activity`](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-reject), except for one difference. The `reject activity` can be used in imperative contexts, however, the `rejected event` can only be used in passive contexts.
+A `rejected event` follows semantics that are exactly equivalent to the semantics described by the [`reject activity`](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-reject), except for one difference. The `reject activity` can be used in both passive and imperative contexts, however, the `rejected event` can only be used in passive contexts.
 
 The semantics as defined by the `reject activity` are, that the `actor` is rejecting the `object`. And that the `target` and `origin` typically have no defined meaning.
 

--- a/schemas/common/event/rejected.description.md
+++ b/schemas/common/event/rejected.description.md
@@ -1,0 +1,9 @@
+A `rejected event` follows semantics that are exactly equivalent to the semantics described by the [`reject activity`](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-reject), except for one difference. The `reject activity` can be used in imperative contexts, however, the `rejected event` can only be used in passive contexts.
+
+The semantics as defined by the `reject activity` are, that the `actor` is rejecting the `object`. And that the `target` and `origin` typically have no defined meaning.
+
+Some examples of the `rejected event` -
+1. Changes to an asset were rejected by the editor/approver.
+2. A batch processing job was rejected by a service on account of runtime errors that occurred during processing.
+3. A loan application was rejected by a financial institution.
+4. A purchase order was rejected by a firm owing to non payment of previous dues.

--- a/schemas/common/event/rejected.example.1.json
+++ b/schemas/common/event/rejected.example.1.json
@@ -1,34 +1,34 @@
 {
-    "@id": "https://events.adobe.io/events/id/82235bac-2b81-4e70-90b5-2bd1f04b5c7b",
-    "activitystreams:published": "2016-07-16T19:20:30+01:00",
-    "activitystreams:to": {
-        "https://ns.adobe.com/xdm-extensions/ims/user#id": "C74F69D7594880280A495D09@AdobeID",
-        "@type": "https://ns.adobe.com/xdm-extensions/ims/user"
+  "@id": "https://events.adobe.io/events/id/82235bac-2b81-4e70-90b5-2bd1f04b5c7b",
+  "activitystreams:published": "2016-07-16T19:20:30+01:00",
+  "activitystreams:to": {
+    "https://ns.adobe.com/xdm-extensions/ims/user#id": "C74F69D7594880280A495D09@AdobeID",
+    "@type": "https://ns.adobe.com/xdm-extensions/ims/user"
+  },
+  "@type": "https://ns.adobe.com/xdm/common/event/rejected",
+  "xdm:objectType": "https://stock.adobe.com/content/json/2017-08-31",
+  "activitystreams:actor": {
+    "name": "Adobe Stock Ingestion Service",
+    "@type": "http://www.w3.org/ns/activitystreams#Service"
+  },
+  "activitystreams:object": {
+    "@type": "https://stock.adobe.com/content/json/2017-08-31",
+    "filename": "2017-03-20T183243Z_131980992_RC110C7B3030_RTRMADP_0_BRAZIL-CORRUPTION-FOOD.JSON",
+    "url": "http://s3.amazonaws.com/bucket/asset/file.jpg",
+    "activitystreams:generator": {
+      "name": "reuters"
+    }
+  },
+  "activitystreams:attributedTo": [
+    {
+      "code": "ASSET_TYPE_EMPTY",
+      "message": "Asset type is empty",
+      "location_type": "jsonpath",
+      "location": "$.type"
     },
-    "@type": "https://ns.adobe.com/xdm/common/event/rejected",
-    "xdm:objectType": "https://stock.adobe.com/content/json/2017-08-31",
-    "activitystreams:actor": {
-        "name": "Adobe Stock Ingestion Service",
-        "@type": "http://www.w3.org/ns/activitystreams#Service"
-    },
-    "activitystreams:object": {
-        "@type": "https://stock.adobe.com/content/json/2017-08-31",
-        "filename": "2017-03-20T183243Z_131980992_RC110C7B3030_RTRMADP_0_BRAZIL-CORRUPTION-FOOD.JSON",
-        "url": "http://s3.amazonaws.com/bucket/asset/file.jpg",
-        "activitystreams:generator": {
-            "name": "reuters"
-        }
-    },
-    "activitystreams:attributedTo": [
-        {
-            "code": "ASSET_TYPE_EMPTY",
-            "message": "Asset type is empty",
-            "location_type": "jsonpath",
-            "location": "$.type"
-         },
-         {
-            "code": "SIGNAL_KEY_NOT_ARRAY",
-            "message": "Signal key is not an array"
-         }
-    ]
+    {
+      "code": "SIGNAL_KEY_NOT_ARRAY",
+      "message": "Signal key is not an array"
+    }
+  ]
 }

--- a/schemas/common/event/rejected.example.1.json
+++ b/schemas/common/event/rejected.example.1.json
@@ -1,0 +1,34 @@
+{
+    "@id": "https://events.adobe.io/events/id/82235bac-2b81-4e70-90b5-2bd1f04b5c7b",
+    "activitystreams:published": "2016-07-16T19:20:30+01:00",
+    "activitystreams:to": {
+        "https://ns.adobe.com/xdm-extensions/ims/user#id": "C74F69D7594880280A495D09@AdobeID",
+        "@type": "https://ns.adobe.com/xdm-extensions/ims/user"
+    },
+    "@type": "https://ns.adobe.com/xdm/common/event/rejected",
+    "xdm:objectType": "https://stock.adobe.com/content/json/2017-08-31",
+    "activitystreams:actor": {
+        "name": "Adobe Stock Ingestion Service",
+        "@type": "http://www.w3.org/ns/activitystreams#Service"
+    },
+    "activitystreams:object": {
+        "@type": "https://stock.adobe.com/content/json/2017-08-31",
+        "filename": "2017-03-20T183243Z_131980992_RC110C7B3030_RTRMADP_0_BRAZIL-CORRUPTION-FOOD.JSON",
+        "url": "http://s3.amazonaws.com/bucket/asset/file.jpg",
+        "activitystreams:generator": {
+            "name": "reuters"
+        }
+    },
+    "activitystreams:attributedTo": [
+        {
+            "code": "ASSET_TYPE_EMPTY",
+            "message": "Asset type is empty",
+            "location_type": "jsonpath",
+            "location": "$.type"
+         },
+         {
+            "code": "SIGNAL_KEY_NOT_ARRAY",
+            "message": "Signal key is not an array"
+         }
+    ]
+}

--- a/schemas/common/event/rejected.schema.json
+++ b/schemas/common/event/rejected.schema.json
@@ -9,7 +9,7 @@
   "$id": "https://ns.adobe.com/xdm/common/event/rejected",
   "type": "object",
   "title": "Rejected Event",
-  "description": "A `rejected event` follows semantics that are exactly equivalent to the semantics described by the [`reject activity`](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-reject), except for one difference. The `reject activity` can be used in imperative contexts, however, the `rejected event` can only be used in passive contexts.",
+  "description": "",
   "allOf": [
     {
       "$ref": "https://ns.adobe.com/xdm/common/eventenvelope"

--- a/schemas/common/event/rejected.schema.json
+++ b/schemas/common/event/rejected.schema.json
@@ -1,0 +1,26 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "https://ns.adobe.com/xdm/common/event/rejected",
+  "type": "object",
+  "title": "Rejected Event",
+  "description": "A `rejected event` follows semantics that are exactly equivalent to the semantics described by the [`reject activity`](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-reject), except for one difference. The `reject activity` can be used in imperative contexts, however, the `rejected event` can only be used in passive contexts.",
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/eventenvelope"
+    },
+    {
+      "properties": {
+        "@type": {
+          "type": "string",
+          "const": "https://ns.adobe.com/xdm/common/event/rejected"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Author Notes

On the same lines as the passive CRUD events added in [a previous PR](https://git.corp.adobe.com/AdobeCloudPlatform/xdm/pull/81), I am adding the `Rejected` event type.

The `Rejected` event is a past tense form of the [`Reject` Activity](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-reject) and represents the act of an `actor` rejecting the `object`.