### PR TITLE
Added Abstract and Standard Schema terms

### DIFF
--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -3,6 +3,9 @@ xdm:navOrder: 3
 ---
 ## Terminology
 
+Abstract Schema
+: a partial schema that is intended to be reused in other schemas to improve overall consistency of similar concepts across all schemas.
+
 Consumer
 : in the context of XDM, a consumer, or an XDM consumer is an application that reads and interprets XDM data.
 
@@ -13,4 +16,7 @@ Producer
 : in the context of XDM, a producer, or an XDM producer is an application that generates data conforming to the XDM models
 
 Schema
-: when used in this document, a Schema is a JSON Schema, as definied by the [JSON Schema Core Specification](http://json-schema.org/latest/json-schema-core.html)
+: when used in this document, a Schema is a JSON Schema, as defined by the [JSON Schema Core Specification](http://json-schema.org/latest/json-schema-core.html)
+
+Standard Schema
+: schemas defined in the Adobe XDM repository with the compact IRIs 'xdm'. Standard Schemas define common representations of Experience concepts that are to be reused for interoperability.


### PR DESCRIPTION
Added Abstract and Standard schema terms because they are distinct for the XDM project and are needed by product documentation. So best to standardize them at the highest levels, or else start the discussion on the correct terms to use in these cases.

Fixed typo in original text.
