### PR TITLE
Updated and Refactored Geo Schemas

### DIFF
--- a/meta.schema.json
+++ b/meta.schema.json
@@ -17,7 +17,7 @@
     "$id": {
       "type": "string",
       "format": "uri",
-      "pattern": "https://ns.adobe.com/xdm/.*"
+      "pattern": "(https://ns\\.adobe\\.com/xdm/[a-z0-9-/]*)|(http://schema\\.org/.*)"
     },
     "meta:license": {
       "type": "array",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "xdm",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Experience Data Models",
   "main": "",
   "config": {
     "aem_user": "packageUser",
     "aem_password": "override me securely",
     "markdown-importer-version": "0.0.4",
-    "schemas": 46
+    "schemas": 49
   },
   "scripts": {
     "clean": "rm -rf docs/reference",

--- a/schemas/common/context.jsonld
+++ b/schemas/common/context.jsonld
@@ -26,6 +26,7 @@
     "stLayerGroup": "http://ns.adobe.com/core/1.0/sType/LayerGroup#",
     "stArtboard": "http://ns.adobe.com/core/1.0/sType/Artboard#",
     "exif": "http://ns.adobe.com/exif/1.0/#",
-    "activitystreams": "https://www.w3.org/ns/activitystreams"
+    "activitystreams": "https://www.w3.org/ns/activitystreams",
+    "schema": "http://schema.org",
   }
 }

--- a/schemas/common/extensible.schema.json
+++ b/schemas/common/extensible.schema.json
@@ -43,6 +43,7 @@
             "^stArtboard:.*$": {},
             "^exif:.*$": {},
             "^activitystreams:.*$": {},
+            "^schema:.*$": {},
             ".+://.+": {}
           },
           "additionalProperties": false
@@ -187,6 +188,11 @@
                   "type": "string",
                   "format": "url",
                   "const": "https://www.w3.org/ns/activitystreams"
+                },
+                "schema": {
+                  "type": "string",
+                  "format": "url",
+                  "const": "http://schema.org/"
                 }
               },
               "additionalProperties": false,
@@ -223,6 +229,7 @@
             "^stArtboard:.*$": {},
             "^exif:.*$": {},
             "^activitystreams:.*$": {},
+            "^schema:.*$": {},
             ".+://.+": {}
           },
           "required": [

--- a/schemas/common/geo.example.1.json
+++ b/schemas/common/geo.example.1.json
@@ -1,8 +1,9 @@
 {
+  "@id": "https://ns.adobe.com/entities/geo/tokyo",
   "xdm:countryCode": "JP",
   "xdm:stateProvince": "Tōkyō-to",
   "xdm:city": "Tōkyō",
   "xdm:postalCode": "141-0032",
-  "xdm:latitude": 35.6185,
-  "xdm:longitude": 139.73237
+  "schema:latitude": 35.6185,
+  "schema:longitude": 139.73237
 }

--- a/schemas/common/geo.example.2.json
+++ b/schemas/common/geo.example.2.json
@@ -1,4 +1,5 @@
 {
+  "@id": "https://ns.adobe.com/entities/geo/potsdam",
   "xdm:countryCode": "DE",
   "xdm:stateProvince": "Brandenburg",
   "xdm:city": "Potsdam",

--- a/schemas/common/geo.schema.json
+++ b/schemas/common/geo.schema.json
@@ -5,10 +5,13 @@
     "you may not use this file except in compliance with the License. You may obtain a copy",
     "of the License at https://creativecommons.org/licenses/by/4.0/"
   ],
-  "$id": "https://ns.adobe.com/xdm/common/geo.schema.json",
+  "$id": "https://ns.adobe.com/xdm/common/geo",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "type": "object",
   "meta:extensible": true,
+  "meta:extends": [
+    "http://schema.org/GeoCoordinates"
+  ],
   "title": "Geo",
   "description": "The geographic related data where an event was observed.",
   "definitions": {
@@ -44,25 +47,14 @@
           "title": "Metropolitan Statistical Area",
           "type": "integer",
           "description": "The Metropolitan Statistical Area in the USA where the observation occurred."
-        },
-        "xdm:latitude": {
-          "title": "Latitude",
-          "type": "number",
-          "minimum": -90,
-          "maximum": 90,
-          "description": "The signed vertical coordinate of a geographic point."
-        },
-        "xdm:longitude": {
-          "title": "Longitude",
-          "type": "number",
-          "minimum": -180,
-          "maximum": 180,
-          "description": "The signed horizontal coordinate of a geographic point."
         }
       }
     }
   },
   "allOf": [
+    {
+      "$ref": "http://schema.org/GeoCoordinates"
+    },
     {
       "$ref": "#/definitions/geo"
     }

--- a/schemas/external/schema/geocircle.example.1.json
+++ b/schemas/external/schema/geocircle.example.1.json
@@ -1,0 +1,12 @@
+{
+  "@id": "https://ns.adobe.com/entities/geo/circleid123",
+  "schema:description": "New York Metro",
+  "schema:coordinates": {
+    "@id": "https://ns.adobe.com/entities/geo/111",
+    "schema:description": "New York",
+    "schema:latitude": 37.3308953,
+    "schema:longitude": -121.8939894,
+    "schema:elevation": 31.0896
+  },
+  "schema:radius": 80000
+}

--- a/schemas/external/schema/geocircle.schema.json
+++ b/schemas/external/schema/geocircle.schema.json
@@ -1,0 +1,47 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "http://schema.org/GeoCircle",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Geo Circle",
+  "type": "object",
+  "description": "A circular region of a particular radius centered on a GeoCoordinate. Based on [schema.org](http://schema.org/GeoCircle)",
+  "definitions": {
+    "geocircle": {
+      "properties": {
+        "@id": {
+          "title": "Identifier",
+          "type": "string",
+          "description": "The unique identifier of the circle."
+        },
+        "schema:description": {
+          "title": "Description",
+          "type": "string",
+          "description": "A description of what the circle contains."
+        },
+        "schema:coordinates": {
+          "title": "Coordinates",
+          "$ref": "http://schema.org/GeoCoordinates",
+          "description": ""
+        },
+        "schema:radius": {
+          "title": "Radius",
+          "type": "number",
+          "description": "The length of the radius of the circle. This value conforms to the WGS84 datum and is measured in meters."
+        }
+      },
+      "required": [
+        "@id"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/geocircle"
+    }
+  ]
+}

--- a/schemas/external/schema/geocoordinates.example.1.json
+++ b/schemas/external/schema/geocoordinates.example.1.json
@@ -1,0 +1,7 @@
+{
+  "@id": "https://ns.adobe.com/entities/geo/111",
+  "xdm:description": "New York",
+  "xdm:latitude": 37.3308953,
+  "xdm:longitude": -121.8939894,
+  "xdm:elevation": 31.0896
+}

--- a/schemas/external/schema/geocoordinates.schema.json
+++ b/schemas/external/schema/geocoordinates.schema.json
@@ -1,0 +1,58 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "http://schema.org/GeoCoordinates",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Geo Coordinates",
+  "type": "object",
+  "meta:extensible": true,
+  "description": "The geographic coordinates of a place. Based on [schema.org](http://schema.org/GeoCoordinates).",
+  "definitions": {
+    "geocoordinates": {
+      "properties": {
+        "@id": {
+          "title": "Coordinates Id",
+          "type": "string",
+          "format": "uri",
+          "description": "The unique identifier of the coordinates."
+        },
+        "schema:description": {
+          "title": "Description",
+          "type": "string",
+          "description": "A description of what the coordinates identify."
+        },
+        "schema:latitude": {
+          "title": "Latitude",
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90,
+          "description": "The signed vertical coordinate of a geographic point."
+        },
+        "schema:longitude": {
+          "title": "Longitude",
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180,
+          "description": "The signed horizontal coordinate of a geographic point."
+        },
+        "schema:elevation": {
+          "title": "Elevation",
+          "type": "number",
+          "description": "The specific altitude of the defined coordinate. The value conforms to the WGS84 datum and is measured in meters."
+        }
+      },
+      "required": [
+        "@id"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/geocoordinates"
+    }
+  ]
+}

--- a/schemas/external/schema/geocoordinates.schema.json
+++ b/schemas/external/schema/geocoordinates.schema.json
@@ -42,7 +42,7 @@
         "schema:elevation": {
           "title": "Elevation",
           "type": "number",
-          "description": "The specific altitude of the defined coordinate. The value conforms to the WGS84 datum and is measured in meters."
+          "description": "The specific elevation of the defined coordinate. The value conforms to the [WGS84](http://gisgeography.com/wgs84-world-geodetic-system/) datum and is measured in meters."
         }
       },
       "required": [

--- a/schemas/external/schema/geoshape.example.1.json
+++ b/schemas/external/schema/geoshape.example.1.json
@@ -1,0 +1,16 @@
+{
+  "@id": "https://ns.adobe.com/entities/geo/shapeid123",
+  "schema:description": "GeoCircle of New York Metro",
+  "schema:circle": {
+    "@id": "https://ns.adobe.com/entities/geo/circleid123",
+    "schema:description": "New York Metro",
+    "schema:coordinates": {
+      "@id": "https://ns.adobe.com/entities/geo/111",
+      "schema:description": "New York",
+      "schema:latitude": 37.3308953,
+      "schema:longitude": -121.8939894,
+      "schema:elevation": 31.0896
+    },
+    "schema:radius": 80000
+  }
+}

--- a/schemas/external/schema/geoshape.schema.json
+++ b/schemas/external/schema/geoshape.schema.json
@@ -50,12 +50,12 @@
         "schema:elevation": {
           "title": "Elevation",
           "type": "number",
-          "description": "The specific or minimum altitude of the shape. This value conforms to the WGS84 datum and is measured in meters."
+          "description": "The specific or minimum elevation of the shape. This value conforms to the [WGS84](http://gisgeography.com/wgs84-world-geodetic-system/) datum and is measured in meters."
         },
         "xdm:ceiling": {
           "title": "Ceiling",
           "type": "number",
-          "description": "The maximum altitude of the shape. Only valid when used in combination with elevation. This value conforms to the WGS84 datum and is measured in meters. This value is not part of the schema.org spec."
+          "description": "The maximum elevation of the shape. Only valid when used in combination with `elevation`. This value conforms to the [WGS84](http://gisgeography.com/wgs84-world-geodetic-system/) datum and is measured in meters. This value is not part of the schema.org spec."
         }
       },
       "required": [

--- a/schemas/external/schema/geoshape.schema.json
+++ b/schemas/external/schema/geoshape.schema.json
@@ -1,0 +1,71 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "http://schema.org/GeoShape",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Geo Shape",
+  "type": "object",
+  "description": "The geographic shape of a place. Based on [schema.org](http://schema.org/GeoShape).",
+  "definitions": {
+    "geoshape": {
+      "properties": {
+        "@id": {
+          "title": "Shape Id",
+          "type": "string",
+          "description": "The unique identifier of the shape."
+        },
+        "schema:description": {
+          "title": "Description",
+          "type": "string",
+          "description": "A description of what the shape is defining."
+        },
+        "schema:polygon": {
+          "title": "Polygon",
+          "type": "array",
+          "items": {
+            "$ref": "http://schema.org/GeoCoordinates"
+          },
+          "description": "A series of four or more coordinates where the first and final coordinates are identical. In schema.org, this is a plain text. In XDM, it is a structured array instead.",
+          "minItems": 4
+        },
+        "schema:circle": {
+          "title": "Circle",
+          "$ref": "http://schema.org/GeoCircle",
+          "description": "A circular region with a specific radius centered on a geographic coordinate."
+        },
+        "schema:box": {
+          "title": "Box",
+          "type": "array",
+          "items": {
+            "$ref": "http://schema.org/GeoCoordinates"
+          },
+          "description": "The area enclosed by the rectangle formed by two coordinates. The first coordinate is the lower corner and the second coordinate is the upper corner of a rectangle.",
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "schema:elevation": {
+          "title": "Elevation",
+          "type": "number",
+          "description": "The specific or minimum altitude of the shape. This value conforms to the WGS84 datum and is measured in meters."
+        },
+        "xdm:ceiling": {
+          "title": "Ceiling",
+          "type": "number",
+          "description": "The maximum altitude of the shape. Only valid when used in combination with elevation. This value conforms to the WGS84 datum and is measured in meters. This value is not part of the schema.org spec."
+        }
+      },
+      "required": [
+        "@id"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/geoshape"
+    }
+  ]
+}


### PR DESCRIPTION
This is one part of #59:

I have taken @jwen-adobe's work for #60, moved it into the new `experience-cloud-staging` branch, and started my clean-up work there. This includes:

* @jwen-adobe has modeled the geo-schemas after schema.org, which is great. To make it official, I've moved them into the `schemas/external/schema` folder
* our old `common/geo` schema now extends `external/schema/geocoordinates`
* I've adjusted the meta-schema and JSON-LD files so that schema.org URLs and prefixes get recognized

Finally, I've prepared this pull request by selectively checking out the files that have been modified using:

```bash
$ git checkout 26e870534924ed6457c006cc3868ba9f07f5d481 \
  meta.schema.json \
  schemas/common/context.jsonld \
  schemas/common/extensibile.schema.json \
  schemas/common/geo.schema.json \
  schemas/common/geo.example.1.json \
  schemas/common/geo.example.2.json \
  schemas/common/geo.invalid.1.json \
  schemas/external/schema

$ npm run lint && npm run test
$ git commit -a
$ git push
```

Note: 26e870534924ed6457c006cc3868ba9f07f5d481 is the latest commit on the experience-cloud-staging branch, it includes the entire history of these files. We can use this model to move things out of the experience-cloud-staging branch step by step.