### PR TITLE
A consistent way to model channels

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,7 @@
     "aem_user": "packageUser",
     "aem_password": "override me securely",
     "markdown-importer-version": "0.0.4",
-<<<<<<< HEAD
     "schemas": 79
-=======
-    "schemas": 61
->>>>>>> master
   },
   "scripts": {
     "clean": "rm -rf docs/reference",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "aem_user": "packageUser",
     "aem_password": "override me securely",
     "markdown-importer-version": "0.0.4",
-    "schemas": 62
+    "schemas": 79
   },
   "scripts": {
     "clean": "rm -rf docs/reference",

--- a/schemas/channels/adm.example.1.json
+++ b/schemas/channels/adm.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/adm",
+  "@type": "https://ns.adobe.com/xdm/channel-types/mobile"
+}

--- a/schemas/channels/adm.schema.json
+++ b/schemas/channels/adm.schema.json
@@ -5,10 +5,10 @@
     "you may not use this file except in compliance with the License. You may obtain a copy",
     "of the License at https://creativecommons.org/licenses/by/4.0/"
   ],
-  "$id": "https://ns.adobe.com/xdm/channels/web",
+  "$id": "https://ns.adobe.com/xdm/channels/adm",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Web",
-  "description": "The world wide web and mobile web. Pages delivered via HTTP to a web browser or in-app browser.",
+  "title": "ADM",
+  "description": "Amazon Device Messaging",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
@@ -20,12 +20,12 @@
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/channels/web",
+          "const": "https://ns.adobe.com/xdm/channels/adm",
           "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
-          "const": "pull",
+          "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
             "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
@@ -37,7 +37,7 @@
           "type": "string",
           "format": "uri",
           "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
-          "const": "https://ns.adobe.com/xdm/channel-types/web",
+          "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
             "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
             "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",

--- a/schemas/channels/adm.schema.json
+++ b/schemas/channels/adm.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/apns.example.1.json
+++ b/schemas/channels/apns.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/apns",
+  "@type": "https://ns.adobe.com/xdm/channel-types/mobile"
+}

--- a/schemas/channels/apns.schema.json
+++ b/schemas/channels/apns.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/apns",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "APNS",
+  "description": "Apple Push Notification Service",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/channels/apns",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "push",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/mobile",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/apns.schema.json
+++ b/schemas/channels/apns.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/baidu.example.1.json
+++ b/schemas/channels/baidu.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/baidu",
+  "@type": "https://ns.adobe.com/xdm/channel-types/mobile"
+}

--- a/schemas/channels/baidu.schema.json
+++ b/schemas/channels/baidu.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/baidu",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Baidu",
+  "description": "Baidu Cloud Push Service",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/channels/baidu",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "push",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/mobile",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/baidu.schema.json
+++ b/schemas/channels/baidu.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/channel.schema.json
+++ b/schemas/channels/channel.schema.json
@@ -51,7 +51,17 @@
             "type": "string",
             "format": "uri",
             "description": "The `@type` of an XDM-defined content type that is supported by this channel."
-          }
+          },
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type":"array",
+          "items": {
+            "type": "string",
+            "format": "uri",
+            "description": "The `@type` of an XDM-defined metric that is supported by this channel."
+          },
+          "description": "The metrics that can be collected in this channel."
         }
       }
     }

--- a/schemas/channels/channel.schema.json
+++ b/schemas/channels/channel.schema.json
@@ -44,6 +44,14 @@
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
             "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri",
+            "description": "The `@type` of an XDM-defined content type that is supported by this channel."
+          }
         }
       }
     }

--- a/schemas/channels/channel.schema.json
+++ b/schemas/channels/channel.schema.json
@@ -11,6 +11,7 @@
   "meta:extensible": true,
   "meta:abstract": true,
   "type": "object",
+  "description": "",
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/channel.schema.json
+++ b/schemas/channels/channel.schema.json
@@ -14,7 +14,7 @@
     "channel": {
       "properties": {
         "@id": {
-          "type":"string",
+          "type": "string",
           "format": "uri",
           "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
@@ -55,7 +55,7 @@
           "description": "The content types that this channel can deliver."
         },
         "xdm:metricTypes": {
-          "type":"array",
+          "type": "array",
           "items": {
             "type": "string",
             "format": "uri",
@@ -76,8 +76,12 @@
     }
   },
   "allOf": [
-    {"$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"},
-    {"$ref": "#/definitions/channel"}
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
   ],
   "required": [
     "@id"

--- a/schemas/channels/channel.schema.json
+++ b/schemas/channels/channel.schema.json
@@ -62,6 +62,15 @@
             "description": "The `@type` of an XDM-defined metric that is supported by this channel."
           },
           "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri",
+            "description": "The `@type` of an XDM-defined location (virtual place) that this channel can contain."
+          },
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }

--- a/schemas/channels/channel.schema.json
+++ b/schemas/channels/channel.schema.json
@@ -10,6 +10,7 @@
   "title": "Experience Channel",
   "meta:extensible": true,
   "meta:abstract": true,
+  "type": "object",
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/direct-mail.example.1.json
+++ b/schemas/channels/direct-mail.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/direct-mail",
+  "@type": "https://ns.adobe.com/xdm/channel-types/offline"
+}

--- a/schemas/channels/direct-mail.schema.json
+++ b/schemas/channels/direct-mail.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/direct-mail",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Direct Mail",
+  "description": "Mail delivered by a postal service.",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "push",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/offline",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/direct-mail.schema.json
+++ b/schemas/channels/direct-mail.schema.json
@@ -21,7 +21,7 @@
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "",
+          "const": "https://ns.adobe.com/xdm/channels/direct-mail",
           "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {

--- a/schemas/channels/direct-mail.schema.json
+++ b/schemas/channels/direct-mail.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/email.example.1.json
+++ b/schemas/channels/email.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/email",
+  "@type": "https://ns.adobe.com/xdm/channel-types/email"
+}

--- a/schemas/channels/email.schema.json
+++ b/schemas/channels/email.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/email",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "E-Mail",
+  "description": "E-Mail messages, delivered via SMTP to list subscribers.",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/channels/email",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "push",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/email",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/email.schema.json
+++ b/schemas/channels/email.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/facebook-feed.example.1.json
+++ b/schemas/channels/facebook-feed.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/facebook-feed",
+  "@type": "https://ns.adobe.com/xdm/channel-types/social"
+}

--- a/schemas/channels/facebook-feed.schema.json
+++ b/schemas/channels/facebook-feed.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/facebook-feed",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Facebook News Feed",
+  "description": "The Facebook News Feed. This does not include Facebook Messenger, or Facebook App pages.",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/channels/facebook-feed",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "push",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/social",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/facebook-feed.schema.json
+++ b/schemas/channels/facebook-feed.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/fax.example.1.json
+++ b/schemas/channels/fax.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/fax",
+  "@type": "https://ns.adobe.com/xdm/channel-types/offline"
+}

--- a/schemas/channels/fax.schema.json
+++ b/schemas/channels/fax.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/fax",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Fax",
+  "description": "Telefacsimile",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/channels/fax",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "push",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/offline",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/fax.schema.json
+++ b/schemas/channels/fax.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/gcm.example.1.json
+++ b/schemas/channels/gcm.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/gcm",
+  "@type": "https://ns.adobe.com/xdm/channel-types/mobile"
+}

--- a/schemas/channels/gcm.schema.json
+++ b/schemas/channels/gcm.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/gcm",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "GCM",
+  "description": "Google Cloud Messaging",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/channels/gcm",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "push",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/mobile",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/gcm.schema.json
+++ b/schemas/channels/gcm.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/line.example.1.json
+++ b/schemas/channels/line.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/line",
+  "@type": "https://ns.adobe.com/xdm/channel-types/messaging"
+}

--- a/schemas/channels/line.schema.json
+++ b/schemas/channels/line.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/line",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "LINE",
+  "description": "Line Platform Notification",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/channels/line",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "push",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/messaging",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/line.schema.json
+++ b/schemas/channels/line.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/mobile-app.example.1.json
+++ b/schemas/channels/mobile-app.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/mobile-app",
+  "@type": "https://ns.adobe.com/xdm/channel-types/mobile"
+}

--- a/schemas/channels/mobile-app.schema.json
+++ b/schemas/channels/mobile-app.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/mobile-app",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Web",
+  "description": "Native mobile applications that are installed through an app store.",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/channels/mobile-app",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "pull",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/mobile",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/mobile-app.schema.json
+++ b/schemas/channels/mobile-app.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/mpns.example.1.json
+++ b/schemas/channels/mpns.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/mpns",
+  "@type": "https://ns.adobe.com/xdm/channel-types/mobile"
+}

--- a/schemas/channels/mpns.schema.json
+++ b/schemas/channels/mpns.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/mpns",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "MPNS",
+  "description": "Microsoft Push Notification Service",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/channels/mpns",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "push",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/mobile",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/mpns.schema.json
+++ b/schemas/channels/mpns.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/phone.example.1.json
+++ b/schemas/channels/phone.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/phone",
+  "@type": "https://ns.adobe.com/xdm/channel-types/offline"
+}

--- a/schemas/channels/phone.schema.json
+++ b/schemas/channels/phone.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/phone",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Phone",
+  "description": "The telephone. Includes both inbound and outbound.",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/channels/phone",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "bidirectional",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/offline",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/phone.schema.json
+++ b/schemas/channels/phone.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/sms.example.1.json
+++ b/schemas/channels/sms.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/sms",
+  "@type": "https://ns.adobe.com/xdm/channel-types/messaging"
+}

--- a/schemas/channels/sms.schema.json
+++ b/schemas/channels/sms.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/sms",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "SMS",
+  "description": "Short Message Service delivered to a mobile phone.",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/channels/sms",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "push",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/messaging",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/sms.schema.json
+++ b/schemas/channels/sms.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/twitter-feed.example.1.json
+++ b/schemas/channels/twitter-feed.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/twitter-feed",
+  "@type": "https://ns.adobe.com/xdm/channel-types/social"
+}

--- a/schemas/channels/twitter-feed.schema.json
+++ b/schemas/channels/twitter-feed.schema.json
@@ -5,10 +5,10 @@
     "you may not use this file except in compliance with the License. You may obtain a copy",
     "of the License at https://creativecommons.org/licenses/by/4.0/"
   ],
-  "$id": "https://ns.adobe.com/xdm/channels/facebook-feed",
+  "$id": "https://ns.adobe.com/xdm/channels/twitter-feed",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Facebook News Feed",
-  "description": "The Facebook News Feed. This does not include Facebook Messenger, or Facebook App pages.",
+  "title": "Twitter Feed",
+  "description": "The Twitter Feed, i.e. the stream of user-generated tweets. This does not include Twitter direct messages.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
@@ -20,7 +20,7 @@
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/channels/facebook-feed",
+          "const": "https://ns.adobe.com/xdm/channels/twitter-feed",
           "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {

--- a/schemas/channels/twitter-feed.schema.json
+++ b/schemas/channels/twitter-feed.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/web.example.1.json
+++ b/schemas/channels/web.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/web",
+  "@type": "https://ns.adobe.com/xdm/channel-types/web"
+}

--- a/schemas/channels/web.schema.json
+++ b/schemas/channels/web.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/web",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Web",
+  "description": "The world wide web and mobile web. Pages delivered via HTTP to a web browser or in-app browser.",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "push",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/web",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/web.schema.json
+++ b/schemas/channels/web.schema.json
@@ -14,6 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "meta:abstract": false,
+  "type": "object",
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/wechat.example.1.json
+++ b/schemas/channels/wechat.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/wechat",
+  "@type": "https://ns.adobe.com/xdm/channel-types/messaging"
+}

--- a/schemas/channels/wechat.schema.json
+++ b/schemas/channels/wechat.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/wechat",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "WeChat",
+  "description": "WeChat Platform Notification",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "push",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/messaging",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/wechat.schema.json
+++ b/schemas/channels/wechat.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {

--- a/schemas/channels/wechat.schema.json
+++ b/schemas/channels/wechat.schema.json
@@ -21,7 +21,7 @@
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "",
+          "const": "https://ns.adobe.com/xdm/channels/wechat",
           "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {

--- a/schemas/channels/wns.example.1.json
+++ b/schemas/channels/wns.example.1.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://ns.adobe.com/xdm/channels/wns",
+  "@type": "https://ns.adobe.com/xdm/channel-types/mobile"
+}

--- a/schemas/channels/wns.schema.json
+++ b/schemas/channels/wns.schema.json
@@ -1,0 +1,82 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/channels/wns",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "WNS",
+  "description": "Windows Push Notification Service.",
+  "meta:extensible": true,
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+  ],
+  "meta:abstract": false,
+  "definitions": {
+    "channel": {
+      "properties": {
+        "@id": {
+          "type": "string",
+          "format": "uri",
+          "const": "https://ns.adobe.com/xdm/channels/wns",
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+        },
+        "xdm:mode": {
+          "type": "string",
+          "const": "push",
+          "description": "How experiences are delivered in this channel.",
+          "meta:enum": {
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+          }
+        },
+        "@type": {
+          "type": "string",
+          "format": "uri",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "const": "https://ns.adobe.com/xdm/channel-types/mobile",
+          "meta:enum": {
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+          }
+        },
+        "xdm:contentTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The content types that this channel can deliver."
+        },
+        "xdm:metricTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The metrics that can be collected in this channel."
+        },
+        "xdm:locationTypes": {
+          "type": "array",
+          "const": [],
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
+    },
+    {
+      "$ref": "#/definitions/channel"
+    }
+  ],
+  "required": [
+    "@id"
+  ]
+}

--- a/schemas/channels/wns.schema.json
+++ b/schemas/channels/wns.schema.json
@@ -13,6 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
+  "type": "object",
   "meta:abstract": false,
   "definitions": {
     "channel": {


### PR DESCRIPTION
As per #81, I had a look at the channel definition in `experience-cloud-staging` and found it lacking in a couple of respects. My version improves this in following dimensions:

- new channels can be added easily without having to change the core channel definition
- all channels are addressed consistently, in that they have a *required* `@id` that points to the schema
- channels are described consistently with properties `@type` (for the rough group), `xdm:mode` (push or pull), as well as (optionally) a list of content types, metric types and location types supported by the channel.

The result is very compact and readable:

**old**
```json
{
    "xdm:types": {
      "xdm:socialPlatform": true
    },
    "xdm:socialPlatform": "facebook"
}
```

**new**
```json
{
  "@id": "https://ns.adobe.com/xdm/channels/facebook-feed",
  "@type": "https://ns.adobe.com/xdm/channel-types/social"
}

```

Please note that `@type` is optional and can be omitted.

I have included all types that were listed in the `experience-cloud-staging` branch, although in the future we might want to add `tv`, `video`, `radio`, `podcast`, etc.