### PR TITLE
Change xdm:timestamp to integer

### DIFF
--- a/schemas/context/experienceevent.example.1.json
+++ b/schemas/context/experienceevent.example.1.json
@@ -4,7 +4,7 @@
     "@id": "https://data.adobe.io/datasources/datasource-123",
     "xdm:name": "DataSourceIntegrationCode-123"
   },
-  "xdm:timestamp": "2017-09-26T15:52:25+00:00",
+  "xdm:timestamp": 978336000000,
   "xdm:endUserIds": {
     "xdm:realm": {
       "@id": "https://data.adobe.io/experiencecloud/audiencemanager",

--- a/schemas/context/experienceevent.schema.json
+++ b/schemas/context/experienceevent.schema.json
@@ -26,9 +26,10 @@
         },
         "xdm:timestamp": {
           "title": "Timestamp",
-          "type": "string",
-          "format": "date-time",
-          "description": "The time when the first event of the interaction occurred."
+          "type": "integer",
+          "description": "The timestamp when the first event of the touchpoint occurred. Milliseconds since midnight of January 1, 1970.",
+          "minimum": 1,
+          "maximum": 9223372036854770000
         },
         "xdm:endUserIds": {
           "title": "End User IDs",


### PR DESCRIPTION
This PR links to the issue #117 

@trieloff @kstreete @cmathis

Change timestamp field back to integer as this has been discussed and agreed from platform.