### PR TITLE
Change the URI for the event fields

### DIFF
--- a/extensions/adobe/experience/analytics/analytics-extensions.schema.json
+++ b/extensions/adobe/experience/analytics/analytics-extensions.schema.json
@@ -2670,5002 +2670,5002 @@
       "type": "string",
       "description": "The original delimiter used to generate the list."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event1": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event1": {
       "title": "event1",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 1."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event2": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event2": {
       "title": "event2",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 2."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event3": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event3": {
       "title": "event3",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 3."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event4": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event4": {
       "title": "event4",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 4."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event5": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event5": {
       "title": "event5",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 5."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event6": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event6": {
       "title": "event6",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 6."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event7": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event7": {
       "title": "event7",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 7."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event8": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event8": {
       "title": "event8",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 8."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event9": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event9": {
       "title": "event9",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 9."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event10": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event10": {
       "title": "event10",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 10."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event11": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event11": {
       "title": "event11",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 11."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event12": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event12": {
       "title": "event12",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 12."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event13": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event13": {
       "title": "event13",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 13."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event14": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event14": {
       "title": "event14",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 14."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event15": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event15": {
       "title": "event15",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 15."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event16": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event16": {
       "title": "event16",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 16."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event17": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event17": {
       "title": "event17",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 17."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event18": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event18": {
       "title": "event18",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 18."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event19": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event19": {
       "title": "event19",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 19."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event20": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event20": {
       "title": "event20",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 20."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event21": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event21": {
       "title": "event21",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 21."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event22": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event22": {
       "title": "event22",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 22."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event23": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event23": {
       "title": "event23",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 23."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event24": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event24": {
       "title": "event24",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 24."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event25": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event25": {
       "title": "event25",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 25."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event26": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event26": {
       "title": "event26",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 26."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event27": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event27": {
       "title": "event27",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 27."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event28": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event28": {
       "title": "event28",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 28."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event29": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event29": {
       "title": "event29",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 29."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event30": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event30": {
       "title": "event30",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 30."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event31": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event31": {
       "title": "event31",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 31."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event32": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event32": {
       "title": "event32",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 32."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event33": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event33": {
       "title": "event33",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 33."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event34": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event34": {
       "title": "event34",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 34."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event35": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event35": {
       "title": "event35",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 35."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event36": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event36": {
       "title": "event36",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 36."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event37": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event37": {
       "title": "event37",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 37."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event38": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event38": {
       "title": "event38",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 38."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event39": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event39": {
       "title": "event39",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 39."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event40": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event40": {
       "title": "event40",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 40."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event41": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event41": {
       "title": "event41",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 41."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event42": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event42": {
       "title": "event42",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 42."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event43": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event43": {
       "title": "event43",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 43."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event44": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event44": {
       "title": "event44",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 44."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event45": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event45": {
       "title": "event45",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 45."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event46": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event46": {
       "title": "event46",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 46."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event47": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event47": {
       "title": "event47",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 47."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event48": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event48": {
       "title": "event48",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 48."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event49": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event49": {
       "title": "event49",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 49."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event50": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event50": {
       "title": "event50",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 50."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event51": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event51": {
       "title": "event51",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 51."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event52": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event52": {
       "title": "event52",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 52."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event53": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event53": {
       "title": "event53",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 53."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event54": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event54": {
       "title": "event54",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 54."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event55": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event55": {
       "title": "event55",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 55."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event56": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event56": {
       "title": "event56",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 56."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event57": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event57": {
       "title": "event57",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 57."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event58": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event58": {
       "title": "event58",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 58."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event59": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event59": {
       "title": "event59",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 59."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event60": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event60": {
       "title": "event60",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 60."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event61": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event61": {
       "title": "event61",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 61."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event62": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event62": {
       "title": "event62",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 62."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event63": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event63": {
       "title": "event63",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 63."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event64": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event64": {
       "title": "event64",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 64."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event65": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event65": {
       "title": "event65",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 65."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event66": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event66": {
       "title": "event66",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 66."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event67": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event67": {
       "title": "event67",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 67."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event68": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event68": {
       "title": "event68",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 68."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event69": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event69": {
       "title": "event69",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 69."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event70": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event70": {
       "title": "event70",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 70."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event71": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event71": {
       "title": "event71",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 71."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event72": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event72": {
       "title": "event72",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 72."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event73": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event73": {
       "title": "event73",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 73."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event74": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event74": {
       "title": "event74",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 74."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event75": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event75": {
       "title": "event75",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 75."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event76": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event76": {
       "title": "event76",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 76."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event77": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event77": {
       "title": "event77",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 77."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event78": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event78": {
       "title": "event78",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 78."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event79": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event79": {
       "title": "event79",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 79."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event80": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event80": {
       "title": "event80",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 80."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event81": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event81": {
       "title": "event81",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 81."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event82": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event82": {
       "title": "event82",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 82."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event83": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event83": {
       "title": "event83",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 83."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event84": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event84": {
       "title": "event84",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 84."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event85": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event85": {
       "title": "event85",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 85."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event86": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event86": {
       "title": "event86",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 86."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event87": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event87": {
       "title": "event87",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 87."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event88": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event88": {
       "title": "event88",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 88."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event89": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event89": {
       "title": "event89",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 89."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event90": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event90": {
       "title": "event90",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 90."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event91": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event91": {
       "title": "event91",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 91."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event92": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event92": {
       "title": "event92",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 92."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event93": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event93": {
       "title": "event93",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 93."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event94": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event94": {
       "title": "event94",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 94."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event95": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event95": {
       "title": "event95",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 95."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event96": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event96": {
       "title": "event96",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 96."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event97": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event97": {
       "title": "event97",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 97."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event98": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event98": {
       "title": "event98",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 98."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event99": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event99": {
       "title": "event99",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 99."
     },
-    "https://ns.adobe.com/experience/analytics/event1to100/event100": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event1to100/event100": {
       "title": "event100",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 100."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event101": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event101": {
       "title": "event101",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 101."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event102": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event102": {
       "title": "event102",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 102."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event103": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event103": {
       "title": "event103",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 103."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event104": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event104": {
       "title": "event104",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 104."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event105": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event105": {
       "title": "event105",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 105."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event106": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event106": {
       "title": "event106",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 106."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event107": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event107": {
       "title": "event107",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 107."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event108": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event108": {
       "title": "event108",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 108."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event109": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event109": {
       "title": "event109",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 109."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event110": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event110": {
       "title": "event110",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 110."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event111": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event111": {
       "title": "event111",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 111."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event112": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event112": {
       "title": "event112",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 112."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event113": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event113": {
       "title": "event113",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 113."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event114": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event114": {
       "title": "event114",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 114."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event115": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event115": {
       "title": "event115",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 115."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event116": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event116": {
       "title": "event116",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 116."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event117": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event117": {
       "title": "event117",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 117."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event118": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event118": {
       "title": "event118",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 118."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event119": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event119": {
       "title": "event119",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 119."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event120": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event120": {
       "title": "event120",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 120."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event121": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event121": {
       "title": "event121",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 121."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event122": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event122": {
       "title": "event122",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 122."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event123": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event123": {
       "title": "event123",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 123."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event124": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event124": {
       "title": "event124",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 124."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event125": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event125": {
       "title": "event125",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 125."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event126": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event126": {
       "title": "event126",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 126."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event127": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event127": {
       "title": "event127",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 127."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event128": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event128": {
       "title": "event128",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 128."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event129": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event129": {
       "title": "event129",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 129."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event130": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event130": {
       "title": "event130",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 130."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event131": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event131": {
       "title": "event131",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 131."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event132": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event132": {
       "title": "event132",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 132."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event133": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event133": {
       "title": "event133",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 133."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event134": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event134": {
       "title": "event134",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 134."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event135": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event135": {
       "title": "event135",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 135."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event136": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event136": {
       "title": "event136",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 136."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event137": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event137": {
       "title": "event137",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 137."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event138": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event138": {
       "title": "event138",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 138."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event139": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event139": {
       "title": "event139",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 139."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event140": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event140": {
       "title": "event140",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 140."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event141": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event141": {
       "title": "event141",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 141."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event142": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event142": {
       "title": "event142",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 142."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event143": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event143": {
       "title": "event143",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 143."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event144": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event144": {
       "title": "event144",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 144."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event145": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event145": {
       "title": "event145",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 145."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event146": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event146": {
       "title": "event146",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 146."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event147": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event147": {
       "title": "event147",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 147."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event148": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event148": {
       "title": "event148",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 148."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event149": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event149": {
       "title": "event149",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 149."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event150": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event150": {
       "title": "event150",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 150."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event151": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event151": {
       "title": "event151",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 151."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event152": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event152": {
       "title": "event152",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 152."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event153": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event153": {
       "title": "event153",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 153."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event154": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event154": {
       "title": "event154",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 154."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event155": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event155": {
       "title": "event155",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 155."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event156": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event156": {
       "title": "event156",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 156."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event157": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event157": {
       "title": "event157",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 157."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event158": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event158": {
       "title": "event158",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 158."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event159": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event159": {
       "title": "event159",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 159."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event160": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event160": {
       "title": "event160",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 160."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event161": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event161": {
       "title": "event161",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 161."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event162": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event162": {
       "title": "event162",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 162."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event163": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event163": {
       "title": "event163",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 163."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event164": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event164": {
       "title": "event164",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 164."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event165": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event165": {
       "title": "event165",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 165."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event166": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event166": {
       "title": "event166",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 166."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event167": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event167": {
       "title": "event167",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 167."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event168": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event168": {
       "title": "event168",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 168."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event169": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event169": {
       "title": "event169",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 169."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event170": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event170": {
       "title": "event170",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 170."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event171": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event171": {
       "title": "event171",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 171."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event172": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event172": {
       "title": "event172",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 172."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event173": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event173": {
       "title": "event173",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 173."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event174": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event174": {
       "title": "event174",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 174."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event175": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event175": {
       "title": "event175",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 175."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event176": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event176": {
       "title": "event176",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 176."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event177": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event177": {
       "title": "event177",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 177."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event178": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event178": {
       "title": "event178",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 178."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event179": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event179": {
       "title": "event179",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 179."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event180": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event180": {
       "title": "event180",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 180."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event181": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event181": {
       "title": "event181",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 181."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event182": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event182": {
       "title": "event182",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 182."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event183": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event183": {
       "title": "event183",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 183."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event184": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event184": {
       "title": "event184",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 184."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event185": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event185": {
       "title": "event185",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 185."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event186": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event186": {
       "title": "event186",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 186."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event187": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event187": {
       "title": "event187",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 187."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event188": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event188": {
       "title": "event188",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 188."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event189": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event189": {
       "title": "event189",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 189."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event190": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event190": {
       "title": "event190",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 190."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event191": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event191": {
       "title": "event191",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 191."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event192": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event192": {
       "title": "event192",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 192."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event193": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event193": {
       "title": "event193",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 193."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event194": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event194": {
       "title": "event194",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 194."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event195": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event195": {
       "title": "event195",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 195."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event196": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event196": {
       "title": "event196",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 196."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event197": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event197": {
       "title": "event197",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 197."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event198": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event198": {
       "title": "event198",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 198."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event199": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event199": {
       "title": "event199",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 199."
     },
-    "https://ns.adobe.com/experience/analytics/event101to200/event200": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event101to200/event200": {
       "title": "event200",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 200."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event201": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event201": {
       "title": "event201",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 201."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event202": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event202": {
       "title": "event202",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 202."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event203": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event203": {
       "title": "event203",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 203."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event204": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event204": {
       "title": "event204",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 204."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event205": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event205": {
       "title": "event205",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 205."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event206": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event206": {
       "title": "event206",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 206."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event207": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event207": {
       "title": "event207",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 207."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event208": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event208": {
       "title": "event208",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 208."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event209": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event209": {
       "title": "event209",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 209."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event210": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event210": {
       "title": "event210",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 210."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event211": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event211": {
       "title": "event211",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 211."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event212": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event212": {
       "title": "event212",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 212."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event213": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event213": {
       "title": "event213",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 213."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event214": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event214": {
       "title": "event214",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 214."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event215": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event215": {
       "title": "event215",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 215."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event216": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event216": {
       "title": "event216",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 216."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event217": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event217": {
       "title": "event217",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 217."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event218": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event218": {
       "title": "event218",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 218."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event219": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event219": {
       "title": "event219",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 219."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event220": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event220": {
       "title": "event220",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 220."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event221": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event221": {
       "title": "event221",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 221."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event222": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event222": {
       "title": "event222",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 222."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event223": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event223": {
       "title": "event223",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 223."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event224": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event224": {
       "title": "event224",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 224."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event225": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event225": {
       "title": "event225",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 225."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event226": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event226": {
       "title": "event226",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 226."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event227": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event227": {
       "title": "event227",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 227."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event228": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event228": {
       "title": "event228",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 228."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event229": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event229": {
       "title": "event229",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 229."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event230": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event230": {
       "title": "event230",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 230."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event231": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event231": {
       "title": "event231",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 231."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event232": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event232": {
       "title": "event232",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 232."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event233": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event233": {
       "title": "event233",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 233."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event234": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event234": {
       "title": "event234",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 234."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event235": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event235": {
       "title": "event235",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 235."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event236": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event236": {
       "title": "event236",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 236."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event237": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event237": {
       "title": "event237",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 237."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event238": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event238": {
       "title": "event238",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 238."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event239": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event239": {
       "title": "event239",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 239."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event240": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event240": {
       "title": "event240",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 240."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event241": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event241": {
       "title": "event241",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 241."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event242": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event242": {
       "title": "event242",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 242."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event243": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event243": {
       "title": "event243",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 243."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event244": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event244": {
       "title": "event244",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 244."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event245": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event245": {
       "title": "event245",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 245."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event246": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event246": {
       "title": "event246",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 246."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event247": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event247": {
       "title": "event247",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 247."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event248": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event248": {
       "title": "event248",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 248."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event249": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event249": {
       "title": "event249",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 249."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event250": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event250": {
       "title": "event250",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 250."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event251": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event251": {
       "title": "event251",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 251."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event252": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event252": {
       "title": "event252",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 252."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event253": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event253": {
       "title": "event253",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 253."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event254": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event254": {
       "title": "event254",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 254."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event255": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event255": {
       "title": "event255",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 255."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event256": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event256": {
       "title": "event256",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 256."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event257": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event257": {
       "title": "event257",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 257."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event258": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event258": {
       "title": "event258",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 258."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event259": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event259": {
       "title": "event259",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 259."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event260": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event260": {
       "title": "event260",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 260."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event261": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event261": {
       "title": "event261",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 261."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event262": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event262": {
       "title": "event262",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 262."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event263": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event263": {
       "title": "event263",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 263."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event264": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event264": {
       "title": "event264",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 264."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event265": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event265": {
       "title": "event265",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 265."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event266": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event266": {
       "title": "event266",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 266."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event267": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event267": {
       "title": "event267",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 267."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event268": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event268": {
       "title": "event268",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 268."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event269": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event269": {
       "title": "event269",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 269."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event270": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event270": {
       "title": "event270",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 270."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event271": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event271": {
       "title": "event271",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 271."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event272": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event272": {
       "title": "event272",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 272."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event273": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event273": {
       "title": "event273",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 273."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event274": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event274": {
       "title": "event274",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 274."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event275": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event275": {
       "title": "event275",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 275."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event276": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event276": {
       "title": "event276",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 276."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event277": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event277": {
       "title": "event277",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 277."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event278": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event278": {
       "title": "event278",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 278."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event279": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event279": {
       "title": "event279",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 279."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event280": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event280": {
       "title": "event280",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 280."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event281": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event281": {
       "title": "event281",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 281."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event282": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event282": {
       "title": "event282",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 282."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event283": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event283": {
       "title": "event283",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 283."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event284": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event284": {
       "title": "event284",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 284."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event285": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event285": {
       "title": "event285",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 285."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event286": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event286": {
       "title": "event286",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 286."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event287": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event287": {
       "title": "event287",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 287."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event288": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event288": {
       "title": "event288",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 288."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event289": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event289": {
       "title": "event289",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 289."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event290": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event290": {
       "title": "event290",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 290."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event291": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event291": {
       "title": "event291",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 291."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event292": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event292": {
       "title": "event292",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 292."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event293": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event293": {
       "title": "event293",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 293."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event294": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event294": {
       "title": "event294",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 294."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event295": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event295": {
       "title": "event295",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 295."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event296": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event296": {
       "title": "event296",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 296."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event297": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event297": {
       "title": "event297",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 297."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event298": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event298": {
       "title": "event298",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 298."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event299": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event299": {
       "title": "event299",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 299."
     },
-    "https://ns.adobe.com/experience/analytics/event201to300/event300": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event201to300/event300": {
       "title": "event300",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 300."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event301": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event301": {
       "title": "event301",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 301."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event302": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event302": {
       "title": "event302",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 302."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event303": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event303": {
       "title": "event303",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 303."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event304": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event304": {
       "title": "event304",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 304."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event305": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event305": {
       "title": "event305",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 305."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event306": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event306": {
       "title": "event306",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 306."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event307": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event307": {
       "title": "event307",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 307."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event308": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event308": {
       "title": "event308",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 308."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event309": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event309": {
       "title": "event309",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 309."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event310": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event310": {
       "title": "event310",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 310."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event311": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event311": {
       "title": "event311",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 311."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event312": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event312": {
       "title": "event312",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 312."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event313": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event313": {
       "title": "event313",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 313."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event314": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event314": {
       "title": "event314",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 314."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event315": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event315": {
       "title": "event315",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 315."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event316": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event316": {
       "title": "event316",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 316."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event317": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event317": {
       "title": "event317",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 317."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event318": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event318": {
       "title": "event318",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 318."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event319": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event319": {
       "title": "event319",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 319."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event320": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event320": {
       "title": "event320",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 320."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event321": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event321": {
       "title": "event321",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 321."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event322": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event322": {
       "title": "event322",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 322."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event323": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event323": {
       "title": "event323",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 323."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event324": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event324": {
       "title": "event324",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 324."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event325": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event325": {
       "title": "event325",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 325."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event326": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event326": {
       "title": "event326",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 326."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event327": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event327": {
       "title": "event327",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 327."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event328": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event328": {
       "title": "event328",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 328."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event329": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event329": {
       "title": "event329",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 329."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event330": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event330": {
       "title": "event330",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 330."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event331": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event331": {
       "title": "event331",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 331."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event332": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event332": {
       "title": "event332",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 332."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event333": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event333": {
       "title": "event333",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 333."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event334": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event334": {
       "title": "event334",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 334."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event335": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event335": {
       "title": "event335",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 335."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event336": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event336": {
       "title": "event336",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 336."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event337": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event337": {
       "title": "event337",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 337."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event338": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event338": {
       "title": "event338",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 338."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event339": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event339": {
       "title": "event339",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 339."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event340": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event340": {
       "title": "event340",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 340."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event341": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event341": {
       "title": "event341",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 341."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event342": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event342": {
       "title": "event342",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 342."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event343": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event343": {
       "title": "event343",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 343."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event344": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event344": {
       "title": "event344",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 344."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event345": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event345": {
       "title": "event345",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 345."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event346": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event346": {
       "title": "event346",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 346."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event347": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event347": {
       "title": "event347",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 347."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event348": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event348": {
       "title": "event348",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 348."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event349": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event349": {
       "title": "event349",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 349."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event350": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event350": {
       "title": "event350",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 350."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event351": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event351": {
       "title": "event351",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 351."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event352": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event352": {
       "title": "event352",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 352."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event353": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event353": {
       "title": "event353",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 353."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event354": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event354": {
       "title": "event354",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 354."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event355": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event355": {
       "title": "event355",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 355."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event356": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event356": {
       "title": "event356",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 356."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event357": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event357": {
       "title": "event357",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 357."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event358": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event358": {
       "title": "event358",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 358."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event359": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event359": {
       "title": "event359",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 359."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event360": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event360": {
       "title": "event360",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 360."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event361": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event361": {
       "title": "event361",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 361."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event362": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event362": {
       "title": "event362",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 362."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event363": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event363": {
       "title": "event363",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 363."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event364": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event364": {
       "title": "event364",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 364."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event365": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event365": {
       "title": "event365",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 365."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event366": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event366": {
       "title": "event366",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 366."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event367": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event367": {
       "title": "event367",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 367."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event368": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event368": {
       "title": "event368",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 368."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event369": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event369": {
       "title": "event369",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 369."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event370": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event370": {
       "title": "event370",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 370."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event371": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event371": {
       "title": "event371",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 371."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event372": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event372": {
       "title": "event372",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 372."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event373": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event373": {
       "title": "event373",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 373."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event374": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event374": {
       "title": "event374",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 374."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event375": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event375": {
       "title": "event375",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 375."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event376": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event376": {
       "title": "event376",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 376."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event377": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event377": {
       "title": "event377",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 377."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event378": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event378": {
       "title": "event378",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 378."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event379": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event379": {
       "title": "event379",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 379."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event380": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event380": {
       "title": "event380",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 380."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event381": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event381": {
       "title": "event381",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 381."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event382": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event382": {
       "title": "event382",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 382."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event383": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event383": {
       "title": "event383",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 383."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event384": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event384": {
       "title": "event384",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 384."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event385": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event385": {
       "title": "event385",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 385."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event386": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event386": {
       "title": "event386",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 386."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event387": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event387": {
       "title": "event387",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 387."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event388": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event388": {
       "title": "event388",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 388."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event389": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event389": {
       "title": "event389",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 389."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event390": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event390": {
       "title": "event390",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 390."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event391": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event391": {
       "title": "event391",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 391."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event392": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event392": {
       "title": "event392",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 392."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event393": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event393": {
       "title": "event393",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 393."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event394": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event394": {
       "title": "event394",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 394."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event395": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event395": {
       "title": "event395",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 395."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event396": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event396": {
       "title": "event396",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 396."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event397": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event397": {
       "title": "event397",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 397."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event398": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event398": {
       "title": "event398",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 398."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event399": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event399": {
       "title": "event399",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 399."
     },
-    "https://ns.adobe.com/experience/analytics/event301to400/event400": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event301to400/event400": {
       "title": "event400",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 400."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event401": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event401": {
       "title": "event401",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 401."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event402": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event402": {
       "title": "event402",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 402."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event403": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event403": {
       "title": "event403",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 403."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event404": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event404": {
       "title": "event404",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 404."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event405": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event405": {
       "title": "event405",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 405."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event406": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event406": {
       "title": "event406",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 406."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event407": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event407": {
       "title": "event407",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 407."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event408": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event408": {
       "title": "event408",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 408."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event409": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event409": {
       "title": "event409",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 409."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event410": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event410": {
       "title": "event410",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 410."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event411": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event411": {
       "title": "event411",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 411."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event412": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event412": {
       "title": "event412",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 412."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event413": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event413": {
       "title": "event413",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 413."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event414": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event414": {
       "title": "event414",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 414."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event415": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event415": {
       "title": "event415",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 415."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event416": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event416": {
       "title": "event416",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 416."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event417": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event417": {
       "title": "event417",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 417."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event418": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event418": {
       "title": "event418",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 418."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event419": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event419": {
       "title": "event419",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 419."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event420": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event420": {
       "title": "event420",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 420."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event421": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event421": {
       "title": "event421",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 421."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event422": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event422": {
       "title": "event422",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 422."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event423": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event423": {
       "title": "event423",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 423."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event424": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event424": {
       "title": "event424",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 424."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event425": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event425": {
       "title": "event425",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 425."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event426": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event426": {
       "title": "event426",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 426."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event427": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event427": {
       "title": "event427",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 427."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event428": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event428": {
       "title": "event428",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 428."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event429": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event429": {
       "title": "event429",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 429."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event430": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event430": {
       "title": "event430",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 430."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event431": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event431": {
       "title": "event431",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 431."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event432": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event432": {
       "title": "event432",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 432."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event433": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event433": {
       "title": "event433",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 433."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event434": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event434": {
       "title": "event434",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 434."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event435": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event435": {
       "title": "event435",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 435."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event436": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event436": {
       "title": "event436",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 436."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event437": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event437": {
       "title": "event437",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 437."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event438": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event438": {
       "title": "event438",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 438."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event439": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event439": {
       "title": "event439",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 439."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event440": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event440": {
       "title": "event440",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 440."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event441": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event441": {
       "title": "event441",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 441."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event442": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event442": {
       "title": "event442",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 442."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event443": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event443": {
       "title": "event443",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 443."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event444": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event444": {
       "title": "event444",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 444."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event445": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event445": {
       "title": "event445",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 445."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event446": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event446": {
       "title": "event446",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 446."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event447": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event447": {
       "title": "event447",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 447."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event448": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event448": {
       "title": "event448",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 448."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event449": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event449": {
       "title": "event449",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 449."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event450": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event450": {
       "title": "event450",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 450."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event451": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event451": {
       "title": "event451",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 451."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event452": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event452": {
       "title": "event452",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 452."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event453": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event453": {
       "title": "event453",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 453."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event454": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event454": {
       "title": "event454",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 454."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event455": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event455": {
       "title": "event455",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 455."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event456": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event456": {
       "title": "event456",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 456."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event457": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event457": {
       "title": "event457",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 457."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event458": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event458": {
       "title": "event458",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 458."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event459": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event459": {
       "title": "event459",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 459."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event460": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event460": {
       "title": "event460",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 460."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event461": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event461": {
       "title": "event461",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 461."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event462": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event462": {
       "title": "event462",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 462."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event463": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event463": {
       "title": "event463",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 463."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event464": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event464": {
       "title": "event464",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 464."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event465": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event465": {
       "title": "event465",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 465."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event466": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event466": {
       "title": "event466",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 466."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event467": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event467": {
       "title": "event467",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 467."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event468": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event468": {
       "title": "event468",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 468."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event469": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event469": {
       "title": "event469",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 469."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event470": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event470": {
       "title": "event470",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 470."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event471": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event471": {
       "title": "event471",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 471."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event472": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event472": {
       "title": "event472",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 472."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event473": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event473": {
       "title": "event473",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 473."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event474": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event474": {
       "title": "event474",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 474."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event475": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event475": {
       "title": "event475",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 475."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event476": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event476": {
       "title": "event476",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 476."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event477": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event477": {
       "title": "event477",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 477."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event478": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event478": {
       "title": "event478",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 478."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event479": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event479": {
       "title": "event479",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 479."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event480": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event480": {
       "title": "event480",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 480."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event481": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event481": {
       "title": "event481",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 481."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event482": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event482": {
       "title": "event482",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 482."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event483": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event483": {
       "title": "event483",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 483."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event484": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event484": {
       "title": "event484",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 484."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event485": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event485": {
       "title": "event485",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 485."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event486": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event486": {
       "title": "event486",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 486."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event487": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event487": {
       "title": "event487",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 487."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event488": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event488": {
       "title": "event488",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 488."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event489": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event489": {
       "title": "event489",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 489."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event490": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event490": {
       "title": "event490",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 490."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event491": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event491": {
       "title": "event491",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 491."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event492": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event492": {
       "title": "event492",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 492."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event493": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event493": {
       "title": "event493",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 493."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event494": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event494": {
       "title": "event494",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 494."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event495": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event495": {
       "title": "event495",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 495."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event496": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event496": {
       "title": "event496",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 496."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event497": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event497": {
       "title": "event497",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 497."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event498": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event498": {
       "title": "event498",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 498."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event499": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event499": {
       "title": "event499",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 499."
     },
-    "https://ns.adobe.com/experience/analytics/event401to500/event500": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event401to500/event500": {
       "title": "event500",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 500."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event501": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event501": {
       "title": "event501",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 501."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event502": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event502": {
       "title": "event502",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 502."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event503": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event503": {
       "title": "event503",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 503."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event504": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event504": {
       "title": "event504",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 504."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event505": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event505": {
       "title": "event505",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 505."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event506": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event506": {
       "title": "event506",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 506."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event507": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event507": {
       "title": "event507",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 507."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event508": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event508": {
       "title": "event508",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 508."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event509": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event509": {
       "title": "event509",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 509."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event510": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event510": {
       "title": "event510",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 510."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event511": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event511": {
       "title": "event511",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 511."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event512": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event512": {
       "title": "event512",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 512."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event513": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event513": {
       "title": "event513",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 513."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event514": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event514": {
       "title": "event514",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 514."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event515": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event515": {
       "title": "event515",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 515."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event516": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event516": {
       "title": "event516",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 516."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event517": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event517": {
       "title": "event517",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 517."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event518": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event518": {
       "title": "event518",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 518."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event519": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event519": {
       "title": "event519",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 519."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event520": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event520": {
       "title": "event520",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 520."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event521": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event521": {
       "title": "event521",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 521."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event522": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event522": {
       "title": "event522",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 522."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event523": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event523": {
       "title": "event523",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 523."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event524": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event524": {
       "title": "event524",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 524."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event525": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event525": {
       "title": "event525",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 525."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event526": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event526": {
       "title": "event526",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 526."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event527": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event527": {
       "title": "event527",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 527."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event528": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event528": {
       "title": "event528",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 528."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event529": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event529": {
       "title": "event529",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 529."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event530": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event530": {
       "title": "event530",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 530."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event531": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event531": {
       "title": "event531",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 531."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event532": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event532": {
       "title": "event532",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 532."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event533": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event533": {
       "title": "event533",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 533."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event534": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event534": {
       "title": "event534",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 534."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event535": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event535": {
       "title": "event535",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 535."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event536": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event536": {
       "title": "event536",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 536."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event537": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event537": {
       "title": "event537",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 537."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event538": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event538": {
       "title": "event538",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 538."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event539": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event539": {
       "title": "event539",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 539."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event540": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event540": {
       "title": "event540",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 540."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event541": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event541": {
       "title": "event541",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 541."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event542": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event542": {
       "title": "event542",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 542."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event543": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event543": {
       "title": "event543",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 543."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event544": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event544": {
       "title": "event544",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 544."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event545": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event545": {
       "title": "event545",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 545."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event546": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event546": {
       "title": "event546",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 546."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event547": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event547": {
       "title": "event547",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 547."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event548": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event548": {
       "title": "event548",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 548."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event549": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event549": {
       "title": "event549",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 549."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event550": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event550": {
       "title": "event550",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 550."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event551": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event551": {
       "title": "event551",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 551."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event552": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event552": {
       "title": "event552",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 552."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event553": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event553": {
       "title": "event553",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 553."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event554": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event554": {
       "title": "event554",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 554."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event555": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event555": {
       "title": "event555",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 555."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event556": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event556": {
       "title": "event556",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 556."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event557": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event557": {
       "title": "event557",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 557."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event558": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event558": {
       "title": "event558",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 558."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event559": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event559": {
       "title": "event559",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 559."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event560": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event560": {
       "title": "event560",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 560."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event561": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event561": {
       "title": "event561",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 561."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event562": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event562": {
       "title": "event562",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 562."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event563": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event563": {
       "title": "event563",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 563."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event564": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event564": {
       "title": "event564",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 564."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event565": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event565": {
       "title": "event565",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 565."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event566": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event566": {
       "title": "event566",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 566."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event567": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event567": {
       "title": "event567",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 567."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event568": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event568": {
       "title": "event568",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 568."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event569": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event569": {
       "title": "event569",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 569."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event570": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event570": {
       "title": "event570",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 570."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event571": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event571": {
       "title": "event571",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 571."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event572": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event572": {
       "title": "event572",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 572."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event573": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event573": {
       "title": "event573",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 573."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event574": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event574": {
       "title": "event574",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 574."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event575": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event575": {
       "title": "event575",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 575."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event576": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event576": {
       "title": "event576",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 576."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event577": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event577": {
       "title": "event577",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 577."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event578": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event578": {
       "title": "event578",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 578."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event579": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event579": {
       "title": "event579",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 579."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event580": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event580": {
       "title": "event580",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 580."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event581": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event581": {
       "title": "event581",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 581."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event582": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event582": {
       "title": "event582",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 582."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event583": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event583": {
       "title": "event583",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 583."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event584": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event584": {
       "title": "event584",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 584."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event585": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event585": {
       "title": "event585",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 585."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event586": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event586": {
       "title": "event586",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 586."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event587": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event587": {
       "title": "event587",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 587."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event588": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event588": {
       "title": "event588",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 588."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event589": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event589": {
       "title": "event589",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 589."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event590": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event590": {
       "title": "event590",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 590."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event591": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event591": {
       "title": "event591",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 591."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event592": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event592": {
       "title": "event592",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 592."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event593": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event593": {
       "title": "event593",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 593."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event594": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event594": {
       "title": "event594",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 594."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event595": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event595": {
       "title": "event595",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 595."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event596": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event596": {
       "title": "event596",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 596."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event597": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event597": {
       "title": "event597",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 597."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event598": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event598": {
       "title": "event598",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 598."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event599": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event599": {
       "title": "event599",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 599."
     },
-    "https://ns.adobe.com/experience/analytics/event501to600/event600": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event501to600/event600": {
       "title": "event600",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 600."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event601": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event601": {
       "title": "event601",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 601."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event602": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event602": {
       "title": "event602",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 602."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event603": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event603": {
       "title": "event603",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 603."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event604": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event604": {
       "title": "event604",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 604."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event605": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event605": {
       "title": "event605",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 605."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event606": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event606": {
       "title": "event606",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 606."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event607": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event607": {
       "title": "event607",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 607."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event608": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event608": {
       "title": "event608",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 608."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event609": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event609": {
       "title": "event609",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 609."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event610": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event610": {
       "title": "event610",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 610."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event611": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event611": {
       "title": "event611",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 611."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event612": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event612": {
       "title": "event612",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 612."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event613": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event613": {
       "title": "event613",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 613."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event614": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event614": {
       "title": "event614",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 614."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event615": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event615": {
       "title": "event615",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 615."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event616": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event616": {
       "title": "event616",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 616."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event617": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event617": {
       "title": "event617",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 617."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event618": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event618": {
       "title": "event618",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 618."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event619": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event619": {
       "title": "event619",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 619."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event620": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event620": {
       "title": "event620",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 620."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event621": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event621": {
       "title": "event621",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 621."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event622": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event622": {
       "title": "event622",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 622."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event623": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event623": {
       "title": "event623",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 623."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event624": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event624": {
       "title": "event624",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 624."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event625": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event625": {
       "title": "event625",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 625."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event626": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event626": {
       "title": "event626",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 626."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event627": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event627": {
       "title": "event627",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 627."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event628": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event628": {
       "title": "event628",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 628."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event629": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event629": {
       "title": "event629",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 629."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event630": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event630": {
       "title": "event630",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 630."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event631": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event631": {
       "title": "event631",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 631."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event632": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event632": {
       "title": "event632",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 632."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event633": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event633": {
       "title": "event633",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 633."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event634": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event634": {
       "title": "event634",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 634."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event635": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event635": {
       "title": "event635",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 635."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event636": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event636": {
       "title": "event636",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 636."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event637": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event637": {
       "title": "event637",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 637."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event638": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event638": {
       "title": "event638",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 638."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event639": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event639": {
       "title": "event639",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 639."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event640": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event640": {
       "title": "event640",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 640."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event641": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event641": {
       "title": "event641",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 641."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event642": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event642": {
       "title": "event642",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 642."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event643": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event643": {
       "title": "event643",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 643."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event644": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event644": {
       "title": "event644",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 644."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event645": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event645": {
       "title": "event645",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 645."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event646": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event646": {
       "title": "event646",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 646."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event647": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event647": {
       "title": "event647",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 647."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event648": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event648": {
       "title": "event648",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 648."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event649": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event649": {
       "title": "event649",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 649."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event650": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event650": {
       "title": "event650",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 650."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event651": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event651": {
       "title": "event651",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 651."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event652": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event652": {
       "title": "event652",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 652."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event653": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event653": {
       "title": "event653",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 653."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event654": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event654": {
       "title": "event654",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 654."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event655": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event655": {
       "title": "event655",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 655."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event656": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event656": {
       "title": "event656",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 656."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event657": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event657": {
       "title": "event657",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 657."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event658": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event658": {
       "title": "event658",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 658."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event659": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event659": {
       "title": "event659",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 659."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event660": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event660": {
       "title": "event660",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 660."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event661": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event661": {
       "title": "event661",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 661."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event662": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event662": {
       "title": "event662",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 662."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event663": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event663": {
       "title": "event663",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 663."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event664": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event664": {
       "title": "event664",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 664."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event665": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event665": {
       "title": "event665",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 665."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event666": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event666": {
       "title": "event666",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 666."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event667": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event667": {
       "title": "event667",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 667."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event668": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event668": {
       "title": "event668",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 668."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event669": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event669": {
       "title": "event669",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 669."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event670": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event670": {
       "title": "event670",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 670."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event671": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event671": {
       "title": "event671",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 671."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event672": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event672": {
       "title": "event672",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 672."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event673": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event673": {
       "title": "event673",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 673."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event674": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event674": {
       "title": "event674",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 674."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event675": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event675": {
       "title": "event675",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 675."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event676": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event676": {
       "title": "event676",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 676."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event677": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event677": {
       "title": "event677",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 677."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event678": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event678": {
       "title": "event678",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 678."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event679": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event679": {
       "title": "event679",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 679."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event680": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event680": {
       "title": "event680",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 680."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event681": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event681": {
       "title": "event681",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 681."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event682": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event682": {
       "title": "event682",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 682."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event683": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event683": {
       "title": "event683",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 683."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event684": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event684": {
       "title": "event684",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 684."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event685": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event685": {
       "title": "event685",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 685."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event686": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event686": {
       "title": "event686",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 686."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event687": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event687": {
       "title": "event687",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 687."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event688": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event688": {
       "title": "event688",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 688."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event689": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event689": {
       "title": "event689",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 689."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event690": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event690": {
       "title": "event690",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 690."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event691": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event691": {
       "title": "event691",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 691."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event692": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event692": {
       "title": "event692",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 692."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event693": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event693": {
       "title": "event693",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 693."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event694": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event694": {
       "title": "event694",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 694."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event695": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event695": {
       "title": "event695",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 695."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event696": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event696": {
       "title": "event696",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 696."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event697": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event697": {
       "title": "event697",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 697."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event698": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event698": {
       "title": "event698",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 698."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event699": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event699": {
       "title": "event699",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 699."
     },
-    "https://ns.adobe.com/experience/analytics/event601to700/event700": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event601to700/event700": {
       "title": "event700",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 700."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event701": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event701": {
       "title": "event701",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 701."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event702": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event702": {
       "title": "event702",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 702."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event703": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event703": {
       "title": "event703",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 703."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event704": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event704": {
       "title": "event704",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 704."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event705": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event705": {
       "title": "event705",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 705."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event706": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event706": {
       "title": "event706",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 706."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event707": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event707": {
       "title": "event707",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 707."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event708": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event708": {
       "title": "event708",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 708."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event709": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event709": {
       "title": "event709",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 709."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event710": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event710": {
       "title": "event710",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 710."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event711": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event711": {
       "title": "event711",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 711."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event712": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event712": {
       "title": "event712",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 712."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event713": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event713": {
       "title": "event713",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 713."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event714": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event714": {
       "title": "event714",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 714."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event715": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event715": {
       "title": "event715",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 715."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event716": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event716": {
       "title": "event716",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 716."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event717": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event717": {
       "title": "event717",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 717."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event718": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event718": {
       "title": "event718",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 718."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event719": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event719": {
       "title": "event719",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 719."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event720": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event720": {
       "title": "event720",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 720."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event721": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event721": {
       "title": "event721",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 721."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event722": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event722": {
       "title": "event722",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 722."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event723": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event723": {
       "title": "event723",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 723."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event724": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event724": {
       "title": "event724",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 724."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event725": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event725": {
       "title": "event725",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 725."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event726": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event726": {
       "title": "event726",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 726."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event727": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event727": {
       "title": "event727",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 727."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event728": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event728": {
       "title": "event728",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 728."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event729": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event729": {
       "title": "event729",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 729."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event730": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event730": {
       "title": "event730",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 730."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event731": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event731": {
       "title": "event731",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 731."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event732": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event732": {
       "title": "event732",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 732."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event733": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event733": {
       "title": "event733",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 733."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event734": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event734": {
       "title": "event734",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 734."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event735": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event735": {
       "title": "event735",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 735."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event736": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event736": {
       "title": "event736",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 736."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event737": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event737": {
       "title": "event737",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 737."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event738": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event738": {
       "title": "event738",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 738."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event739": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event739": {
       "title": "event739",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 739."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event740": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event740": {
       "title": "event740",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 740."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event741": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event741": {
       "title": "event741",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 741."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event742": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event742": {
       "title": "event742",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 742."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event743": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event743": {
       "title": "event743",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 743."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event744": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event744": {
       "title": "event744",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 744."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event745": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event745": {
       "title": "event745",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 745."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event746": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event746": {
       "title": "event746",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 746."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event747": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event747": {
       "title": "event747",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 747."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event748": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event748": {
       "title": "event748",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 748."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event749": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event749": {
       "title": "event749",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 749."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event750": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event750": {
       "title": "event750",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 750."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event751": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event751": {
       "title": "event751",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 751."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event752": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event752": {
       "title": "event752",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 752."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event753": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event753": {
       "title": "event753",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 753."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event754": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event754": {
       "title": "event754",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 754."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event755": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event755": {
       "title": "event755",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 755."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event756": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event756": {
       "title": "event756",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 756."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event757": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event757": {
       "title": "event757",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 757."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event758": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event758": {
       "title": "event758",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 758."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event759": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event759": {
       "title": "event759",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 759."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event760": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event760": {
       "title": "event760",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 760."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event761": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event761": {
       "title": "event761",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 761."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event762": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event762": {
       "title": "event762",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 762."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event763": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event763": {
       "title": "event763",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 763."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event764": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event764": {
       "title": "event764",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 764."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event765": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event765": {
       "title": "event765",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 765."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event766": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event766": {
       "title": "event766",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 766."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event767": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event767": {
       "title": "event767",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 767."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event768": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event768": {
       "title": "event768",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 768."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event769": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event769": {
       "title": "event769",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 769."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event770": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event770": {
       "title": "event770",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 770."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event771": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event771": {
       "title": "event771",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 771."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event772": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event772": {
       "title": "event772",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 772."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event773": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event773": {
       "title": "event773",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 773."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event774": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event774": {
       "title": "event774",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 774."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event775": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event775": {
       "title": "event775",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 775."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event776": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event776": {
       "title": "event776",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 776."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event777": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event777": {
       "title": "event777",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 777."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event778": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event778": {
       "title": "event778",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 778."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event779": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event779": {
       "title": "event779",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 779."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event780": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event780": {
       "title": "event780",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 780."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event781": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event781": {
       "title": "event781",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 781."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event782": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event782": {
       "title": "event782",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 782."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event783": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event783": {
       "title": "event783",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 783."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event784": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event784": {
       "title": "event784",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 784."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event785": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event785": {
       "title": "event785",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 785."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event786": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event786": {
       "title": "event786",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 786."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event787": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event787": {
       "title": "event787",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 787."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event788": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event788": {
       "title": "event788",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 788."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event789": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event789": {
       "title": "event789",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 789."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event790": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event790": {
       "title": "event790",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 790."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event791": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event791": {
       "title": "event791",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 791."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event792": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event792": {
       "title": "event792",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 792."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event793": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event793": {
       "title": "event793",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 793."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event794": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event794": {
       "title": "event794",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 794."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event795": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event795": {
       "title": "event795",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 795."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event796": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event796": {
       "title": "event796",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 796."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event797": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event797": {
       "title": "event797",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 797."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event798": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event798": {
       "title": "event798",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 798."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event799": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event799": {
       "title": "event799",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 799."
     },
-    "https://ns.adobe.com/experience/analytics/event701to800/event800": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event701to800/event800": {
       "title": "event800",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 800."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event801": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event801": {
       "title": "event801",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 801."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event802": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event802": {
       "title": "event802",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 802."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event803": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event803": {
       "title": "event803",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 803."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event804": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event804": {
       "title": "event804",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 804."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event805": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event805": {
       "title": "event805",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 805."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event806": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event806": {
       "title": "event806",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 806."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event807": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event807": {
       "title": "event807",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 807."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event808": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event808": {
       "title": "event808",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 808."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event809": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event809": {
       "title": "event809",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 809."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event810": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event810": {
       "title": "event810",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 810."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event811": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event811": {
       "title": "event811",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 811."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event812": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event812": {
       "title": "event812",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 812."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event813": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event813": {
       "title": "event813",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 813."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event814": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event814": {
       "title": "event814",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 814."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event815": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event815": {
       "title": "event815",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 815."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event816": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event816": {
       "title": "event816",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 816."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event817": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event817": {
       "title": "event817",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 817."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event818": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event818": {
       "title": "event818",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 818."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event819": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event819": {
       "title": "event819",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 819."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event820": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event820": {
       "title": "event820",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 820."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event821": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event821": {
       "title": "event821",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 821."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event822": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event822": {
       "title": "event822",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 822."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event823": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event823": {
       "title": "event823",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 823."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event824": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event824": {
       "title": "event824",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 824."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event825": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event825": {
       "title": "event825",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 825."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event826": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event826": {
       "title": "event826",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 826."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event827": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event827": {
       "title": "event827",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 827."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event828": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event828": {
       "title": "event828",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 828."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event829": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event829": {
       "title": "event829",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 829."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event830": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event830": {
       "title": "event830",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 830."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event831": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event831": {
       "title": "event831",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 831."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event832": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event832": {
       "title": "event832",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 832."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event833": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event833": {
       "title": "event833",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 833."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event834": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event834": {
       "title": "event834",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 834."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event835": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event835": {
       "title": "event835",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 835."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event836": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event836": {
       "title": "event836",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 836."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event837": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event837": {
       "title": "event837",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 837."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event838": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event838": {
       "title": "event838",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 838."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event839": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event839": {
       "title": "event839",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 839."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event840": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event840": {
       "title": "event840",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 840."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event841": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event841": {
       "title": "event841",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 841."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event842": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event842": {
       "title": "event842",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 842."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event843": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event843": {
       "title": "event843",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 843."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event844": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event844": {
       "title": "event844",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 844."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event845": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event845": {
       "title": "event845",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 845."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event846": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event846": {
       "title": "event846",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 846."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event847": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event847": {
       "title": "event847",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 847."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event848": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event848": {
       "title": "event848",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 848."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event849": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event849": {
       "title": "event849",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 849."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event850": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event850": {
       "title": "event850",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 850."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event851": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event851": {
       "title": "event851",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 851."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event852": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event852": {
       "title": "event852",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 852."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event853": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event853": {
       "title": "event853",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 853."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event854": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event854": {
       "title": "event854",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 854."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event855": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event855": {
       "title": "event855",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 855."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event856": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event856": {
       "title": "event856",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 856."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event857": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event857": {
       "title": "event857",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 857."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event858": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event858": {
       "title": "event858",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 858."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event859": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event859": {
       "title": "event859",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 859."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event860": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event860": {
       "title": "event860",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 860."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event861": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event861": {
       "title": "event861",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 861."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event862": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event862": {
       "title": "event862",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 862."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event863": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event863": {
       "title": "event863",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 863."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event864": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event864": {
       "title": "event864",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 864."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event865": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event865": {
       "title": "event865",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 865."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event866": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event866": {
       "title": "event866",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 866."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event867": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event867": {
       "title": "event867",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 867."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event868": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event868": {
       "title": "event868",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 868."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event869": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event869": {
       "title": "event869",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 869."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event870": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event870": {
       "title": "event870",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 870."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event871": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event871": {
       "title": "event871",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 871."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event872": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event872": {
       "title": "event872",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 872."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event873": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event873": {
       "title": "event873",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 873."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event874": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event874": {
       "title": "event874",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 874."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event875": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event875": {
       "title": "event875",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 875."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event876": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event876": {
       "title": "event876",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 876."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event877": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event877": {
       "title": "event877",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 877."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event878": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event878": {
       "title": "event878",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 878."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event879": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event879": {
       "title": "event879",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 879."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event880": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event880": {
       "title": "event880",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 880."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event881": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event881": {
       "title": "event881",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 881."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event882": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event882": {
       "title": "event882",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 882."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event883": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event883": {
       "title": "event883",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 883."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event884": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event884": {
       "title": "event884",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 884."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event885": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event885": {
       "title": "event885",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 885."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event886": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event886": {
       "title": "event886",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 886."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event887": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event887": {
       "title": "event887",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 887."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event888": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event888": {
       "title": "event888",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 888."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event889": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event889": {
       "title": "event889",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 889."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event890": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event890": {
       "title": "event890",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 890."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event891": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event891": {
       "title": "event891",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 891."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event892": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event892": {
       "title": "event892",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 892."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event893": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event893": {
       "title": "event893",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 893."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event894": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event894": {
       "title": "event894",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 894."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event895": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event895": {
       "title": "event895",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 895."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event896": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event896": {
       "title": "event896",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 896."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event897": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event897": {
       "title": "event897",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 897."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event898": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event898": {
       "title": "event898",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 898."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event899": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event899": {
       "title": "event899",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 899."
     },
-    "https://ns.adobe.com/experience/analytics/event801to900/event900": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event801to900/event900": {
       "title": "event900",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 900."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event901": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event901": {
       "title": "event901",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 901."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event902": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event902": {
       "title": "event902",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 902."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event903": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event903": {
       "title": "event903",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 903."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event904": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event904": {
       "title": "event904",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 904."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event905": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event905": {
       "title": "event905",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 905."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event906": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event906": {
       "title": "event906",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 906."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event907": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event907": {
       "title": "event907",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 907."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event908": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event908": {
       "title": "event908",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 908."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event909": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event909": {
       "title": "event909",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 909."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event910": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event910": {
       "title": "event910",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 910."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event911": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event911": {
       "title": "event911",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 911."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event912": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event912": {
       "title": "event912",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 912."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event913": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event913": {
       "title": "event913",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 913."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event914": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event914": {
       "title": "event914",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 914."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event915": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event915": {
       "title": "event915",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 915."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event916": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event916": {
       "title": "event916",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 916."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event917": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event917": {
       "title": "event917",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 917."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event918": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event918": {
       "title": "event918",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 918."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event919": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event919": {
       "title": "event919",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 919."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event920": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event920": {
       "title": "event920",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 920."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event921": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event921": {
       "title": "event921",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 921."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event922": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event922": {
       "title": "event922",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 922."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event923": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event923": {
       "title": "event923",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 923."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event924": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event924": {
       "title": "event924",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 924."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event925": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event925": {
       "title": "event925",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 925."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event926": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event926": {
       "title": "event926",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 926."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event927": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event927": {
       "title": "event927",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 927."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event928": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event928": {
       "title": "event928",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 928."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event929": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event929": {
       "title": "event929",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 929."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event930": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event930": {
       "title": "event930",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 930."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event931": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event931": {
       "title": "event931",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 931."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event932": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event932": {
       "title": "event932",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 932."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event933": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event933": {
       "title": "event933",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 933."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event934": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event934": {
       "title": "event934",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 934."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event935": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event935": {
       "title": "event935",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 935."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event936": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event936": {
       "title": "event936",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 936."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event937": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event937": {
       "title": "event937",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 937."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event938": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event938": {
       "title": "event938",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 938."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event939": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event939": {
       "title": "event939",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 939."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event940": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event940": {
       "title": "event940",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 940."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event941": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event941": {
       "title": "event941",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 941."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event942": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event942": {
       "title": "event942",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 942."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event943": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event943": {
       "title": "event943",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 943."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event944": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event944": {
       "title": "event944",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 944."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event945": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event945": {
       "title": "event945",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 945."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event946": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event946": {
       "title": "event946",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 946."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event947": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event947": {
       "title": "event947",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 947."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event948": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event948": {
       "title": "event948",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 948."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event949": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event949": {
       "title": "event949",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 949."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event950": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event950": {
       "title": "event950",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 950."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event951": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event951": {
       "title": "event951",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 951."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event952": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event952": {
       "title": "event952",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 952."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event953": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event953": {
       "title": "event953",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 953."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event954": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event954": {
       "title": "event954",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 954."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event955": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event955": {
       "title": "event955",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 955."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event956": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event956": {
       "title": "event956",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 956."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event957": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event957": {
       "title": "event957",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 957."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event958": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event958": {
       "title": "event958",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 958."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event959": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event959": {
       "title": "event959",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 959."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event960": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event960": {
       "title": "event960",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 960."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event961": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event961": {
       "title": "event961",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 961."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event962": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event962": {
       "title": "event962",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 962."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event963": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event963": {
       "title": "event963",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 963."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event964": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event964": {
       "title": "event964",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 964."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event965": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event965": {
       "title": "event965",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 965."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event966": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event966": {
       "title": "event966",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 966."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event967": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event967": {
       "title": "event967",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 967."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event968": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event968": {
       "title": "event968",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 968."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event969": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event969": {
       "title": "event969",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 969."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event970": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event970": {
       "title": "event970",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 970."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event971": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event971": {
       "title": "event971",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 971."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event972": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event972": {
       "title": "event972",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 972."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event973": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event973": {
       "title": "event973",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 973."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event974": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event974": {
       "title": "event974",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 974."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event975": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event975": {
       "title": "event975",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 975."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event976": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event976": {
       "title": "event976",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 976."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event977": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event977": {
       "title": "event977",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 977."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event978": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event978": {
       "title": "event978",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 978."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event979": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event979": {
       "title": "event979",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 979."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event980": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event980": {
       "title": "event980",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 980."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event981": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event981": {
       "title": "event981",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 981."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event982": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event982": {
       "title": "event982",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 982."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event983": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event983": {
       "title": "event983",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 983."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event984": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event984": {
       "title": "event984",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 984."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event985": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event985": {
       "title": "event985",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 985."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event986": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event986": {
       "title": "event986",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 986."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event987": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event987": {
       "title": "event987",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 987."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event988": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event988": {
       "title": "event988",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 988."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event989": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event989": {
       "title": "event989",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 989."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event990": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event990": {
       "title": "event990",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 990."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event991": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event991": {
       "title": "event991",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 991."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event992": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event992": {
       "title": "event992",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 992."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event993": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event993": {
       "title": "event993",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 993."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event994": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event994": {
       "title": "event994",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 994."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event995": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event995": {
       "title": "event995",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 995."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event996": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event996": {
       "title": "event996",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 996."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event997": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event997": {
       "title": "event997",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 997."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event998": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event998": {
       "title": "event998",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 998."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event999": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event999": {
       "title": "event999",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 999."
     },
-    "https://ns.adobe.com/experience/analytics/event901to1000/event1000": {
+    "https://ns.adobe.com/xdm/data/metrics/_experience/analytics/event901to1000/event1000": {
       "title": "event1000",
       "$ref": "https://ns.adobe.com/xdm/data/measure",
       "description": "Custom event 1000."


### PR DESCRIPTION
This PR links to the issue #163 

@trieloff @kstreeter @cmathis

This PR changes the analytics-extensions event fields' URIs, so the analytics events fields have the same parent namespace like standard metrics (requested by analytics).
