### PR TITLE
Fix the $id by adding adobe to be consistent with the folder path

### DIFF
--- a/extensions/adobe/experience/analytics/analytics-extensions.schema.json
+++ b/extensions/adobe/experience/analytics/analytics-extensions.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://ns.adobe.com/xdm-extensions/experience/analytics/analytics-extensions",
+  "$id": "https://ns.adobe.com/xdm-extensions/adobe/experience/analytics/analytics-extensions",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Adobe Analytics Cloud Experience Event Extension",
   "type": "object",


### PR DESCRIPTION
This PR links to the issue #159 

@trieloff @kstreeter @cmathis

Fix the $id of the schema which is missing "adobe".