### PR TITLE
Add `meta:status` of type `enum`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -349,6 +349,15 @@ The third schema is `third.schema.json`, it extends both `second`, and transitiv
 }
 ```
 
+### Schema Stability Status
+
+Each schema should contains the enum property `meta:status` that designates it's stability. The value should be one of the following enumerations:
+
+* `stable` : No open issues and has been in `stabilizing` for 1 month without major changes
+* `stabilizing` : No further major changes are expected
+* `experimental` : Major changes can be expected
+* `deprecated` : Applicable to `stable` once they are superceded by another model or set of models
+
 ### Other Schema Extensions
 
 XDM is using a couple of custom keywords that are not part of the JSON Schema standard. These include:

--- a/meta.schema.json
+++ b/meta.schema.json
@@ -149,6 +149,6 @@
     "description":
       "Indicates if the schema’s level of stability. Defined values are: stable, stabilizing, and experimental.",
     "type": "string",
-    "meta:enum": ["stable", "stabilizing", "experimental"]
+    "meta:enum": ["stable", "stabilizing", "experimental", "deprecated"]
   }
 }

--- a/meta.schema.json
+++ b/meta.schema.json
@@ -17,8 +17,7 @@
     "$id": {
       "type": "string",
       "format": "uri",
-      "pattern":
-        "(https://ns\\.adobe\\.com/xdm/[a-z0-9-/]*)|(http://schema\\.org/.*)|(http://ns.adobe.com/adobecloud/core/1.0.*)|(https://tools\\.ietf\\.org/html/draft-kelly-json-hal-08/.*)"
+      "pattern": "(https://ns\\.adobe\\.com/xdm/[a-z0-9-/]*)|(http://schema\\.org/.*)|(http://ns.adobe.com/adobecloud/core/1.0.*)|(https://tools\\.ietf\\.org/html/draft-kelly-json-hal-08/.*)"
     },
     "meta:license": {
       "type": "array",
@@ -29,32 +28,27 @@
         },
         {
           "type": "string",
-          "const":
-            "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license"
+          "const": "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license"
         },
         {
           "type": "string",
-          "const":
-            "you may not use this file except in compliance with the License. You may obtain a copy"
+          "const": "you may not use this file except in compliance with the License. You may obtain a copy"
         },
         {
           "type": "string",
-          "const":
-            "of the License at https://creativecommons.org/licenses/by/4.0/"
+          "const": "of the License at https://creativecommons.org/licenses/by/4.0/"
         }
       ]
     },
     "meta:extensible": {
       "type": "boolean",
       "default": false,
-      "description":
-        "Set this `true` if the schema can be extended by other schemas."
+      "description": "Set this `true` if the schema can be extended by other schemas."
     },
     "meta:auditable": {
       "type": "boolean",
       "default": false,
-      "description":
-        "Set this `true` if entities of this schema can have an audit record."
+      "description": "Set this `true` if entities of this schema can have an audit record."
     },
     "meta:extends": {
       "oneOf": [
@@ -89,7 +83,10 @@
               "const": true
             }
           },
-          "required": ["definitions", "meta:extensible"]
+          "required": [
+            "definitions",
+            "meta:extensible"
+          ]
         },
         {
           "properties": {
@@ -109,7 +106,10 @@
               "format": "uri"
             }
           },
-          "required": ["meta:extends", "allOf"]
+          "required": [
+            "meta:extends",
+            "allOf"
+          ]
         },
         {
           "properties": {
@@ -121,7 +121,10 @@
               }
             }
           },
-          "required": ["meta:extends", "allOf"]
+          "required": [
+            "meta:extends",
+            "allOf"
+          ]
         },
         {
           "properties": {
@@ -143,5 +146,15 @@
         "description"
       ]
     }
-  ]
+  ],
+  "meta:status": {
+    "title": "Status",
+    "description": "Indicates if the schema’s level of stability. Defined values are: stable, stabilizing, and experimental.",
+    "type": "string",
+    "meta:enum": [
+      "stable",
+      "stabilizing",
+      "experimental"
+    ]
+  }
 }

--- a/meta.schema.json
+++ b/meta.schema.json
@@ -17,7 +17,8 @@
     "$id": {
       "type": "string",
       "format": "uri",
-      "pattern": "(https://ns\\.adobe\\.com/xdm/[a-z0-9-/]*)|(http://schema\\.org/.*)|(http://ns.adobe.com/adobecloud/core/1.0.*)|(https://tools\\.ietf\\.org/html/draft-kelly-json-hal-08/.*)"
+      "pattern":
+        "(https://ns\\.adobe\\.com/xdm/[a-z0-9-/]*)|(http://schema\\.org/.*)|(http://ns.adobe.com/adobecloud/core/1.0.*)|(https://tools\\.ietf\\.org/html/draft-kelly-json-hal-08/.*)"
     },
     "meta:license": {
       "type": "array",
@@ -28,27 +29,32 @@
         },
         {
           "type": "string",
-          "const": "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license"
+          "const":
+            "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license"
         },
         {
           "type": "string",
-          "const": "you may not use this file except in compliance with the License. You may obtain a copy"
+          "const":
+            "you may not use this file except in compliance with the License. You may obtain a copy"
         },
         {
           "type": "string",
-          "const": "of the License at https://creativecommons.org/licenses/by/4.0/"
+          "const":
+            "of the License at https://creativecommons.org/licenses/by/4.0/"
         }
       ]
     },
     "meta:extensible": {
       "type": "boolean",
       "default": false,
-      "description": "Set this `true` if the schema can be extended by other schemas."
+      "description":
+        "Set this `true` if the schema can be extended by other schemas."
     },
     "meta:auditable": {
       "type": "boolean",
       "default": false,
-      "description": "Set this `true` if entities of this schema can have an audit record."
+      "description":
+        "Set this `true` if entities of this schema can have an audit record."
     },
     "meta:extends": {
       "oneOf": [
@@ -83,10 +89,7 @@
               "const": true
             }
           },
-          "required": [
-            "definitions",
-            "meta:extensible"
-          ]
+          "required": ["definitions", "meta:extensible"]
         },
         {
           "properties": {
@@ -106,10 +109,7 @@
               "format": "uri"
             }
           },
-          "required": [
-            "meta:extends",
-            "allOf"
-          ]
+          "required": ["meta:extends", "allOf"]
         },
         {
           "properties": {
@@ -121,10 +121,7 @@
               }
             }
           },
-          "required": [
-            "meta:extends",
-            "allOf"
-          ]
+          "required": ["meta:extends", "allOf"]
         },
         {
           "properties": {
@@ -149,12 +146,9 @@
   ],
   "meta:status": {
     "title": "Status",
-    "description": "Indicates if the schema’s level of stability. Defined values are: stable, stabilizing, and experimental.",
+    "description":
+      "Indicates if the schema’s level of stability. Defined values are: stable, stabilizing, and experimental.",
     "type": "string",
-    "meta:enum": [
-      "stable",
-      "stabilizing",
-      "experimental"
-    ]
+    "meta:enum": ["stable", "stabilizing", "experimental"]
   }
 }

--- a/schemas/addtoschema.sh
+++ b/schemas/addtoschema.sh
@@ -1,0 +1,10 @@
+#!/bin/bash 
+
+schemas=$1
+newcontent=$2
+echo -e "Adding:\n\tjson: ${newcontent}\n\tto: ${schemas}"
+
+for cur in $( find . -iname "${schemas}" ); do
+  jq ". + ${newcontent}" $cur > "${cur}.out"
+  mv "${cur}.out" $cur
+done

--- a/schemas/assets/aggregated-asset.schema.json
+++ b/schemas/assets/aggregated-asset.schema.json
@@ -9,20 +9,17 @@
   "$id": "https://ns.adobe.com/xdm/assets/aggregated-asset",
   "title": "Aggregated Asset",
   "type": "object",
-  "description":
-    "This schema aggregates all asset sub-schemas that are supported by XDM.",
+  "description": "This schema aggregates all asset sub-schemas that are supported by XDM.",
   "additionalProperties": true,
   "allOf": [
     {
       "$ref": "http://ns.adobe.com/adobecloud/core/1.0/asset#/definitions/asset"
     },
     {
-      "$ref":
-        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/common-properties"
+      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/common-properties"
     },
     {
-      "$ref":
-        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
+      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/external/hal/resource#/definitions/hal"
@@ -31,15 +28,13 @@
       "$ref": "https://ns.adobe.com/xdm/content/content#/definitions/content"
     },
     {
-      "$ref":
-        "https://ns.adobe.com/xdm/assets/copyright-owner#/definitions/copyright"
+      "$ref": "https://ns.adobe.com/xdm/assets/copyright-owner#/definitions/copyright"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/assets/asset#/definitions/asset"
     },
     {
-      "$ref":
-        "https://ns.adobe.com/xdm/assets/rectangular#/definitions/rectangular"
+      "$ref": "https://ns.adobe.com/xdm/assets/rectangular#/definitions/rectangular"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/assets/image#/definitions/image"
@@ -47,5 +42,6 @@
     {
       "$ref": "https://ns.adobe.com/xdm/assets/video#/definitions/video"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/assets/aggregated-asset.schema.json
+++ b/schemas/assets/aggregated-asset.schema.json
@@ -9,17 +9,20 @@
   "$id": "https://ns.adobe.com/xdm/assets/aggregated-asset",
   "title": "Aggregated Asset",
   "type": "object",
-  "description": "This schema aggregates all asset sub-schemas that are supported by XDM.",
+  "description":
+    "This schema aggregates all asset sub-schemas that are supported by XDM.",
   "additionalProperties": true,
   "allOf": [
     {
       "$ref": "http://ns.adobe.com/adobecloud/core/1.0/asset#/definitions/asset"
     },
     {
-      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/common-properties"
+      "$ref":
+        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/common-properties"
     },
     {
-      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
+      "$ref":
+        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/external/hal/resource#/definitions/hal"
@@ -28,13 +31,15 @@
       "$ref": "https://ns.adobe.com/xdm/content/content#/definitions/content"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/assets/copyright-owner#/definitions/copyright"
+      "$ref":
+        "https://ns.adobe.com/xdm/assets/copyright-owner#/definitions/copyright"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/assets/asset#/definitions/asset"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/assets/rectangular#/definitions/rectangular"
+      "$ref":
+        "https://ns.adobe.com/xdm/assets/rectangular#/definitions/rectangular"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/assets/image#/definitions/image"

--- a/schemas/assets/artboard.schema.json
+++ b/schemas/assets/artboard.schema.json
@@ -17,7 +17,8 @@
       "properties": {
         "xdm:name": {
           "type": "string",
-          "description": "Name of the artboard. This would be visible to the user and users can specify names that can help them uniquely identfiy different Artboards."
+          "description":
+            "Name of the artboard. This would be visible to the user and users can specify names that can help them uniquely identfiy different Artboards."
         }
       }
     }
@@ -27,7 +28,8 @@
       "$ref": "#/definitions/artboard"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/assets/variable-unit-rectangular#/definitions/rectangular"
+      "$ref":
+        "https://ns.adobe.com/xdm/assets/variable-unit-rectangular#/definitions/rectangular"
     }
   ],
   "meta:status": "experimental"

--- a/schemas/assets/artboard.schema.json
+++ b/schemas/assets/artboard.schema.json
@@ -17,8 +17,7 @@
       "properties": {
         "xdm:name": {
           "type": "string",
-          "description":
-            "Name of the artboard. This would be visible to the user and users can specify names that can help them uniquely identfiy different Artboards."
+          "description": "Name of the artboard. This would be visible to the user and users can specify names that can help them uniquely identfiy different Artboards."
         }
       }
     }
@@ -28,8 +27,8 @@
       "$ref": "#/definitions/artboard"
     },
     {
-      "$ref":
-        "https://ns.adobe.com/xdm/assets/variable-unit-rectangular#/definitions/rectangular"
+      "$ref": "https://ns.adobe.com/xdm/assets/variable-unit-rectangular#/definitions/rectangular"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/assets/asset.schema.json
+++ b/schemas/assets/asset.schema.json
@@ -17,7 +17,8 @@
     "http://ns.adobe.com/adobecloud/core/1.0/asset",
     "https://ns.adobe.com/xdm/content/content"
   ],
-  "description": "A digital asset, is anything that exists in a binary format and comes with the right to use. Content that does not possess that right is not considered an asset. Digital assets include but are not exclusive to: digital documents, audible content, motion picture, and other relevant digital content that is currently in circulation or production.",
+  "description":
+    "A digital asset, is anything that exists in a binary format and comes with the right to use. Content that does not possess that right is not considered an asset. Digital assets include but are not exclusive to: digital documents, audible content, motion picture, and other relevant digital content that is currently in circulation or production.",
   "definitions": {
     "asset": {
       "properties": {
@@ -25,11 +26,11 @@
           "type": "string",
           "title": "Document ID",
           "meta:immutable": true,
-          "description": "It takes the value of xmpMM:DocumentID present in the [XMP packet of the asset](http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2014-12/XMPSpecificationPart1.pdf). For the assets having no XMP packet this property won't be populated. \n\nThe value is a GUID, capital A-F, 8-4-4-12, preceded by the string `uuid:`",
-          "examples": [
-            "uuid:00112233-4455-6677-8899-AABBCCDDEEFF"
-          ],
-          "pattern": "^uuid:[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$"
+          "description":
+            "It takes the value of xmpMM:DocumentID present in the [XMP packet of the asset](http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2014-12/XMPSpecificationPart1.pdf). For the assets having no XMP packet this property won't be populated. \n\nThe value is a GUID, capital A-F, 8-4-4-12, preceded by the string `uuid:`",
+          "examples": ["uuid:00112233-4455-6677-8899-AABBCCDDEEFF"],
+          "pattern":
+            "^uuid:[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$"
         },
         "xdm:aliasIDs": {
           "type": "array",
@@ -40,22 +41,26 @@
               "system": {
                 "title": "External System",
                 "type": "string",
-                "description": "A string used to identify the external systems like google, facebook etc."
+                "description":
+                  "A string used to identify the external systems like google, facebook etc."
               },
               "id": {
                 "type": "string",
                 "title": "External ID",
-                "description": "An ID under which external systems track the asset."
+                "description":
+                  "An ID under which external systems track the asset."
               }
             }
           },
-          "description": "List of IDs under which external systems track the asset. Example of external systems : google, facebook etc."
+          "description":
+            "List of IDs under which external systems track the asset. Example of external systems : google, facebook etc."
         },
         "xmp:createDate": {
           "title": "Date Created",
           "type": "string",
           "format": "date-time",
-          "description": "The date and time the resource was created. It will be taken from within the asset."
+          "description":
+            "The date and time the resource was created. It will be taken from within the asset."
         },
         "dc:creator": {
           "title": "Creator",
@@ -63,20 +68,23 @@
           "items": {
             "type": "string"
           },
-          "description": "An entity primarily responsible for making the resource. Examples of a creator include a person, an organization, or a service. Typically, the name of a creator should be used to indicate the entity.\n\nXMP usage is a list of creators. Entities should be listed in order of decreasing precedence, if such order is significant."
+          "description":
+            "An entity primarily responsible for making the resource. Examples of a creator include a person, an organization, or a service. Typically, the name of a creator should be used to indicate the entity.\n\nXMP usage is a list of creators. Entities should be listed in order of decreasing precedence, if such order is significant."
         },
         "xmp:creatorTool": {
           "title": "Creator Tool",
           "type": "string",
           "meta:usereditable": false,
-          "description": "Name of the application which authored the asset. It takes the value present in `xmp:CreatorTool` property in XMP.\nIt is recommended that the value use this format convention:\nOrganization Software_name Version (token;token;...)\n- Organization: The name of the company or organization providing the software, no SPACEs.\n- Software_name: The full name of the software, SPACEs allowed.\n- version: The version of the software, no SPACEs.\n- tokens: Can be used to identify an operating system, plug-in, or more detailed version information."
+          "description":
+            "Name of the application which authored the asset. It takes the value present in `xmp:CreatorTool` property in XMP.\nIt is recommended that the value use this format convention:\nOrganization Software_name Version (token;token;...)\n- Organization: The name of the company or organization providing the software, no SPACEs.\n- Software_name: The full name of the software, SPACEs allowed.\n- version: The version of the software, no SPACEs.\n- tokens: Can be used to identify an operating system, plug-in, or more detailed version information."
         },
         "xmp:modifyDate": {
           "title": "Mofification Date",
           "type": "string",
           "meta:usereditable": false,
           "format": "date-time",
-          "description": "The date and time when asset was last modified. The Date Time property should conform to ISO 8601 standard. An example form is \"2004-10-23T12:00:00-06:00\". Opposed to `repositoryLastModifiedDate`, this is the time when the asset was last modified locally, with or without knowledge of the repository."
+          "description":
+            "The date and time when asset was last modified. The Date Time property should conform to ISO 8601 standard. An example form is \"2004-10-23T12:00:00-06:00\". Opposed to `repositoryLastModifiedDate`, this is the time when the asset was last modified locally, with or without knowledge of the repository."
         },
         "xdm:milestone": {
           "title": "Milestone",
@@ -97,39 +105,45 @@
         },
         "xmpRights:webStatement": {
           "type": "string",
-          "description": "A Web URL for a statement of the ownership and usage rights for this resource. This is a normal (non-URI) simple value because of historical usage.",
-          "examples": [
-            "http://creativecommons.org/licenses/by/4.0/"
-          ]
+          "description":
+            "A Web URL for a statement of the ownership and usage rights for this resource. This is a normal (non-URI) simple value because of historical usage.",
+          "examples": ["http://creativecommons.org/licenses/by/4.0/"]
         },
         "dc:rights": {
           "title": "Rights",
           "type": "array",
           "items": {
-            "$ref": "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
+            "$ref":
+              "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
           },
-          "description": "Information about rights held in and over the resource.\nWe can live without mentioning locale if only one entry is there. Default locale is en_us.\nLocale codes should follow IETF BCP 47 standard."
+          "description":
+            "Information about rights held in and over the resource.\nWe can live without mentioning locale if only one entry is there. Default locale is en_us.\nLocale codes should follow IETF BCP 47 standard."
         },
         "xmpRights:marked": {
           "title": "Marked",
           "type": "boolean",
-          "description": "When true, indicates that this is a rights-managed resource. When false, indicates that this is a public-domain resource. Omit if the state is unknown."
+          "description":
+            "When true, indicates that this is a rights-managed resource. When false, indicates that this is a public-domain resource. Omit if the state is unknown."
         },
         "xmpRights:usageTerms": {
           "type": "array",
           "title": "Usage Terms",
           "items": {
-            "$ref": "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
+            "$ref":
+              "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
           },
-          "description": "A collection of text instructions on how a resource can be legally used, given in a variety of languages."
+          "description":
+            "A collection of text instructions on how a resource can be legally used, given in a variety of languages."
         },
         "plus:copyrightOwner": {
           "title": "Copyright Owners",
           "type": "array",
           "items": {
-            "$ref": "https://ns.adobe.com/xdm/assets/copyright-owner#/definitions/copyright"
+            "$ref":
+              "https://ns.adobe.com/xdm/assets/copyright-owner#/definitions/copyright"
           },
-          "description": "Owner or owners of the copyright in the licensed asset."
+          "description":
+            "Owner or owners of the copyright in the licensed asset."
         },
         "photoshop:credit": {
           "title": "Credit",
@@ -140,64 +154,73 @@
           "type": "string",
           "title": "License",
           "format": "uri",
-          "description": "A license is a set of requests/permissions to users of a Work, e.g. a copyright license, the public domain, information for distributors."
+          "description":
+            "A license is a set of requests/permissions to users of a Work, e.g. a copyright license, the public domain, information for distributors."
         },
         "cc:attributionUrl": {
           "title": "Attribution URL",
           "format": "uri",
           "type": "string",
-          "description": "For licenses that require attribution, such as some Creative Commons licenses, a URL that identifies the user to which a work should be attributed. When publishing to Behance, we link to the user's profile page."
+          "description":
+            "For licenses that require attribution, such as some Creative Commons licenses, a URL that identifies the user to which a work should be attributed. When publishing to Behance, we link to the user's profile page."
         },
         "cc:attributionName": {
           "title": "Attribution Name",
           "type": "string",
-          "description": "For licenses that require attribution, such as some Creative Commons licenses, the user to which a work is attributed. When publishing to Behance, this is taken from the user's Behance profile information."
+          "description":
+            "For licenses that require attribution, such as some Creative Commons licenses, the user to which a work is attributed. When publishing to Behance, this is taken from the user's Behance profile information."
         },
         "xmpMM:manageUI": {
           "title": "Manage UI",
           "format": "uri",
           "type": "string",
-          "description": "A URI that can be used to access information about the managed resource through a web browser."
+          "description":
+            "A URI that can be used to access information about the managed resource through a web browser."
         },
         "xmpMM:manageTo": {
           "title": "Manage To",
           "type": "string",
           "format": "uri",
-          "description": "A URI identifying the managed resource to the asset management system; the presence of this property is the formal indication that this resource is managed. The form and content of this URI is private to the asset management system."
+          "description":
+            "A URI identifying the managed resource to the asset management system; the presence of this property is the formal indication that this resource is managed. The form and content of this URI is private to the asset management system."
         },
         "xmpMM:history": {
           "meta:usereditable": false,
           "type": "array",
           "title": "History",
           "items": {
-            "$ref": "https://ns.adobe.com/xdm/assets/resource-event#/definitions/resource-event"
+            "$ref":
+              "https://ns.adobe.com/xdm/assets/resource-event#/definitions/resource-event"
           },
-          "description": "High-level actions that resulted in the creation of this asset. It is intended to give human readers a description of the steps taken to make the changes from the previous version to this one. The list should be at an abstract level; it is not intended to be an exhaustive keystroke or other detailed history. The description should be sufficient for metadata management, as well as for workflow enhancement."
+          "description":
+            "High-level actions that resulted in the creation of this asset. It is intended to give human readers a description of the steps taken to make the changes from the previous version to this one. The list should be at an abstract level; it is not intended to be an exhaustive keystroke or other detailed history. The description should be sufficient for metadata management, as well as for workflow enhancement."
         },
         "dc:title": {
           "title": "Title",
           "type": "array",
           "items": {
-            "$ref": "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
+            "$ref":
+              "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
           },
-          "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known."
+          "description":
+            "A name given to the resource. Typically, a Title will be a name by which the resource is formally known."
         },
         "dc:description": {
           "type": "array",
           "title": "Description",
           "items": {
-            "$ref": "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
+            "$ref":
+              "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
           },
-          "description": "An account of the content of the resource. Description may include but is not limited to: an abstract, table of contents, reference to a graphical representation of content or a free-text account of the content."
+          "description":
+            "An account of the content of the resource. Description may include but is not limited to: an abstract, table of contents, reference to a graphical representation of content or a free-text account of the content."
         },
         "xdm:notSafe": {
           "title": "NSFW State",
-          "description": "Indicates if the content is SFW (safe for work). Safe is value 0 or missing value. NSFW is value 1.",
+          "description":
+            "Indicates if the content is SFW (safe for work). Safe is value 0 or missing value. NSFW is value 1.",
           "type": "integer",
-          "enum": [
-            0,
-            1
-          ],
+          "enum": [0, 1],
           "meta:enum": {
             "0": "The content is safe for work",
             "1": "The content is not safe for work"
@@ -209,21 +232,20 @@
           "title": "Language",
           "items": {
             "type": "string",
-            "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
+            "pattern":
+              "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
           },
-          "description": "The language or languages of the resource.\nLanguages are specified in language code as defined in [IETF RFC 3066](https://www.ietf.org/rfc/rfc3066.txt), which is part of BCP 47, which is used elsewhere in XDM.",
-          "examples": [
-            "\n",
-            "pt-BR",
-            "es-ES"
-          ]
+          "description":
+            "The language or languages of the resource.\nLanguages are specified in language code as defined in [IETF RFC 3066](https://www.ietf.org/rfc/rfc3066.txt), which is part of BCP 47, which is used elsewhere in XDM.",
+          "examples": ["\n", "pt-BR", "es-ES"]
         },
         "xmpTPg:NPages": {
           "meta:usereditable": false,
           "title": "Number of pages",
           "type": "integer",
           "minimum": 0,
-          "description": "The number of pages in the document (including any in contained documents)."
+          "description":
+            "The number of pages in the document (including any in contained documents)."
         },
         "exif:gpsAltitude": {
           "meta:usereditable": false,
@@ -235,43 +257,35 @@
           "meta:usereditable": false,
           "type": "integer",
           "title": "GPS Altitude Reference",
-          "enum": [
-            0,
-            1
-          ],
+          "enum": [0, 1],
           "meta:enum": {
             "0": "The `exif:gpsAltitude` specifies a value above sea level",
             "1": "The `exif:gpsAltitude` specifies a value below sea level"
           },
-          "description": "GPS tag 5, 0x5. Indicates whether the altitude is above or below sea level."
+          "description":
+            "GPS tag 5, 0x5. Indicates whether the altitude is above or below sea level."
         },
         "exif:gpsLatitude": {
           "meta:usereditable": false,
           "type": "string",
           "title": "GPS Latitude",
           "pattern": "^[\\d]{1,3},[\\d]{1,2}(,[\\d]{1,2}|.[\\d]+)[NS]$",
-          "description": "GPS tag 2, 0x02 (position) and 1, 0x01 (North/South). Indicates latitude. A Text value in the form “DDD,MM,SSk” or “DDD,MM.mmk”, where:\n* DDD is a number of degrees\n* MM is a number of minutes\n* SS is a number of seconds\n* mm is a fraction of minutes\n* k is a single character N or S, indicating a direction (north, south)\nLeading zeros are not necessary for the for DDD, MM, and SS values. The DDD,MM.mmk form should be used when any of the native Exif component rational values has a denominator other than 1. There can be any number of fractional digits."
+          "description":
+            "GPS tag 2, 0x02 (position) and 1, 0x01 (North/South). Indicates latitude. A Text value in the form “DDD,MM,SSk” or “DDD,MM.mmk”, where:\n* DDD is a number of degrees\n* MM is a number of minutes\n* SS is a number of seconds\n* mm is a fraction of minutes\n* k is a single character N or S, indicating a direction (north, south)\nLeading zeros are not necessary for the for DDD, MM, and SS values. The DDD,MM.mmk form should be used when any of the native Exif component rational values has a denominator other than 1. There can be any number of fractional digits."
         },
         "exif:gpsLongitude": {
           "meta:usereditable": false,
           "type": "string",
           "title": "GPS Longitude",
           "pattern": "^[\\d]{1,3},[\\d]{1,2}(,[\\d]{1,2}|.[\\d]+)[EW]$",
-          "description": "GPS tag 4, 0x04 (position) and 3, 0x03 (East/West). Indicates longitude. A Text value in the form “DDD,MM,SSk” or “DDD,MM.mmk”, where:\n* DDD is a number of degrees\n* MM is a number of minutes\n* SS is a number of seconds\n* mm is a fraction of minutes\n* k is a single character E or W, indicating a direction (east, west)\nLeading zeros are not necessary for the for DDD, MM, and SS values. The DDD,MM.mmk form should be used when any of the native Exif component rational values has a denominator other than 1. There can be any number of fractional digits."
+          "description":
+            "GPS tag 4, 0x04 (position) and 3, 0x03 (East/West). Indicates longitude. A Text value in the form “DDD,MM,SSk” or “DDD,MM.mmk”, where:\n* DDD is a number of degrees\n* MM is a number of minutes\n* SS is a number of seconds\n* mm is a fraction of minutes\n* k is a single character E or W, indicating a direction (east, west)\nLeading zeros are not necessary for the for DDD, MM, and SS values. The DDD,MM.mmk form should be used when any of the native Exif component rational values has a denominator other than 1. There can be any number of fractional digits."
         },
         "xmp:rating": {
           "meta:usereditable": true,
           "type": "integer",
           "title": "Rating",
-          "enum": [
-            -1,
-            0,
-            1,
-            2,
-            3,
-            4,
-            5
-          ],
+          "enum": [-1, 0, 1, 2, 3, 4, 5],
           "meta:enum": {
             "0": "",
             "1": "⭑",
@@ -281,7 +295,8 @@
             "5": "⭑⭑⭑⭑⭑",
             "-1": "rejected"
           },
-          "description": "A user-assigned editable rating for this file. The value shall be -1 or in the range [0..5], where -1 indicates “rejected” and 0 indicates “unrated”. If xmp:Rating is not present, a value of 0 should be assumed. NOTE: Anticipated usage is for a typical “star rating” UI, with the addition of a notion of rejection."
+          "description":
+            "A user-assigned editable rating for this file. The value shall be -1 or in the range [0..5], where -1 indicates “rejected” and 0 indicates “unrated”. If xmp:Rating is not present, a value of 0 should be assumed. NOTE: Anticipated usage is for a typical “star rating” UI, with the addition of a notion of rejection."
         },
         "dc:subject": {
           "title": "Subject",
@@ -289,7 +304,8 @@
           "items": {
             "type": "string"
           },
-          "description": "Set of descriptive phrases or keywords that describe the content of the resource. These keywords are part of the XMP metadata of the asset. Compare this with the `keyword` and `machineKeywords` properties, which provide more structure and context."
+          "description":
+            "Set of descriptive phrases or keywords that describe the content of the resource. These keywords are part of the XMP metadata of the asset. Compare this with the `keyword` and `machineKeywords` properties, which provide more structure and context."
         },
         "xmp:keywords": {
           "type": "array",
@@ -297,35 +313,36 @@
           "items": {
             "$schema": "http://json-schema.org/draft-06/schema#",
             "title": "Keyword",
-            "description": "The `Keyword` schema describes a keyword in a list of keywords, with specific locale and importance relative to other keywords in the same list.",
+            "description":
+              "The `Keyword` schema describes a keyword in a list of keywords, with specific locale and importance relative to other keywords in the same list.",
             "properties": {
               "value": {
                 "title": "Value",
-                "description": "The keyword itself. A keyword can be considered like a tag, i.e. a short description of the content of the asset.",
+                "description":
+                  "The keyword itself. A keyword can be considered like a tag, i.e. a short description of the content of the asset.",
                 "type": "string"
               },
               "localeCode": {
                 "type": "string",
-                "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
-                "description": "Language of the keyword. The locale code should follow [RFC BCP 47](https://tools.ietf.org/html/bcp47)",
-                "examples": [
-                  "en-US",
-                  "de-CH"
-                ]
+                "pattern":
+                  "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
+                "description":
+                  "Language of the keyword. The locale code should follow [RFC BCP 47](https://tools.ietf.org/html/bcp47)",
+                "examples": ["en-US", "de-CH"]
               },
               "importance": {
                 "type": "number",
                 "title": "Importance",
                 "minimum": 0,
                 "maximum": 1,
-                "description": "The importance of the keyword on a scale from zero to one. If required repository will infer it as per its policies and add it for the keywords"
+                "description":
+                  "The importance of the keyword on a scale from zero to one. If required repository will infer it as per its policies and add it for the keywords"
               }
             },
-            "required": [
-              "value"
-            ]
+            "required": ["value"]
           },
-          "description": "The `keywords` property is used to track human-assigned descriptive phrases like keywords or tags of an asset. Rather than a plan list of tags, it is a structured set of keywords, where keywords can have an explicit importance ranking and a locale. This allows the management of multi-lingual keywords for a given asset. For machine-generated keywords, use the `machineKeywords` property. "
+          "description":
+            "The `keywords` property is used to track human-assigned descriptive phrases like keywords or tags of an asset. Rather than a plan list of tags, it is a structured set of keywords, where keywords can have an explicit importance ranking and a locale. This allows the management of multi-lingual keywords for a given asset. For machine-generated keywords, use the `machineKeywords` property. "
         },
         "xmp:machineKeywords": {
           "meta:usereditable": false,
@@ -338,36 +355,44 @@
                 "type": "number",
                 "minimum": 0,
                 "maximum": 1,
-                "description": "Confidence of the algorithm that this keyword is applicable to the asset. Confidence values are numbers between zero and one. A value of .95 indicates that the algorithm expects less than 5% of all tags with the same confidence value to be mis-applied, i.e. not to be a proper description of the asset."
+                "description":
+                  "Confidence of the algorithm that this keyword is applicable to the asset. Confidence values are numbers between zero and one. A value of .95 indicates that the algorithm expects less than 5% of all tags with the same confidence value to be mis-applied, i.e. not to be a proper description of the asset."
               },
               "algorithm": {
                 "type": "string",
-                "description": "Name of the algorithm which generated the keyword."
+                "description":
+                  "Name of the algorithm which generated the keyword."
               },
               "value": {
                 "type": "string",
-                "description": "The keyword itself. A keyword can be considered like a tag, i.e. a short description of the content of the asset."
+                "description":
+                  "The keyword itself. A keyword can be considered like a tag, i.e. a short description of the content of the asset."
               },
               "localeCode": {
                 "type": "string",
-                "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
-                "description": "Language of the keyword. The locale code should follow [RFC BCP47](https://tools.ietf.org/html/bcp47)"
+                "pattern":
+                  "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
+                "description":
+                  "Language of the keyword. The locale code should follow [RFC BCP47](https://tools.ietf.org/html/bcp47)"
               }
             }
           },
-          "description": "The `machineKeywords` property is used to track machine-assigned descriptive phrases like keywords or tags of an asset. Rather than a plan list of tags, it is a structured set of keywords, where keywords can have an explicit confidence ranking and a locale. For human-defined keywords, use the `keywords` property. "
+          "description":
+            "The `machineKeywords` property is used to track machine-assigned descriptive phrases like keywords or tags of an asset. Rather than a plan list of tags, it is a structured set of keywords, where keywords can have an explicit confidence ranking and a locale. For human-defined keywords, use the `keywords` property. "
         },
         "xmp:fonts": {
           "title": "Fonts",
           "meta:usereditable": false,
-          "description": "This is a list of fonts and typefaces that are used in the document. The order of fonts does not matter.",
+          "description":
+            "This is a list of fonts and typefaces that are used in the document. The order of fonts does not matter.",
           "type": "array",
           "items": {
             "$ref": "https://ns.adobe.com/xdm/assets/font#/definitions/font"
           }
         },
         "xmp:layers": {
-          "$ref": "https://ns.adobe.com/xdm/assets/layer-group#/definitions/layer-group"
+          "$ref":
+            "https://ns.adobe.com/xdm/assets/layer-group#/definitions/layer-group"
         },
         "xmp:artboards": {
           "title": "Artboards",
@@ -375,7 +400,8 @@
           "items": {
             "$ref": "https://ns.adobe.com/xdm/assets/artboard"
           },
-          "description": "Contains the artboards that are being used in the document. A document can have multiple artboards."
+          "description":
+            "Contains the artboards that are being used in the document. A document can have multiple artboards."
         }
       }
     }
@@ -385,10 +411,12 @@
       "$ref": "http://ns.adobe.com/adobecloud/core/1.0/asset#/definitions/asset"
     },
     {
-      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/common-properties"
+      "$ref":
+        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/common-properties"
     },
     {
-      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
+      "$ref":
+        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/external/hal/resource#/definitions/hal"
@@ -397,7 +425,8 @@
       "$ref": "https://ns.adobe.com/xdm/content/content#/definitions/content"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/assets/copyright-owner#/definitions/copyright"
+      "$ref":
+        "https://ns.adobe.com/xdm/assets/copyright-owner#/definitions/copyright"
     },
     {
       "$ref": "#/definitions/asset"

--- a/schemas/assets/asset.schema.json
+++ b/schemas/assets/asset.schema.json
@@ -17,8 +17,7 @@
     "http://ns.adobe.com/adobecloud/core/1.0/asset",
     "https://ns.adobe.com/xdm/content/content"
   ],
-  "description":
-    "A digital asset, is anything that exists in a binary format and comes with the right to use. Content that does not possess that right is not considered an asset. Digital assets include but are not exclusive to: digital documents, audible content, motion picture, and other relevant digital content that is currently in circulation or production.",
+  "description": "A digital asset, is anything that exists in a binary format and comes with the right to use. Content that does not possess that right is not considered an asset. Digital assets include but are not exclusive to: digital documents, audible content, motion picture, and other relevant digital content that is currently in circulation or production.",
   "definitions": {
     "asset": {
       "properties": {
@@ -26,11 +25,11 @@
           "type": "string",
           "title": "Document ID",
           "meta:immutable": true,
-          "description":
-            "It takes the value of xmpMM:DocumentID present in the [XMP packet of the asset](http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2014-12/XMPSpecificationPart1.pdf). For the assets having no XMP packet this property won't be populated. \n\nThe value is a GUID, capital A-F, 8-4-4-12, preceded by the string `uuid:`",
-          "examples": ["uuid:00112233-4455-6677-8899-AABBCCDDEEFF"],
-          "pattern":
-            "^uuid:[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$"
+          "description": "It takes the value of xmpMM:DocumentID present in the [XMP packet of the asset](http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2014-12/XMPSpecificationPart1.pdf). For the assets having no XMP packet this property won't be populated. \n\nThe value is a GUID, capital A-F, 8-4-4-12, preceded by the string `uuid:`",
+          "examples": [
+            "uuid:00112233-4455-6677-8899-AABBCCDDEEFF"
+          ],
+          "pattern": "^uuid:[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$"
         },
         "xdm:aliasIDs": {
           "type": "array",
@@ -41,26 +40,22 @@
               "system": {
                 "title": "External System",
                 "type": "string",
-                "description":
-                  "A string used to identify the external systems like google, facebook etc."
+                "description": "A string used to identify the external systems like google, facebook etc."
               },
               "id": {
                 "type": "string",
                 "title": "External ID",
-                "description":
-                  "An ID under which external systems track the asset."
+                "description": "An ID under which external systems track the asset."
               }
             }
           },
-          "description":
-            "List of IDs under which external systems track the asset. Example of external systems : google, facebook etc."
+          "description": "List of IDs under which external systems track the asset. Example of external systems : google, facebook etc."
         },
         "xmp:createDate": {
           "title": "Date Created",
           "type": "string",
           "format": "date-time",
-          "description":
-            "The date and time the resource was created. It will be taken from within the asset."
+          "description": "The date and time the resource was created. It will be taken from within the asset."
         },
         "dc:creator": {
           "title": "Creator",
@@ -68,23 +63,20 @@
           "items": {
             "type": "string"
           },
-          "description":
-            "An entity primarily responsible for making the resource. Examples of a creator include a person, an organization, or a service. Typically, the name of a creator should be used to indicate the entity.\n\nXMP usage is a list of creators. Entities should be listed in order of decreasing precedence, if such order is significant."
+          "description": "An entity primarily responsible for making the resource. Examples of a creator include a person, an organization, or a service. Typically, the name of a creator should be used to indicate the entity.\n\nXMP usage is a list of creators. Entities should be listed in order of decreasing precedence, if such order is significant."
         },
         "xmp:creatorTool": {
           "title": "Creator Tool",
           "type": "string",
           "meta:usereditable": false,
-          "description":
-            "Name of the application which authored the asset. It takes the value present in `xmp:CreatorTool` property in XMP.\nIt is recommended that the value use this format convention:\nOrganization Software_name Version (token;token;...)\n- Organization: The name of the company or organization providing the software, no SPACEs.\n- Software_name: The full name of the software, SPACEs allowed.\n- version: The version of the software, no SPACEs.\n- tokens: Can be used to identify an operating system, plug-in, or more detailed version information."
+          "description": "Name of the application which authored the asset. It takes the value present in `xmp:CreatorTool` property in XMP.\nIt is recommended that the value use this format convention:\nOrganization Software_name Version (token;token;...)\n- Organization: The name of the company or organization providing the software, no SPACEs.\n- Software_name: The full name of the software, SPACEs allowed.\n- version: The version of the software, no SPACEs.\n- tokens: Can be used to identify an operating system, plug-in, or more detailed version information."
         },
         "xmp:modifyDate": {
           "title": "Mofification Date",
           "type": "string",
           "meta:usereditable": false,
           "format": "date-time",
-          "description":
-            "The date and time when asset was last modified. The Date Time property should conform to ISO 8601 standard. An example form is \"2004-10-23T12:00:00-06:00\". Opposed to `repositoryLastModifiedDate`, this is the time when the asset was last modified locally, with or without knowledge of the repository."
+          "description": "The date and time when asset was last modified. The Date Time property should conform to ISO 8601 standard. An example form is \"2004-10-23T12:00:00-06:00\". Opposed to `repositoryLastModifiedDate`, this is the time when the asset was last modified locally, with or without knowledge of the repository."
         },
         "xdm:milestone": {
           "title": "Milestone",
@@ -105,45 +97,39 @@
         },
         "xmpRights:webStatement": {
           "type": "string",
-          "description":
-            "A Web URL for a statement of the ownership and usage rights for this resource. This is a normal (non-URI) simple value because of historical usage.",
-          "examples": ["http://creativecommons.org/licenses/by/4.0/"]
+          "description": "A Web URL for a statement of the ownership and usage rights for this resource. This is a normal (non-URI) simple value because of historical usage.",
+          "examples": [
+            "http://creativecommons.org/licenses/by/4.0/"
+          ]
         },
         "dc:rights": {
           "title": "Rights",
           "type": "array",
           "items": {
-            "$ref":
-              "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
+            "$ref": "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
           },
-          "description":
-            "Information about rights held in and over the resource.\nWe can live without mentioning locale if only one entry is there. Default locale is en_us.\nLocale codes should follow IETF BCP 47 standard."
+          "description": "Information about rights held in and over the resource.\nWe can live without mentioning locale if only one entry is there. Default locale is en_us.\nLocale codes should follow IETF BCP 47 standard."
         },
         "xmpRights:marked": {
           "title": "Marked",
           "type": "boolean",
-          "description":
-            "When true, indicates that this is a rights-managed resource. When false, indicates that this is a public-domain resource. Omit if the state is unknown."
+          "description": "When true, indicates that this is a rights-managed resource. When false, indicates that this is a public-domain resource. Omit if the state is unknown."
         },
         "xmpRights:usageTerms": {
           "type": "array",
           "title": "Usage Terms",
           "items": {
-            "$ref":
-              "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
+            "$ref": "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
           },
-          "description":
-            "A collection of text instructions on how a resource can be legally used, given in a variety of languages."
+          "description": "A collection of text instructions on how a resource can be legally used, given in a variety of languages."
         },
         "plus:copyrightOwner": {
           "title": "Copyright Owners",
           "type": "array",
           "items": {
-            "$ref":
-              "https://ns.adobe.com/xdm/assets/copyright-owner#/definitions/copyright"
+            "$ref": "https://ns.adobe.com/xdm/assets/copyright-owner#/definitions/copyright"
           },
-          "description":
-            "Owner or owners of the copyright in the licensed asset."
+          "description": "Owner or owners of the copyright in the licensed asset."
         },
         "photoshop:credit": {
           "title": "Credit",
@@ -154,73 +140,64 @@
           "type": "string",
           "title": "License",
           "format": "uri",
-          "description":
-            "A license is a set of requests/permissions to users of a Work, e.g. a copyright license, the public domain, information for distributors."
+          "description": "A license is a set of requests/permissions to users of a Work, e.g. a copyright license, the public domain, information for distributors."
         },
         "cc:attributionUrl": {
           "title": "Attribution URL",
           "format": "uri",
           "type": "string",
-          "description":
-            "For licenses that require attribution, such as some Creative Commons licenses, a URL that identifies the user to which a work should be attributed. When publishing to Behance, we link to the user's profile page."
+          "description": "For licenses that require attribution, such as some Creative Commons licenses, a URL that identifies the user to which a work should be attributed. When publishing to Behance, we link to the user's profile page."
         },
         "cc:attributionName": {
           "title": "Attribution Name",
           "type": "string",
-          "description":
-            "For licenses that require attribution, such as some Creative Commons licenses, the user to which a work is attributed. When publishing to Behance, this is taken from the user's Behance profile information."
+          "description": "For licenses that require attribution, such as some Creative Commons licenses, the user to which a work is attributed. When publishing to Behance, this is taken from the user's Behance profile information."
         },
         "xmpMM:manageUI": {
           "title": "Manage UI",
           "format": "uri",
           "type": "string",
-          "description":
-            "A URI that can be used to access information about the managed resource through a web browser."
+          "description": "A URI that can be used to access information about the managed resource through a web browser."
         },
         "xmpMM:manageTo": {
           "title": "Manage To",
           "type": "string",
           "format": "uri",
-          "description":
-            "A URI identifying the managed resource to the asset management system; the presence of this property is the formal indication that this resource is managed. The form and content of this URI is private to the asset management system."
+          "description": "A URI identifying the managed resource to the asset management system; the presence of this property is the formal indication that this resource is managed. The form and content of this URI is private to the asset management system."
         },
         "xmpMM:history": {
           "meta:usereditable": false,
           "type": "array",
           "title": "History",
           "items": {
-            "$ref":
-              "https://ns.adobe.com/xdm/assets/resource-event#/definitions/resource-event"
+            "$ref": "https://ns.adobe.com/xdm/assets/resource-event#/definitions/resource-event"
           },
-          "description":
-            "High-level actions that resulted in the creation of this asset. It is intended to give human readers a description of the steps taken to make the changes from the previous version to this one. The list should be at an abstract level; it is not intended to be an exhaustive keystroke or other detailed history. The description should be sufficient for metadata management, as well as for workflow enhancement."
+          "description": "High-level actions that resulted in the creation of this asset. It is intended to give human readers a description of the steps taken to make the changes from the previous version to this one. The list should be at an abstract level; it is not intended to be an exhaustive keystroke or other detailed history. The description should be sufficient for metadata management, as well as for workflow enhancement."
         },
         "dc:title": {
           "title": "Title",
           "type": "array",
           "items": {
-            "$ref":
-              "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
+            "$ref": "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
           },
-          "description":
-            "A name given to the resource. Typically, a Title will be a name by which the resource is formally known."
+          "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known."
         },
         "dc:description": {
           "type": "array",
           "title": "Description",
           "items": {
-            "$ref":
-              "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
+            "$ref": "https://ns.adobe.com/xdm/assets/language-alternative#/definitions/language-alternative"
           },
-          "description":
-            "An account of the content of the resource. Description may include but is not limited to: an abstract, table of contents, reference to a graphical representation of content or a free-text account of the content."
+          "description": "An account of the content of the resource. Description may include but is not limited to: an abstract, table of contents, reference to a graphical representation of content or a free-text account of the content."
         },
         "xdm:notSafe": {
           "title": "NSFW State",
-          "description":
-            "Indicates if the content is SFW (safe for work). Safe is value 0 or missing value. NSFW is value 1.",
+          "description": "Indicates if the content is SFW (safe for work). Safe is value 0 or missing value. NSFW is value 1.",
           "type": "integer",
-          "enum": [0, 1],
+          "enum": [
+            0,
+            1
+          ],
           "meta:enum": {
             "0": "The content is safe for work",
             "1": "The content is not safe for work"
@@ -232,20 +209,21 @@
           "title": "Language",
           "items": {
             "type": "string",
-            "pattern":
-              "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
+            "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
           },
-          "description":
-            "The language or languages of the resource.\nLanguages are specified in language code as defined in [IETF RFC 3066](https://www.ietf.org/rfc/rfc3066.txt), which is part of BCP 47, which is used elsewhere in XDM.",
-          "examples": ["\n", "pt-BR", "es-ES"]
+          "description": "The language or languages of the resource.\nLanguages are specified in language code as defined in [IETF RFC 3066](https://www.ietf.org/rfc/rfc3066.txt), which is part of BCP 47, which is used elsewhere in XDM.",
+          "examples": [
+            "\n",
+            "pt-BR",
+            "es-ES"
+          ]
         },
         "xmpTPg:NPages": {
           "meta:usereditable": false,
           "title": "Number of pages",
           "type": "integer",
           "minimum": 0,
-          "description":
-            "The number of pages in the document (including any in contained documents)."
+          "description": "The number of pages in the document (including any in contained documents)."
         },
         "exif:gpsAltitude": {
           "meta:usereditable": false,
@@ -257,35 +235,43 @@
           "meta:usereditable": false,
           "type": "integer",
           "title": "GPS Altitude Reference",
-          "enum": [0, 1],
+          "enum": [
+            0,
+            1
+          ],
           "meta:enum": {
             "0": "The `exif:gpsAltitude` specifies a value above sea level",
             "1": "The `exif:gpsAltitude` specifies a value below sea level"
           },
-          "description":
-            "GPS tag 5, 0x5. Indicates whether the altitude is above or below sea level."
+          "description": "GPS tag 5, 0x5. Indicates whether the altitude is above or below sea level."
         },
         "exif:gpsLatitude": {
           "meta:usereditable": false,
           "type": "string",
           "title": "GPS Latitude",
           "pattern": "^[\\d]{1,3},[\\d]{1,2}(,[\\d]{1,2}|.[\\d]+)[NS]$",
-          "description":
-            "GPS tag 2, 0x02 (position) and 1, 0x01 (North/South). Indicates latitude. A Text value in the form “DDD,MM,SSk” or “DDD,MM.mmk”, where:\n* DDD is a number of degrees\n* MM is a number of minutes\n* SS is a number of seconds\n* mm is a fraction of minutes\n* k is a single character N or S, indicating a direction (north, south)\nLeading zeros are not necessary for the for DDD, MM, and SS values. The DDD,MM.mmk form should be used when any of the native Exif component rational values has a denominator other than 1. There can be any number of fractional digits."
+          "description": "GPS tag 2, 0x02 (position) and 1, 0x01 (North/South). Indicates latitude. A Text value in the form “DDD,MM,SSk” or “DDD,MM.mmk”, where:\n* DDD is a number of degrees\n* MM is a number of minutes\n* SS is a number of seconds\n* mm is a fraction of minutes\n* k is a single character N or S, indicating a direction (north, south)\nLeading zeros are not necessary for the for DDD, MM, and SS values. The DDD,MM.mmk form should be used when any of the native Exif component rational values has a denominator other than 1. There can be any number of fractional digits."
         },
         "exif:gpsLongitude": {
           "meta:usereditable": false,
           "type": "string",
           "title": "GPS Longitude",
           "pattern": "^[\\d]{1,3},[\\d]{1,2}(,[\\d]{1,2}|.[\\d]+)[EW]$",
-          "description":
-            "GPS tag 4, 0x04 (position) and 3, 0x03 (East/West). Indicates longitude. A Text value in the form “DDD,MM,SSk” or “DDD,MM.mmk”, where:\n* DDD is a number of degrees\n* MM is a number of minutes\n* SS is a number of seconds\n* mm is a fraction of minutes\n* k is a single character E or W, indicating a direction (east, west)\nLeading zeros are not necessary for the for DDD, MM, and SS values. The DDD,MM.mmk form should be used when any of the native Exif component rational values has a denominator other than 1. There can be any number of fractional digits."
+          "description": "GPS tag 4, 0x04 (position) and 3, 0x03 (East/West). Indicates longitude. A Text value in the form “DDD,MM,SSk” or “DDD,MM.mmk”, where:\n* DDD is a number of degrees\n* MM is a number of minutes\n* SS is a number of seconds\n* mm is a fraction of minutes\n* k is a single character E or W, indicating a direction (east, west)\nLeading zeros are not necessary for the for DDD, MM, and SS values. The DDD,MM.mmk form should be used when any of the native Exif component rational values has a denominator other than 1. There can be any number of fractional digits."
         },
         "xmp:rating": {
           "meta:usereditable": true,
           "type": "integer",
           "title": "Rating",
-          "enum": [-1, 0, 1, 2, 3, 4, 5],
+          "enum": [
+            -1,
+            0,
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
           "meta:enum": {
             "0": "",
             "1": "⭑",
@@ -295,8 +281,7 @@
             "5": "⭑⭑⭑⭑⭑",
             "-1": "rejected"
           },
-          "description":
-            "A user-assigned editable rating for this file. The value shall be -1 or in the range [0..5], where -1 indicates “rejected” and 0 indicates “unrated”. If xmp:Rating is not present, a value of 0 should be assumed. NOTE: Anticipated usage is for a typical “star rating” UI, with the addition of a notion of rejection."
+          "description": "A user-assigned editable rating for this file. The value shall be -1 or in the range [0..5], where -1 indicates “rejected” and 0 indicates “unrated”. If xmp:Rating is not present, a value of 0 should be assumed. NOTE: Anticipated usage is for a typical “star rating” UI, with the addition of a notion of rejection."
         },
         "dc:subject": {
           "title": "Subject",
@@ -304,8 +289,7 @@
           "items": {
             "type": "string"
           },
-          "description":
-            "Set of descriptive phrases or keywords that describe the content of the resource. These keywords are part of the XMP metadata of the asset. Compare this with the `keyword` and `machineKeywords` properties, which provide more structure and context."
+          "description": "Set of descriptive phrases or keywords that describe the content of the resource. These keywords are part of the XMP metadata of the asset. Compare this with the `keyword` and `machineKeywords` properties, which provide more structure and context."
         },
         "xmp:keywords": {
           "type": "array",
@@ -313,36 +297,35 @@
           "items": {
             "$schema": "http://json-schema.org/draft-06/schema#",
             "title": "Keyword",
-            "description":
-              "The `Keyword` schema describes a keyword in a list of keywords, with specific locale and importance relative to other keywords in the same list.",
+            "description": "The `Keyword` schema describes a keyword in a list of keywords, with specific locale and importance relative to other keywords in the same list.",
             "properties": {
               "value": {
                 "title": "Value",
-                "description":
-                  "The keyword itself. A keyword can be considered like a tag, i.e. a short description of the content of the asset.",
+                "description": "The keyword itself. A keyword can be considered like a tag, i.e. a short description of the content of the asset.",
                 "type": "string"
               },
               "localeCode": {
                 "type": "string",
-                "pattern":
-                  "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
-                "description":
-                  "Language of the keyword. The locale code should follow [RFC BCP 47](https://tools.ietf.org/html/bcp47)",
-                "examples": ["en-US", "de-CH"]
+                "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
+                "description": "Language of the keyword. The locale code should follow [RFC BCP 47](https://tools.ietf.org/html/bcp47)",
+                "examples": [
+                  "en-US",
+                  "de-CH"
+                ]
               },
               "importance": {
                 "type": "number",
                 "title": "Importance",
                 "minimum": 0,
                 "maximum": 1,
-                "description":
-                  "The importance of the keyword on a scale from zero to one. If required repository will infer it as per its policies and add it for the keywords"
+                "description": "The importance of the keyword on a scale from zero to one. If required repository will infer it as per its policies and add it for the keywords"
               }
             },
-            "required": ["value"]
+            "required": [
+              "value"
+            ]
           },
-          "description":
-            "The `keywords` property is used to track human-assigned descriptive phrases like keywords or tags of an asset. Rather than a plan list of tags, it is a structured set of keywords, where keywords can have an explicit importance ranking and a locale. This allows the management of multi-lingual keywords for a given asset. For machine-generated keywords, use the `machineKeywords` property. "
+          "description": "The `keywords` property is used to track human-assigned descriptive phrases like keywords or tags of an asset. Rather than a plan list of tags, it is a structured set of keywords, where keywords can have an explicit importance ranking and a locale. This allows the management of multi-lingual keywords for a given asset. For machine-generated keywords, use the `machineKeywords` property. "
         },
         "xmp:machineKeywords": {
           "meta:usereditable": false,
@@ -355,44 +338,36 @@
                 "type": "number",
                 "minimum": 0,
                 "maximum": 1,
-                "description":
-                  "Confidence of the algorithm that this keyword is applicable to the asset. Confidence values are numbers between zero and one. A value of .95 indicates that the algorithm expects less than 5% of all tags with the same confidence value to be mis-applied, i.e. not to be a proper description of the asset."
+                "description": "Confidence of the algorithm that this keyword is applicable to the asset. Confidence values are numbers between zero and one. A value of .95 indicates that the algorithm expects less than 5% of all tags with the same confidence value to be mis-applied, i.e. not to be a proper description of the asset."
               },
               "algorithm": {
                 "type": "string",
-                "description":
-                  "Name of the algorithm which generated the keyword."
+                "description": "Name of the algorithm which generated the keyword."
               },
               "value": {
                 "type": "string",
-                "description":
-                  "The keyword itself. A keyword can be considered like a tag, i.e. a short description of the content of the asset."
+                "description": "The keyword itself. A keyword can be considered like a tag, i.e. a short description of the content of the asset."
               },
               "localeCode": {
                 "type": "string",
-                "pattern":
-                  "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
-                "description":
-                  "Language of the keyword. The locale code should follow [RFC BCP47](https://tools.ietf.org/html/bcp47)"
+                "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
+                "description": "Language of the keyword. The locale code should follow [RFC BCP47](https://tools.ietf.org/html/bcp47)"
               }
             }
           },
-          "description":
-            "The `machineKeywords` property is used to track machine-assigned descriptive phrases like keywords or tags of an asset. Rather than a plan list of tags, it is a structured set of keywords, where keywords can have an explicit confidence ranking and a locale. For human-defined keywords, use the `keywords` property. "
+          "description": "The `machineKeywords` property is used to track machine-assigned descriptive phrases like keywords or tags of an asset. Rather than a plan list of tags, it is a structured set of keywords, where keywords can have an explicit confidence ranking and a locale. For human-defined keywords, use the `keywords` property. "
         },
         "xmp:fonts": {
           "title": "Fonts",
           "meta:usereditable": false,
-          "description":
-            "This is a list of fonts and typefaces that are used in the document. The order of fonts does not matter.",
+          "description": "This is a list of fonts and typefaces that are used in the document. The order of fonts does not matter.",
           "type": "array",
           "items": {
             "$ref": "https://ns.adobe.com/xdm/assets/font#/definitions/font"
           }
         },
         "xmp:layers": {
-          "$ref":
-            "https://ns.adobe.com/xdm/assets/layer-group#/definitions/layer-group"
+          "$ref": "https://ns.adobe.com/xdm/assets/layer-group#/definitions/layer-group"
         },
         "xmp:artboards": {
           "title": "Artboards",
@@ -400,8 +375,7 @@
           "items": {
             "$ref": "https://ns.adobe.com/xdm/assets/artboard"
           },
-          "description":
-            "Contains the artboards that are being used in the document. A document can have multiple artboards."
+          "description": "Contains the artboards that are being used in the document. A document can have multiple artboards."
         }
       }
     }
@@ -411,12 +385,10 @@
       "$ref": "http://ns.adobe.com/adobecloud/core/1.0/asset#/definitions/asset"
     },
     {
-      "$ref":
-        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/common-properties"
+      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/common-properties"
     },
     {
-      "$ref":
-        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
+      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/external/hal/resource#/definitions/hal"
@@ -425,8 +397,7 @@
       "$ref": "https://ns.adobe.com/xdm/content/content#/definitions/content"
     },
     {
-      "$ref":
-        "https://ns.adobe.com/xdm/assets/copyright-owner#/definitions/copyright"
+      "$ref": "https://ns.adobe.com/xdm/assets/copyright-owner#/definitions/copyright"
     },
     {
       "$ref": "#/definitions/asset"
@@ -442,5 +413,6 @@
     "repo:etag",
     "repo:version",
     "repo:size"
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/assets/copyright-owner.schema.json
+++ b/schemas/assets/copyright-owner.schema.json
@@ -9,14 +9,16 @@
   "$id": "https://ns.adobe.com/xdm/assets/copyright-owner",
   "title": "Copyright Owner",
   "type": "object",
-  "description": "Describes the owner of a copyrighted work through name and ID",
+  "description":
+    "Describes the owner of a copyrighted work through name and ID",
   "definitions": {
     "copyright": {
       "properties": {
         "plus:copyrightOwnerID": {
           "title": "Copyright Owner ID",
           "type": "string",
-          "description": "ID of the copyright owner.\nIf the PLUS-ID being stored in this property is registered with the PLUS Coalition, it should be expressed as a URL. For example: http://plus-id.org/PLUS-ID"
+          "description":
+            "ID of the copyright owner.\nIf the PLUS-ID being stored in this property is registered with the PLUS Coalition, it should be expressed as a URL. For example: http://plus-id.org/PLUS-ID"
         },
         "plus:copyrightOwnerName": {
           "title": "Copyright Owner Name",

--- a/schemas/assets/copyright-owner.schema.json
+++ b/schemas/assets/copyright-owner.schema.json
@@ -9,16 +9,14 @@
   "$id": "https://ns.adobe.com/xdm/assets/copyright-owner",
   "title": "Copyright Owner",
   "type": "object",
-  "description":
-    "Describes the owner of a copyrighted work through name and ID",
+  "description": "Describes the owner of a copyrighted work through name and ID",
   "definitions": {
     "copyright": {
       "properties": {
         "plus:copyrightOwnerID": {
           "title": "Copyright Owner ID",
           "type": "string",
-          "description":
-            "ID of the copyright owner.\nIf the PLUS-ID being stored in this property is registered with the PLUS Coalition, it should be expressed as a URL. For example: http://plus-id.org/PLUS-ID"
+          "description": "ID of the copyright owner.\nIf the PLUS-ID being stored in this property is registered with the PLUS Coalition, it should be expressed as a URL. For example: http://plus-id.org/PLUS-ID"
         },
         "plus:copyrightOwnerName": {
           "title": "Copyright Owner Name",
@@ -27,5 +25,6 @@
         }
       }
     }
-  }
+  },
+  "meta:status": "experimental"
 }

--- a/schemas/assets/font.schema.json
+++ b/schemas/assets/font.schema.json
@@ -18,7 +18,8 @@
           "type": "array",
           "name": "Child Font Files",
           "meta:usereditable": false,
-          "description": "The list of file names for the font files that make up a composite font. See also `composite`, `fontFace`.",
+          "description":
+            "The list of file names for the font files that make up a composite font. See also `composite`, `fontFace`.",
           "items": {
             "type": "string"
           }
@@ -27,63 +28,58 @@
           "type": "boolean",
           "name": "Composite",
           "meta:usereditable": false,
-          "description": "`true` for composite fonts. See also `childFontFiles`."
+          "description":
+            "`true` for composite fonts. See also `childFontFiles`."
         },
         "xdm:fontFace": {
           "type": "string",
           "name": "Font Face",
           "meta:usereditable": false,
-          "description": "The name of the typeface, i.e. the specific weight or instance of the fontFamily. For example: Bold, Italic"
+          "description":
+            "The name of the typeface, i.e. the specific weight or instance of the fontFamily. For example: Bold, Italic"
         },
         "xdm:fontFamily": {
           "type": "string",
           "name": "Font Family",
           "meta:usereditable": false,
-          "description": "Complete collection of typefaces in different weights and classifications, but having the same point size, and designed to work together. For example, a Times Roman font family may include Times Roman Bold, Times Roman Extra Bold, Times Roman Italic, Times Roman Bold Italic, Times Roman Condensed, etc., all in the same size."
+          "description":
+            "Complete collection of typefaces in different weights and classifications, but having the same point size, and designed to work together. For example, a Times Roman font family may include Times Roman Bold, Times Roman Extra Bold, Times Roman Italic, Times Roman Bold Italic, Times Roman Condensed, etc., all in the same size."
         },
         "xdm:fontFileName": {
           "type": "string",
           "name": "Font File Name",
           "meta:usereditable": false,
-          "description": "The font file name (not a complete path). For example: `Times New Roman.otf`. Some products are not storing file extension information. XMP spec is open about specifics of the file name. If font information is stored in multiple files, use the semicolon separator to store file names. For example: `zx___.mmm; zx__.pfm`",
-          "examples": [
-            "zx___.mmm",
-            "zx__.pfm"
-          ]
+          "description":
+            "The font file name (not a complete path). For example: `Times New Roman.otf`. Some products are not storing file extension information. XMP spec is open about specifics of the file name. If font information is stored in multiple files, use the semicolon separator to store file names. For example: `zx___.mmm; zx__.pfm`",
+          "examples": ["zx___.mmm", "zx__.pfm"]
         },
         "xdm:fontName": {
           "type": "string",
           "name": "Font Name",
           "meta:usereditable": false,
-          "description": "PostScript name of the font. For example: `TimesNewRomanPS-BoldItalicMT`. `font_name` is manadatory to identify the font used in an asset but an asset may not have a `font` property if it has only images/vector arts (no text)."
+          "description":
+            "PostScript name of the font. For example: `TimesNewRomanPS-BoldItalicMT`. `font_name` is manadatory to identify the font used in an asset but an asset may not have a `font` property if it has only images/vector arts (no text)."
         },
         "xdm:fontType": {
           "type": "string",
           "name": "Font Type",
           "meta:usereditable": false,
-          "description": "The font type, such as TrueType, Type 1, OpenType, and so on. `font_type` is manadatory to identify font category but an asset may not have a `font` property if it has only images/vector arts (no text).",
-          "meta:enum": [
-            "TrueType",
-            "Type 1",
-            "OpenType"
-          ]
+          "description":
+            "The font type, such as TrueType, Type 1, OpenType, and so on. `font_type` is manadatory to identify font category but an asset may not have a `font` property if it has only images/vector arts (no text).",
+          "meta:enum": ["TrueType", "Type 1", "OpenType"]
         },
         "xdm:versionString": {
           "type": "string",
           "meta:usereditable": false,
-          "enum": [
-            "version",
-            "nameId 5",
-            "CIDFontVersion",
-            ""
-          ],
+          "enum": ["version", "nameId 5", "CIDFontVersion", ""],
           "meta:enum": {
             "version": "for Type1 fonts",
             "nameId 5": "for Apple TrueType and OpenType",
             "CIDFontVersion": "for CID fonts",
             "": "for bitmap fonts"
           },
-          "description": "The Adobe CoolType font engine allows two fonts with the same PostScript name and different technologies to be used at the same time, but not if they are from different versions. So even without this data for a given document you will have unique font data. However, the version can tell you if the font has changed metrics, glyph forms or other important information. This is useful for comparing fonts in two documents or fonts in a document to those in your system."
+          "description":
+            "The Adobe CoolType font engine allows two fonts with the same PostScript name and different technologies to be used at the same time, but not if they are from different versions. So even without this data for a given document you will have unique font data. However, the version can tell you if the font has changed metrics, glyph forms or other important information. This is useful for comparing fonts in two documents or fonts in a document to those in your system."
         }
       }
     }
@@ -93,9 +89,6 @@
       "$ref": "#/definitions/font"
     }
   ],
-  "required": [
-    "xdm:fontName",
-    "xdm:fontType"
-  ],
+  "required": ["xdm:fontName", "xdm:fontType"],
   "meta:status": "experimental"
 }

--- a/schemas/assets/font.schema.json
+++ b/schemas/assets/font.schema.json
@@ -18,8 +18,7 @@
           "type": "array",
           "name": "Child Font Files",
           "meta:usereditable": false,
-          "description":
-            "The list of file names for the font files that make up a composite font. See also `composite`, `fontFace`.",
+          "description": "The list of file names for the font files that make up a composite font. See also `composite`, `fontFace`.",
           "items": {
             "type": "string"
           }
@@ -28,58 +27,63 @@
           "type": "boolean",
           "name": "Composite",
           "meta:usereditable": false,
-          "description":
-            "`true` for composite fonts. See also `childFontFiles`."
+          "description": "`true` for composite fonts. See also `childFontFiles`."
         },
         "xdm:fontFace": {
           "type": "string",
           "name": "Font Face",
           "meta:usereditable": false,
-          "description":
-            "The name of the typeface, i.e. the specific weight or instance of the fontFamily. For example: Bold, Italic"
+          "description": "The name of the typeface, i.e. the specific weight or instance of the fontFamily. For example: Bold, Italic"
         },
         "xdm:fontFamily": {
           "type": "string",
           "name": "Font Family",
           "meta:usereditable": false,
-          "description":
-            "Complete collection of typefaces in different weights and classifications, but having the same point size, and designed to work together. For example, a Times Roman font family may include Times Roman Bold, Times Roman Extra Bold, Times Roman Italic, Times Roman Bold Italic, Times Roman Condensed, etc., all in the same size."
+          "description": "Complete collection of typefaces in different weights and classifications, but having the same point size, and designed to work together. For example, a Times Roman font family may include Times Roman Bold, Times Roman Extra Bold, Times Roman Italic, Times Roman Bold Italic, Times Roman Condensed, etc., all in the same size."
         },
         "xdm:fontFileName": {
           "type": "string",
           "name": "Font File Name",
           "meta:usereditable": false,
-          "description":
-            "The font file name (not a complete path). For example: `Times New Roman.otf`. Some products are not storing file extension information. XMP spec is open about specifics of the file name. If font information is stored in multiple files, use the semicolon separator to store file names. For example: `zx___.mmm; zx__.pfm`",
-          "examples": ["zx___.mmm", "zx__.pfm"]
+          "description": "The font file name (not a complete path). For example: `Times New Roman.otf`. Some products are not storing file extension information. XMP spec is open about specifics of the file name. If font information is stored in multiple files, use the semicolon separator to store file names. For example: `zx___.mmm; zx__.pfm`",
+          "examples": [
+            "zx___.mmm",
+            "zx__.pfm"
+          ]
         },
         "xdm:fontName": {
           "type": "string",
           "name": "Font Name",
           "meta:usereditable": false,
-          "description":
-            "PostScript name of the font. For example: `TimesNewRomanPS-BoldItalicMT`. `font_name` is manadatory to identify the font used in an asset but an asset may not have a `font` property if it has only images/vector arts (no text)."
+          "description": "PostScript name of the font. For example: `TimesNewRomanPS-BoldItalicMT`. `font_name` is manadatory to identify the font used in an asset but an asset may not have a `font` property if it has only images/vector arts (no text)."
         },
         "xdm:fontType": {
           "type": "string",
           "name": "Font Type",
           "meta:usereditable": false,
-          "description":
-            "The font type, such as TrueType, Type 1, OpenType, and so on. `font_type` is manadatory to identify font category but an asset may not have a `font` property if it has only images/vector arts (no text).",
-          "meta:enum": ["TrueType", "Type 1", "OpenType"]
+          "description": "The font type, such as TrueType, Type 1, OpenType, and so on. `font_type` is manadatory to identify font category but an asset may not have a `font` property if it has only images/vector arts (no text).",
+          "meta:enum": [
+            "TrueType",
+            "Type 1",
+            "OpenType"
+          ]
         },
         "xdm:versionString": {
           "type": "string",
           "meta:usereditable": false,
-          "enum": ["version", "nameId 5", "CIDFontVersion", ""],
+          "enum": [
+            "version",
+            "nameId 5",
+            "CIDFontVersion",
+            ""
+          ],
           "meta:enum": {
             "version": "for Type1 fonts",
             "nameId 5": "for Apple TrueType and OpenType",
             "CIDFontVersion": "for CID fonts",
             "": "for bitmap fonts"
           },
-          "description":
-            "The Adobe CoolType font engine allows two fonts with the same PostScript name and different technologies to be used at the same time, but not if they are from different versions. So even without this data for a given document you will have unique font data. However, the version can tell you if the font has changed metrics, glyph forms or other important information. This is useful for comparing fonts in two documents or fonts in a document to those in your system."
+          "description": "The Adobe CoolType font engine allows two fonts with the same PostScript name and different technologies to be used at the same time, but not if they are from different versions. So even without this data for a given document you will have unique font data. However, the version can tell you if the font has changed metrics, glyph forms or other important information. This is useful for comparing fonts in two documents or fonts in a document to those in your system."
         }
       }
     }
@@ -89,5 +93,9 @@
       "$ref": "#/definitions/font"
     }
   ],
-  "required": ["xdm:fontName", "xdm:fontType"]
+  "required": [
+    "xdm:fontName",
+    "xdm:fontType"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/assets/image.schema.json
+++ b/schemas/assets/image.schema.json
@@ -19,12 +19,14 @@
     "https://ns.adobe.com/xdm/assets/asset",
     "https://ns.adobe.com/xdm/assets/rectangular"
   ],
-  "description": "The Image class is for raster and vector image assets, including JPEG, PNG, SVG files",
+  "description":
+    "The Image class is for raster and vector image assets, including JPEG, PNG, SVG files",
   "definitions": {
     "rational": {
       "$id": "https://ns.adobe.com/xdm/assets/image/rational",
       "title": "Rational",
-      "description": "A representation of rational numbers as fractions of denominator and numerator.",
+      "description":
+        "A representation of rational numbers as fractions of denominator and numerator.",
       "properties": {
         "tiff:numerator": {
           "title": "Numerator",
@@ -41,10 +43,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "tiff:numerator",
-        "tiff:denominator"
-      ]
+      "required": ["tiff:numerator", "tiff:denominator"]
     },
     "image": {
       "properties": {
@@ -52,7 +51,8 @@
           "type": "integer",
           "meta:usereditable": false,
           "title": "Orientation",
-          "description": "The orientation of the image. Following values are permitted:\n- `1` = Horizontal (normal)\n- `2` = Mirror horizontal\n- `3` = Rotate 180 degrees\n- `4` = Mirror vertical\n- `5` = Mirror horizontal and rotate 270 degrees clockwise\n- `6` = Rotate 90 degrees clockwise\n- `7` = Mirror horizontal and rotate 90 degrees clockwise\n- `8` = Rotate 270 degrees clockwise",
+          "description":
+            "The orientation of the image. Following values are permitted:\n- `1` = Horizontal (normal)\n- `2` = Mirror horizontal\n- `3` = Rotate 180 degrees\n- `4` = Mirror vertical\n- `5` = Mirror horizontal and rotate 270 degrees clockwise\n- `6` = Rotate 90 degrees clockwise\n- `7` = Mirror horizontal and rotate 90 degrees clockwise\n- `8` = Rotate 270 degrees clockwise",
           "minimum": 1,
           "maximum": 8,
           "meta:enum": {
@@ -69,7 +69,8 @@
         "tiff:XResolution": {
           "title": "X-Resolution",
           "meta:usereditable": false,
-          "description": "Horizontal resolution in pixels per `resolutionUnit`.",
+          "description":
+            "Horizontal resolution in pixels per `resolutionUnit`.",
           "type": "object",
           "allOf": [
             {
@@ -91,12 +92,10 @@
         "tiff:resolutionUnit": {
           "meta:usereditable": false,
           "title": "Resolution Unit",
-          "description": "Unit used for `XResolution` and `YRresolution`. Possible values are 2 (inches) and 3 (centimeters).",
+          "description":
+            "Unit used for `XResolution` and `YRresolution`. Possible values are 2 (inches) and 3 (centimeters).",
           "type": "integer",
-          "enum": [
-            2,
-            3
-          ],
+          "enum": [2, 3],
           "meta:enum": {
             "2": "inches",
             "3": "centimeters"
@@ -112,18 +111,10 @@
         "photoshop:colorMode": {
           "meta:usereditable": false,
           "title": "Color Mode",
-          "description": "The color mode or image mode determines how colors combine based on the number of channels in a color model. Different color modes result in different levels of color detail and file size. For instance, use CMYK color mode for images in a full-color print brochure, and use RGB color mode for images in web or e-mail to reduce file size while maintaining color integrity.",
+          "description":
+            "The color mode or image mode determines how colors combine based on the number of channels in a color model. Different color modes result in different levels of color detail and file size. For instance, use CMYK color mode for images in a full-color print brochure, and use RGB color mode for images in web or e-mail to reduce file size while maintaining color integrity.",
           "type": "integer",
-          "enum": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            7,
-            8,
-            9
-          ],
+          "enum": [0, 1, 2, 3, 4, 7, 8, 9],
           "meta:enum": {
             "0": "Bitmap",
             "1": "Gray scale",
@@ -139,7 +130,8 @@
           "meta:usereditable": false,
           "type": "string",
           "title": "ICC Profile",
-          "description": "The [ICC color profile](http://www.color.org/iccprofile.xalter), such as AppleRGB, AdobeRGB1998.",
+          "description":
+            "The [ICC color profile](http://www.color.org/iccprofile.xalter), such as AppleRGB, AdobeRGB1998.",
           "meta:enum": [
             "ColorMatchRGB",
             "AppleRGB",
@@ -169,7 +161,8 @@
       "$ref": "https://ns.adobe.com/xdm/assets/asset#/definitions/asset"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/assets/rectangular#/definitions/rectangular"
+      "$ref":
+        "https://ns.adobe.com/xdm/assets/rectangular#/definitions/rectangular"
     },
     {
       "$ref": "#/definitions/image"

--- a/schemas/assets/image.schema.json
+++ b/schemas/assets/image.schema.json
@@ -19,14 +19,12 @@
     "https://ns.adobe.com/xdm/assets/asset",
     "https://ns.adobe.com/xdm/assets/rectangular"
   ],
-  "description":
-    "The Image class is for raster and vector image assets, including JPEG, PNG, SVG files",
+  "description": "The Image class is for raster and vector image assets, including JPEG, PNG, SVG files",
   "definitions": {
     "rational": {
       "$id": "https://ns.adobe.com/xdm/assets/image/rational",
       "title": "Rational",
-      "description":
-        "A representation of rational numbers as fractions of denominator and numerator.",
+      "description": "A representation of rational numbers as fractions of denominator and numerator.",
       "properties": {
         "tiff:numerator": {
           "title": "Numerator",
@@ -43,7 +41,10 @@
           "type": "integer"
         }
       },
-      "required": ["tiff:numerator", "tiff:denominator"]
+      "required": [
+        "tiff:numerator",
+        "tiff:denominator"
+      ]
     },
     "image": {
       "properties": {
@@ -51,8 +52,7 @@
           "type": "integer",
           "meta:usereditable": false,
           "title": "Orientation",
-          "description":
-            "The orientation of the image. Following values are permitted:\n- `1` = Horizontal (normal)\n- `2` = Mirror horizontal\n- `3` = Rotate 180 degrees\n- `4` = Mirror vertical\n- `5` = Mirror horizontal and rotate 270 degrees clockwise\n- `6` = Rotate 90 degrees clockwise\n- `7` = Mirror horizontal and rotate 90 degrees clockwise\n- `8` = Rotate 270 degrees clockwise",
+          "description": "The orientation of the image. Following values are permitted:\n- `1` = Horizontal (normal)\n- `2` = Mirror horizontal\n- `3` = Rotate 180 degrees\n- `4` = Mirror vertical\n- `5` = Mirror horizontal and rotate 270 degrees clockwise\n- `6` = Rotate 90 degrees clockwise\n- `7` = Mirror horizontal and rotate 90 degrees clockwise\n- `8` = Rotate 270 degrees clockwise",
           "minimum": 1,
           "maximum": 8,
           "meta:enum": {
@@ -69,8 +69,7 @@
         "tiff:XResolution": {
           "title": "X-Resolution",
           "meta:usereditable": false,
-          "description":
-            "Horizontal resolution in pixels per `resolutionUnit`.",
+          "description": "Horizontal resolution in pixels per `resolutionUnit`.",
           "type": "object",
           "allOf": [
             {
@@ -92,10 +91,12 @@
         "tiff:resolutionUnit": {
           "meta:usereditable": false,
           "title": "Resolution Unit",
-          "description":
-            "Unit used for `XResolution` and `YRresolution`. Possible values are 2 (inches) and 3 (centimeters).",
+          "description": "Unit used for `XResolution` and `YRresolution`. Possible values are 2 (inches) and 3 (centimeters).",
           "type": "integer",
-          "enum": [2, 3],
+          "enum": [
+            2,
+            3
+          ],
           "meta:enum": {
             "2": "inches",
             "3": "centimeters"
@@ -111,10 +112,18 @@
         "photoshop:colorMode": {
           "meta:usereditable": false,
           "title": "Color Mode",
-          "description":
-            "The color mode or image mode determines how colors combine based on the number of channels in a color model. Different color modes result in different levels of color detail and file size. For instance, use CMYK color mode for images in a full-color print brochure, and use RGB color mode for images in web or e-mail to reduce file size while maintaining color integrity.",
+          "description": "The color mode or image mode determines how colors combine based on the number of channels in a color model. Different color modes result in different levels of color detail and file size. For instance, use CMYK color mode for images in a full-color print brochure, and use RGB color mode for images in web or e-mail to reduce file size while maintaining color integrity.",
           "type": "integer",
-          "enum": [0, 1, 2, 3, 4, 7, 8, 9],
+          "enum": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            7,
+            8,
+            9
+          ],
           "meta:enum": {
             "0": "Bitmap",
             "1": "Gray scale",
@@ -130,8 +139,7 @@
           "meta:usereditable": false,
           "type": "string",
           "title": "ICC Profile",
-          "description":
-            "The [ICC color profile](http://www.color.org/iccprofile.xalter), such as AppleRGB, AdobeRGB1998.",
+          "description": "The [ICC color profile](http://www.color.org/iccprofile.xalter), such as AppleRGB, AdobeRGB1998.",
           "meta:enum": [
             "ColorMatchRGB",
             "AppleRGB",
@@ -161,8 +169,7 @@
       "$ref": "https://ns.adobe.com/xdm/assets/asset#/definitions/asset"
     },
     {
-      "$ref":
-        "https://ns.adobe.com/xdm/assets/rectangular#/definitions/rectangular"
+      "$ref": "https://ns.adobe.com/xdm/assets/rectangular#/definitions/rectangular"
     },
     {
       "$ref": "#/definitions/image"
@@ -178,5 +185,6 @@
     "repo:size",
     "xdm:path",
     "repo:etag"
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/assets/language-alternative.schema.json
+++ b/schemas/assets/language-alternative.schema.json
@@ -9,7 +9,8 @@
   "$id": "https://ns.adobe.com/xdm/assets/language-alternative",
   "title": "Language Alternative",
   "type": "object",
-  "description": "A tuple in a set of language alternatives, i.e. pairs of localized text and their locale, that are equivalent in meaning.",
+  "description":
+    "A tuple in a set of language alternatives, i.e. pairs of localized text and their locale, that are equivalent in meaning.",
   "definitions": {
     "language-alternative": {
       "properties": {
@@ -18,9 +19,11 @@
           "type": "string"
         },
         "xml:lang": {
-          "title": "The locale of the language alternative. Locales are expressed following [RFC BCP47](https://tools.ietf.org/html/bcp47)",
+          "title":
+            "The locale of the language alternative. Locales are expressed following [RFC BCP47](https://tools.ietf.org/html/bcp47)",
           "type": "string",
-          "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
+          "pattern":
+            "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
         }
       }
     }

--- a/schemas/assets/language-alternative.schema.json
+++ b/schemas/assets/language-alternative.schema.json
@@ -9,8 +9,7 @@
   "$id": "https://ns.adobe.com/xdm/assets/language-alternative",
   "title": "Language Alternative",
   "type": "object",
-  "description":
-    "A tuple in a set of language alternatives, i.e. pairs of localized text and their locale, that are equivalent in meaning.",
+  "description": "A tuple in a set of language alternatives, i.e. pairs of localized text and their locale, that are equivalent in meaning.",
   "definitions": {
     "language-alternative": {
       "properties": {
@@ -19,13 +18,12 @@
           "type": "string"
         },
         "xml:lang": {
-          "title":
-            "The locale of the language alternative. Locales are expressed following [RFC BCP47](https://tools.ietf.org/html/bcp47)",
+          "title": "The locale of the language alternative. Locales are expressed following [RFC BCP47](https://tools.ietf.org/html/bcp47)",
           "type": "string",
-          "pattern":
-            "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
+          "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
         }
       }
     }
-  }
+  },
+  "meta:status": "experimental"
 }

--- a/schemas/assets/layer-group.schema.json
+++ b/schemas/assets/layer-group.schema.json
@@ -17,13 +17,11 @@
         "xdm:name": {
           "type": "string",
           "title": "Name",
-          "description":
-            "Name of the Layer Group. This will be visible to the user and users can specify names that can help them to identify different Layer Groups"
+          "description": "Name of the Layer Group. This will be visible to the user and users can specify names that can help them to identify different Layer Groups"
         },
         "xdm:layers": {
           "name": "Layers",
-          "description":
-            "The layers or layer groups contained in this layer group.",
+          "description": "The layers or layer groups contained in this layer group.",
           "type": "array",
           "items": {
             "anyOf": [
@@ -31,8 +29,7 @@
                 "$ref": "#/definitions/layer-group"
               },
               {
-                "$ref":
-                  "https://ns.adobe.com/xdm/assets/layer#/definitions/layer"
+                "$ref": "https://ns.adobe.com/xdm/assets/layer#/definitions/layer"
               }
             ]
           }
@@ -44,5 +41,6 @@
     {
       "$ref": "#/definitions/layer-group"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/assets/layer-group.schema.json
+++ b/schemas/assets/layer-group.schema.json
@@ -17,11 +17,13 @@
         "xdm:name": {
           "type": "string",
           "title": "Name",
-          "description": "Name of the Layer Group. This will be visible to the user and users can specify names that can help them to identify different Layer Groups"
+          "description":
+            "Name of the Layer Group. This will be visible to the user and users can specify names that can help them to identify different Layer Groups"
         },
         "xdm:layers": {
           "name": "Layers",
-          "description": "The layers or layer groups contained in this layer group.",
+          "description":
+            "The layers or layer groups contained in this layer group.",
           "type": "array",
           "items": {
             "anyOf": [
@@ -29,7 +31,8 @@
                 "$ref": "#/definitions/layer-group"
               },
               {
-                "$ref": "https://ns.adobe.com/xdm/assets/layer#/definitions/layer"
+                "$ref":
+                  "https://ns.adobe.com/xdm/assets/layer#/definitions/layer"
               }
             ]
           }

--- a/schemas/assets/layer.schema.json
+++ b/schemas/assets/layer.schema.json
@@ -17,18 +17,21 @@
         "xdm:name": {
           "type": "string",
           "title": "Name",
-          "description": "Name of the Layer. This will be visible to the user and users can specify names that can help them to identify different Layers"
+          "description":
+            "Name of the Layer. This will be visible to the user and users can specify names that can help them to identify different Layers"
         },
         "xdm:visible": {
           "type": "boolean",
           "title": "Visible",
-          "description": "Indicates if a layer is visible in the document. `visible = true` - Layer is visible and `false` - Layer is hidden. Visibility is not to be confused with opacity, which is a layer effect."
+          "description":
+            "Indicates if a layer is visible in the document. `visible = true` - Layer is visible and `false` - Layer is hidden. Visibility is not to be confused with opacity, which is a layer effect."
         },
         "xdm:style": {
           "type": "string",
           "name": "Style",
           "meta:usereditable": false,
-          "description": "A layer style is one or more effects applied to a layer or layer group. You can apply one of the preset styles provided with Photoshop or create a custom style. Photoshop provides a variety of effects—such as shadows, glows, and bevels—that change the appearance of a layer’s contents in a non-distructive way. Layer effects are linked to the layer contents. When you move or edit the contents of the layer, the same effects are applied to the modified contents. For example, if you apply a drop shadow to a text layer and then add new text, the shadow is added automatically to the new text."
+          "description":
+            "A layer style is one or more effects applied to a layer or layer group. You can apply one of the preset styles provided with Photoshop or create a custom style. Photoshop provides a variety of effects—such as shadows, glows, and bevels—that change the appearance of a layer’s contents in a non-distructive way. Layer effects are linked to the layer contents. When you move or edit the contents of the layer, the same effects are applied to the modified contents. For example, if you apply a drop shadow to a text layer and then add new text, the shadow is added automatically to the new text."
         }
       }
     }
@@ -38,7 +41,8 @@
       "$ref": "#/definitions/layer"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/assets/variable-unit-rectangular#/definitions/rectangular"
+      "$ref":
+        "https://ns.adobe.com/xdm/assets/variable-unit-rectangular#/definitions/rectangular"
     }
   ],
   "meta:status": "experimental"

--- a/schemas/assets/layer.schema.json
+++ b/schemas/assets/layer.schema.json
@@ -17,21 +17,18 @@
         "xdm:name": {
           "type": "string",
           "title": "Name",
-          "description":
-            "Name of the Layer. This will be visible to the user and users can specify names that can help them to identify different Layers"
+          "description": "Name of the Layer. This will be visible to the user and users can specify names that can help them to identify different Layers"
         },
         "xdm:visible": {
           "type": "boolean",
           "title": "Visible",
-          "description":
-            "Indicates if a layer is visible in the document. `visible = true` - Layer is visible and `false` - Layer is hidden. Visibility is not to be confused with opacity, which is a layer effect."
+          "description": "Indicates if a layer is visible in the document. `visible = true` - Layer is visible and `false` - Layer is hidden. Visibility is not to be confused with opacity, which is a layer effect."
         },
         "xdm:style": {
           "type": "string",
           "name": "Style",
           "meta:usereditable": false,
-          "description":
-            "A layer style is one or more effects applied to a layer or layer group. You can apply one of the preset styles provided with Photoshop or create a custom style. Photoshop provides a variety of effects—such as shadows, glows, and bevels—that change the appearance of a layer’s contents in a non-distructive way. Layer effects are linked to the layer contents. When you move or edit the contents of the layer, the same effects are applied to the modified contents. For example, if you apply a drop shadow to a text layer and then add new text, the shadow is added automatically to the new text."
+          "description": "A layer style is one or more effects applied to a layer or layer group. You can apply one of the preset styles provided with Photoshop or create a custom style. Photoshop provides a variety of effects—such as shadows, glows, and bevels—that change the appearance of a layer’s contents in a non-distructive way. Layer effects are linked to the layer contents. When you move or edit the contents of the layer, the same effects are applied to the modified contents. For example, if you apply a drop shadow to a text layer and then add new text, the shadow is added automatically to the new text."
         }
       }
     }
@@ -41,8 +38,8 @@
       "$ref": "#/definitions/layer"
     },
     {
-      "$ref":
-        "https://ns.adobe.com/xdm/assets/variable-unit-rectangular#/definitions/rectangular"
+      "$ref": "https://ns.adobe.com/xdm/assets/variable-unit-rectangular#/definitions/rectangular"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/assets/rectangular.schema.json
+++ b/schemas/assets/rectangular.schema.json
@@ -9,8 +9,7 @@
   "$id": "https://ns.adobe.com/xdm/assets/rectangular",
   "title": "Rectangular Media",
   "type": "object",
-  "description":
-    "Properties that apply to images, videos, and other rectangular media",
+  "description": "Properties that apply to images, videos, and other rectangular media",
   "definitions": {
     "rectangular": {
       "properties": {
@@ -24,8 +23,7 @@
         },
         "tiff:imageLength": {
           "title": "Length",
-          "description":
-            "Height in pixels. To maintain continuity with the XMP and TIFF standards, the height of an image or video is specified in the property `imageLength`. The duration of the video (also commonly called length) is specified in the property `extent`",
+          "description": "Height in pixels. To maintain continuity with the XMP and TIFF standards, the height of an image or video is specified in the property `imageLength`. The duration of the video (also commonly called length) is specified in the property `extent`",
           "type": "integer",
           "meta:usereditable": false,
           "minimum": 0,
@@ -33,8 +31,7 @@
         },
         "xdm:aspectRatio": {
           "title": "Aspect Ratio",
-          "description":
-            "Describes the proportional relationship between the width and the height. To determine the aspect ratio, divide width by height. Media that have an aspect ratio smaller than one are in landscape format, media that have an aspect ratio greater than one are in portrait format.",
+          "description": "Describes the proportional relationship between the width and the height. To determine the aspect ratio, divide width by height. Media that have an aspect ratio smaller than one are in landscape format, media that have an aspect ratio greater than one are in portrait format.",
           "type": "number",
           "minimum": 0,
           "meta:usereditable": false,
@@ -42,5 +39,6 @@
         }
       }
     }
-  }
+  },
+  "meta:status": "experimental"
 }

--- a/schemas/assets/rectangular.schema.json
+++ b/schemas/assets/rectangular.schema.json
@@ -9,7 +9,8 @@
   "$id": "https://ns.adobe.com/xdm/assets/rectangular",
   "title": "Rectangular Media",
   "type": "object",
-  "description": "Properties that apply to images, videos, and other rectangular media",
+  "description":
+    "Properties that apply to images, videos, and other rectangular media",
   "definitions": {
     "rectangular": {
       "properties": {
@@ -23,7 +24,8 @@
         },
         "tiff:imageLength": {
           "title": "Length",
-          "description": "Height in pixels. To maintain continuity with the XMP and TIFF standards, the height of an image or video is specified in the property `imageLength`. The duration of the video (also commonly called length) is specified in the property `extent`",
+          "description":
+            "Height in pixels. To maintain continuity with the XMP and TIFF standards, the height of an image or video is specified in the property `imageLength`. The duration of the video (also commonly called length) is specified in the property `extent`",
           "type": "integer",
           "meta:usereditable": false,
           "minimum": 0,
@@ -31,7 +33,8 @@
         },
         "xdm:aspectRatio": {
           "title": "Aspect Ratio",
-          "description": "Describes the proportional relationship between the width and the height. To determine the aspect ratio, divide width by height. Media that have an aspect ratio smaller than one are in landscape format, media that have an aspect ratio greater than one are in portrait format.",
+          "description":
+            "Describes the proportional relationship between the width and the height. To determine the aspect ratio, divide width by height. Media that have an aspect ratio smaller than one are in landscape format, media that have an aspect ratio greater than one are in portrait format.",
           "type": "number",
           "minimum": 0,
           "meta:usereditable": false,

--- a/schemas/assets/resource-event.schema.json
+++ b/schemas/assets/resource-event.schema.json
@@ -16,8 +16,7 @@
       "properties": {
         "stEvt:action": {
           "title": "Action",
-          "description":
-            "The action that occurred. Defined values are: converted, copied, created, cropped, edited, filtered, formatted, version_updated, printed, published, managed, produced, resized, and saved. New values should be verbs in the past tense.",
+          "description": "The action that occurred. Defined values are: converted, copied, created, cropped, edited, filtered, formatted, version_updated, printed, published, managed, produced, resized, and saved. New values should be verbs in the past tense.",
           "meta:enum": [
             "converted",
             "copied",
@@ -37,17 +36,16 @@
         },
         "stEvt:changed": {
           "title": "Changed",
-          "description":
-            "A semicolon-delimited list of the parts of the resource that were changed since the previous event history. If not present, presumed to be undefined. When tracking changes and the scope of the changed components is unknown, it should be assumed that anything might have changed.",
+          "description": "A semicolon-delimited list of the parts of the resource that were changed since the previous event history. If not present, presumed to be undefined. When tracking changes and the scope of the changed components is unknown, it should be assumed that anything might have changed.",
           "type": "string"
         },
         "stEvt:instanceID": {
           "title": "Instance ID",
-          "description":
-            "The value of the `instanceID` property for the modified (output) resource. The value is a GUID, capital A-F, 8-4-4-12",
-          "examples": ["00112233-4455-6677-8899-AABBCCDDEEFF"],
-          "pattern":
-            "^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$",
+          "description": "The value of the `instanceID` property for the modified (output) resource. The value is a GUID, capital A-F, 8-4-4-12",
+          "examples": [
+            "00112233-4455-6677-8899-AABBCCDDEEFF"
+          ],
+          "pattern": "^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$",
           "type": "string"
         },
         "stEvt:parameters": {
@@ -57,14 +55,12 @@
         },
         "stEvt:softwareAgent": {
           "title": "Software Agent",
-          "description":
-            "The software agent (program) that performed the action.\nIt is recommended that the value use this format convention:\nOrganization Software_name Version (token;token;...)\n- Organization: The name of the company or organization providing the software, no SPACEs.\n- Software_name: The full name of the software, SPACEs allowed.\n- version: The version of the software, no SPACEs.\n- tokens: Can be used to identify an operating system, plug-in, or more detailed version information.",
+          "description": "The software agent (program) that performed the action.\nIt is recommended that the value use this format convention:\nOrganization Software_name Version (token;token;...)\n- Organization: The name of the company or organization providing the software, no SPACEs.\n- Software_name: The full name of the software, SPACEs allowed.\n- version: The version of the software, no SPACEs.\n- tokens: Can be used to identify an operating system, plug-in, or more detailed version information.",
           "type": "string"
         },
         "stEvt:when": {
           "title": "When",
-          "description":
-            "Timestamp of when the action occurred. For events that create or write to a file, this should be the approximate modification time of the file.",
+          "description": "Timestamp of when the action occurred. For events that create or write to a file, this should be the approximate modification time of the file.",
           "format": "date-time",
           "type": "string"
         }
@@ -75,5 +71,6 @@
     {
       "$ref": "#/definitions/resource-event"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/assets/resource-event.schema.json
+++ b/schemas/assets/resource-event.schema.json
@@ -16,7 +16,8 @@
       "properties": {
         "stEvt:action": {
           "title": "Action",
-          "description": "The action that occurred. Defined values are: converted, copied, created, cropped, edited, filtered, formatted, version_updated, printed, published, managed, produced, resized, and saved. New values should be verbs in the past tense.",
+          "description":
+            "The action that occurred. Defined values are: converted, copied, created, cropped, edited, filtered, formatted, version_updated, printed, published, managed, produced, resized, and saved. New values should be verbs in the past tense.",
           "meta:enum": [
             "converted",
             "copied",
@@ -36,16 +37,17 @@
         },
         "stEvt:changed": {
           "title": "Changed",
-          "description": "A semicolon-delimited list of the parts of the resource that were changed since the previous event history. If not present, presumed to be undefined. When tracking changes and the scope of the changed components is unknown, it should be assumed that anything might have changed.",
+          "description":
+            "A semicolon-delimited list of the parts of the resource that were changed since the previous event history. If not present, presumed to be undefined. When tracking changes and the scope of the changed components is unknown, it should be assumed that anything might have changed.",
           "type": "string"
         },
         "stEvt:instanceID": {
           "title": "Instance ID",
-          "description": "The value of the `instanceID` property for the modified (output) resource. The value is a GUID, capital A-F, 8-4-4-12",
-          "examples": [
-            "00112233-4455-6677-8899-AABBCCDDEEFF"
-          ],
-          "pattern": "^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$",
+          "description":
+            "The value of the `instanceID` property for the modified (output) resource. The value is a GUID, capital A-F, 8-4-4-12",
+          "examples": ["00112233-4455-6677-8899-AABBCCDDEEFF"],
+          "pattern":
+            "^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$",
           "type": "string"
         },
         "stEvt:parameters": {
@@ -55,12 +57,14 @@
         },
         "stEvt:softwareAgent": {
           "title": "Software Agent",
-          "description": "The software agent (program) that performed the action.\nIt is recommended that the value use this format convention:\nOrganization Software_name Version (token;token;...)\n- Organization: The name of the company or organization providing the software, no SPACEs.\n- Software_name: The full name of the software, SPACEs allowed.\n- version: The version of the software, no SPACEs.\n- tokens: Can be used to identify an operating system, plug-in, or more detailed version information.",
+          "description":
+            "The software agent (program) that performed the action.\nIt is recommended that the value use this format convention:\nOrganization Software_name Version (token;token;...)\n- Organization: The name of the company or organization providing the software, no SPACEs.\n- Software_name: The full name of the software, SPACEs allowed.\n- version: The version of the software, no SPACEs.\n- tokens: Can be used to identify an operating system, plug-in, or more detailed version information.",
           "type": "string"
         },
         "stEvt:when": {
           "title": "When",
-          "description": "Timestamp of when the action occurred. For events that create or write to a file, this should be the approximate modification time of the file.",
+          "description":
+            "Timestamp of when the action occurred. For events that create or write to a file, this should be the approximate modification time of the file.",
           "format": "date-time",
           "type": "string"
         }

--- a/schemas/assets/variable-unit-rectangular.schema.json
+++ b/schemas/assets/variable-unit-rectangular.schema.json
@@ -10,7 +10,8 @@
   "title": "Rectangular Object (measured in variable unit)",
   "type": "object",
   "meta:extensible": true,
-  "description": "This is an abstract schema for objects of rectangular dimensions and position, with a user-specified unit of measurement. Examples include `Artboard` and `Layer`.",
+  "description":
+    "This is an abstract schema for objects of rectangular dimensions and position, with a user-specified unit of measurement. Examples include `Artboard` and `Layer`.",
   "definitions": {
     "rectangular": {
       "properties": {
@@ -18,13 +19,15 @@
           "type": "integer",
           "title": "Origin X",
           "meta:usereditable": false,
-          "description": "Origin X position - Base system is cartesian, relative to master page and origin in top, left (X increasing to right, Y increasing downwards)"
+          "description":
+            "Origin X position - Base system is cartesian, relative to master page and origin in top, left (X increasing to right, Y increasing downwards)"
         },
         "stLayer:originY": {
           "type": "integer",
           "title": "Origin Y",
           "meta:usereditable": false,
-          "description": "Origin Y position - Base system is cartesian, relative to master page and origin in top, left (X increasing to right, Y increasing downwards)"
+          "description":
+            "Origin Y position - Base system is cartesian, relative to master page and origin in top, left (X increasing to right, Y increasing downwards)"
         },
         "stLayer:width": {
           "title": "Width",
@@ -45,7 +48,8 @@
           "meta:usereditable": false,
           "type": "string",
           "default": "pixel",
-          "description": "Unit used for artboard coordinates (`originX`, `originY`, `width` and `height`). For example: `inch`, `mm`, `pixel`, `pica`, `point` (default is `pixel`)"
+          "description":
+            "Unit used for artboard coordinates (`originX`, `originY`, `width` and `height`). For example: `inch`, `mm`, `pixel`, `pica`, `point` (default is `pixel`)"
         }
       }
     }

--- a/schemas/assets/variable-unit-rectangular.schema.json
+++ b/schemas/assets/variable-unit-rectangular.schema.json
@@ -10,8 +10,7 @@
   "title": "Rectangular Object (measured in variable unit)",
   "type": "object",
   "meta:extensible": true,
-  "description":
-    "This is an abstract schema for objects of rectangular dimensions and position, with a user-specified unit of measurement. Examples include `Artboard` and `Layer`.",
+  "description": "This is an abstract schema for objects of rectangular dimensions and position, with a user-specified unit of measurement. Examples include `Artboard` and `Layer`.",
   "definitions": {
     "rectangular": {
       "properties": {
@@ -19,15 +18,13 @@
           "type": "integer",
           "title": "Origin X",
           "meta:usereditable": false,
-          "description":
-            "Origin X position - Base system is cartesian, relative to master page and origin in top, left (X increasing to right, Y increasing downwards)"
+          "description": "Origin X position - Base system is cartesian, relative to master page and origin in top, left (X increasing to right, Y increasing downwards)"
         },
         "stLayer:originY": {
           "type": "integer",
           "title": "Origin Y",
           "meta:usereditable": false,
-          "description":
-            "Origin Y position - Base system is cartesian, relative to master page and origin in top, left (X increasing to right, Y increasing downwards)"
+          "description": "Origin Y position - Base system is cartesian, relative to master page and origin in top, left (X increasing to right, Y increasing downwards)"
         },
         "stLayer:width": {
           "title": "Width",
@@ -48,10 +45,10 @@
           "meta:usereditable": false,
           "type": "string",
           "default": "pixel",
-          "description":
-            "Unit used for artboard coordinates (`originX`, `originY`, `width` and `height`). For example: `inch`, `mm`, `pixel`, `pica`, `point` (default is `pixel`)"
+          "description": "Unit used for artboard coordinates (`originX`, `originY`, `width` and `height`). For example: `inch`, `mm`, `pixel`, `pica`, `point` (default is `pixel`)"
         }
       }
     }
-  }
+  },
+  "meta:status": "experimental"
 }

--- a/schemas/assets/video.schema.json
+++ b/schemas/assets/video.schema.json
@@ -19,7 +19,8 @@
     "https://ns.adobe.com/xdm/assets/asset",
     "https://ns.adobe.com/xdm/assets/rectangular"
   ],
-  "description": "The Video class is for video assets, i.e. assets that consist of moving pictures and, optionally, sound.",
+  "description":
+    "The Video class is for video assets, i.e. assets that consist of moving pictures and, optionally, sound.",
   "definitions": {
     "video": {
       "properties": {
@@ -27,7 +28,8 @@
           "title": "Duration",
           "meta:usereditable": false,
           "type": "integer",
-          "description": "The duration of the video in milliseconds. This property is inspired by `dc:extent`. However, `dc:extent` does not specify units. `core:extent` is always an integer and describes the duration in milliseconds.",
+          "description":
+            "The duration of the video in milliseconds. This property is inspired by `dc:extent`. However, `dc:extent` does not specify units. `core:extent` is always an integer and describes the duration in milliseconds.",
           "example": 8880000
         },
         "xmpDM:videoFrameRate": {
@@ -35,7 +37,8 @@
           "title": "Frame Rate",
           "meta:usereditable": false,
           "pattern": "((f\\d+(s\\d+)?)|PAL|NTSC|24)",
-          "description": "The video frame rate in frames per second (FPS). Predefined values include: \n -`24`\n -`NTSC`\n -`PAL`\n Other values must include `f` and the integer value of the frame rate. Optionally, `s` and the integer value of the rate basis may be included.\n\nThese examples show common video and audio frame rates:\n- Film at 24 fps (frame rate = 24, rate basis = 1): `f24`\n- Speech-to-text in milliseconds (frame rate = 1000, rate basis = 1): `f1000`\n- NTSC at 29.97 fps (frame rate = 30000, rate basis = 1001): `f30000s1001`"
+          "description":
+            "The video frame rate in frames per second (FPS). Predefined values include: \n -`24`\n -`NTSC`\n -`PAL`\n Other values must include `f` and the integer value of the frame rate. Optionally, `s` and the integer value of the rate basis may be included.\n\nThese examples show common video and audio frame rates:\n- Film at 24 fps (frame rate = 24, rate basis = 1): `f24`\n- Speech-to-text in milliseconds (frame rate = 1000, rate basis = 1): `f1000`\n- NTSC at 29.97 fps (frame rate = 30000, rate basis = 1001): `f30000s1001`"
         }
       }
     }
@@ -45,7 +48,8 @@
       "$ref": "https://ns.adobe.com/xdm/assets/asset#/definitions/asset"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/assets/rectangular#/definitions/rectangular"
+      "$ref":
+        "https://ns.adobe.com/xdm/assets/rectangular#/definitions/rectangular"
     },
     {
       "$ref": "#/definitions/video"

--- a/schemas/assets/video.schema.json
+++ b/schemas/assets/video.schema.json
@@ -19,8 +19,7 @@
     "https://ns.adobe.com/xdm/assets/asset",
     "https://ns.adobe.com/xdm/assets/rectangular"
   ],
-  "description":
-    "The Video class is for video assets, i.e. assets that consist of moving pictures and, optionally, sound.",
+  "description": "The Video class is for video assets, i.e. assets that consist of moving pictures and, optionally, sound.",
   "definitions": {
     "video": {
       "properties": {
@@ -28,8 +27,7 @@
           "title": "Duration",
           "meta:usereditable": false,
           "type": "integer",
-          "description":
-            "The duration of the video in milliseconds. This property is inspired by `dc:extent`. However, `dc:extent` does not specify units. `core:extent` is always an integer and describes the duration in milliseconds.",
+          "description": "The duration of the video in milliseconds. This property is inspired by `dc:extent`. However, `dc:extent` does not specify units. `core:extent` is always an integer and describes the duration in milliseconds.",
           "example": 8880000
         },
         "xmpDM:videoFrameRate": {
@@ -37,8 +35,7 @@
           "title": "Frame Rate",
           "meta:usereditable": false,
           "pattern": "((f\\d+(s\\d+)?)|PAL|NTSC|24)",
-          "description":
-            "The video frame rate in frames per second (FPS). Predefined values include: \n -`24`\n -`NTSC`\n -`PAL`\n Other values must include `f` and the integer value of the frame rate. Optionally, `s` and the integer value of the rate basis may be included.\n\nThese examples show common video and audio frame rates:\n- Film at 24 fps (frame rate = 24, rate basis = 1): `f24`\n- Speech-to-text in milliseconds (frame rate = 1000, rate basis = 1): `f1000`\n- NTSC at 29.97 fps (frame rate = 30000, rate basis = 1001): `f30000s1001`"
+          "description": "The video frame rate in frames per second (FPS). Predefined values include: \n -`24`\n -`NTSC`\n -`PAL`\n Other values must include `f` and the integer value of the frame rate. Optionally, `s` and the integer value of the rate basis may be included.\n\nThese examples show common video and audio frame rates:\n- Film at 24 fps (frame rate = 24, rate basis = 1): `f24`\n- Speech-to-text in milliseconds (frame rate = 1000, rate basis = 1): `f1000`\n- NTSC at 29.97 fps (frame rate = 30000, rate basis = 1001): `f30000s1001`"
         }
       }
     }
@@ -48,8 +45,7 @@
       "$ref": "https://ns.adobe.com/xdm/assets/asset#/definitions/asset"
     },
     {
-      "$ref":
-        "https://ns.adobe.com/xdm/assets/rectangular#/definitions/rectangular"
+      "$ref": "https://ns.adobe.com/xdm/assets/rectangular#/definitions/rectangular"
     },
     {
       "$ref": "#/definitions/video"
@@ -65,5 +61,6 @@
     "repo:size",
     "xdm:path",
     "repo:etag"
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/adm.schema.json
+++ b/schemas/channels/adm.schema.json
@@ -22,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/adm",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -71,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -88,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/adm.schema.json
+++ b/schemas/channels/adm.schema.json
@@ -22,30 +22,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/adm",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +71,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +88,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/apns.schema.json
+++ b/schemas/channels/apns.schema.json
@@ -22,30 +22,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/apns",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +71,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +88,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/apns.schema.json
+++ b/schemas/channels/apns.schema.json
@@ -22,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/apns",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -71,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -88,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/application.schema.json
+++ b/schemas/channels/application.schema.json
@@ -9,7 +9,8 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Application",
   "type": "object",
-  "description": "An application that accepts messages or emit events (Facebook page, Mobile App, ...).\n",
+  "description":
+    "An application that accepts messages or emit events (Facebook page, Mobile App, ...).\n",
   "definitions": {
     "application": {
       "properties": {

--- a/schemas/channels/application.schema.json
+++ b/schemas/channels/application.schema.json
@@ -9,8 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Application",
   "type": "object",
-  "description":
-    "An application that accepts messages or emit events (Facebook page, Mobile App, ...).\n",
+  "description": "An application that accepts messages or emit events (Facebook page, Mobile App, ...).\n",
   "definitions": {
     "application": {
       "properties": {
@@ -36,5 +35,6 @@
     {
       "$ref": "#/definitions/application"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/baidu.schema.json
+++ b/schemas/channels/baidu.schema.json
@@ -22,30 +22,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/baidu",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +71,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +88,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/baidu.schema.json
+++ b/schemas/channels/baidu.schema.json
@@ -22,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/baidu",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -71,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -88,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/channel.schema.json
+++ b/schemas/channels/channel.schema.json
@@ -18,33 +18,39 @@
         "@id": {
           "type": "string",
           "format": "uri",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
-          "enum": [
-            "push",
-            "pull",
-            "bidirectional"
-          ],
+          "enum": ["push", "pull", "bidirectional"],
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -52,7 +58,8 @@
           "items": {
             "type": "string",
             "format": "uri",
-            "description": "The `@type` of an XDM-defined content type that is supported by this channel."
+            "description":
+              "The `@type` of an XDM-defined content type that is supported by this channel."
           },
           "description": "The content types that this channel can deliver."
         },
@@ -61,7 +68,8 @@
           "items": {
             "type": "string",
             "format": "uri",
-            "description": "The `@type` of an XDM-defined metric that is supported by this channel."
+            "description":
+              "The `@type` of an XDM-defined metric that is supported by this channel."
           },
           "description": "The metrics that can be collected in this channel."
         },
@@ -70,9 +78,11 @@
           "items": {
             "type": "string",
             "format": "uri",
-            "description": "The `@type` of an XDM-defined location (virtual place) that this channel can contain."
+            "description":
+              "The `@type` of an XDM-defined location (virtual place) that this channel can contain."
           },
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -85,8 +95,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/channel.schema.json
+++ b/schemas/channels/channel.schema.json
@@ -18,39 +18,33 @@
         "@id": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
-          "enum": ["push", "pull", "bidirectional"],
+          "enum": [
+            "push",
+            "pull",
+            "bidirectional"
+          ],
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -58,8 +52,7 @@
           "items": {
             "type": "string",
             "format": "uri",
-            "description":
-              "The `@type` of an XDM-defined content type that is supported by this channel."
+            "description": "The `@type` of an XDM-defined content type that is supported by this channel."
           },
           "description": "The content types that this channel can deliver."
         },
@@ -68,8 +61,7 @@
           "items": {
             "type": "string",
             "format": "uri",
-            "description":
-              "The `@type` of an XDM-defined metric that is supported by this channel."
+            "description": "The `@type` of an XDM-defined metric that is supported by this channel."
           },
           "description": "The metrics that can be collected in this channel."
         },
@@ -78,11 +70,9 @@
           "items": {
             "type": "string",
             "format": "uri",
-            "description":
-              "The `@type` of an XDM-defined location (virtual place) that this channel can contain."
+            "description": "The `@type` of an XDM-defined location (virtual place) that this channel can contain."
           },
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -95,5 +85,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/direct-mail.schema.json
+++ b/schemas/channels/direct-mail.schema.json
@@ -22,30 +22,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/direct-mail",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/offline",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +71,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +88,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/direct-mail.schema.json
+++ b/schemas/channels/direct-mail.schema.json
@@ -22,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/direct-mail",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/offline",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -71,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -88,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/email.schema.json
+++ b/schemas/channels/email.schema.json
@@ -22,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/email",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/email",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -71,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -88,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/email.schema.json
+++ b/schemas/channels/email.schema.json
@@ -22,30 +22,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/email",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/email",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +71,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +88,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/facebook-feed.schema.json
+++ b/schemas/channels/facebook-feed.schema.json
@@ -8,8 +8,7 @@
   "$id": "https://ns.adobe.com/xdm/channels/facebook-feed",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Facebook News Feed",
-  "description":
-    "The Facebook News Feed. This does not include Facebook Messenger, or Facebook App pages.",
+  "description": "The Facebook News Feed. This does not include Facebook Messenger, or Facebook App pages.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
@@ -23,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/facebook-feed",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "pull",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/social",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -72,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -89,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/facebook-feed.schema.json
+++ b/schemas/channels/facebook-feed.schema.json
@@ -8,7 +8,8 @@
   "$id": "https://ns.adobe.com/xdm/channels/facebook-feed",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Facebook News Feed",
-  "description": "The Facebook News Feed. This does not include Facebook Messenger, or Facebook App pages.",
+  "description":
+    "The Facebook News Feed. This does not include Facebook Messenger, or Facebook App pages.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
@@ -22,30 +23,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/facebook-feed",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "pull",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/social",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +72,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +89,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/fax.schema.json
+++ b/schemas/channels/fax.schema.json
@@ -22,30 +22,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/fax",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/offline",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +71,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +88,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/fax.schema.json
+++ b/schemas/channels/fax.schema.json
@@ -22,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/fax",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/offline",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -71,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -88,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/gcm.schema.json
+++ b/schemas/channels/gcm.schema.json
@@ -22,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/gcm",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -71,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -88,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/gcm.schema.json
+++ b/schemas/channels/gcm.schema.json
@@ -22,30 +22,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/gcm",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +71,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +88,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/line.schema.json
+++ b/schemas/channels/line.schema.json
@@ -22,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/line",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/messaging",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -71,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -88,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/line.schema.json
+++ b/schemas/channels/line.schema.json
@@ -22,30 +22,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/line",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/messaging",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +71,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +88,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/mobile-app.schema.json
+++ b/schemas/channels/mobile-app.schema.json
@@ -8,8 +8,7 @@
   "$id": "https://ns.adobe.com/xdm/channels/mobile-app",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Web",
-  "description":
-    "Native mobile applications that are installed through an app store.",
+  "description": "Native mobile applications that are installed through an app store.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
@@ -23,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/mobile-app",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "pull",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -72,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -89,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/mobile-app.schema.json
+++ b/schemas/channels/mobile-app.schema.json
@@ -8,7 +8,8 @@
   "$id": "https://ns.adobe.com/xdm/channels/mobile-app",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Web",
-  "description": "Native mobile applications that are installed through an app store.",
+  "description":
+    "Native mobile applications that are installed through an app store.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
@@ -22,30 +23,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/mobile-app",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "pull",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +72,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +89,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/mpns.schema.json
+++ b/schemas/channels/mpns.schema.json
@@ -22,30 +22,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/mpns",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +71,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +88,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/mpns.schema.json
+++ b/schemas/channels/mpns.schema.json
@@ -22,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/mpns",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -71,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -88,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/phone.schema.json
+++ b/schemas/channels/phone.schema.json
@@ -22,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/phone",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "bidirectional",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/offline",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -71,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -88,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/phone.schema.json
+++ b/schemas/channels/phone.schema.json
@@ -22,30 +22,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/phone",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "bidirectional",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/offline",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +71,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +88,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/sms.schema.json
+++ b/schemas/channels/sms.schema.json
@@ -22,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/sms",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/messaging",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -71,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -88,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/sms.schema.json
+++ b/schemas/channels/sms.schema.json
@@ -22,30 +22,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/sms",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/messaging",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +71,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +88,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/twitter-feed.schema.json
+++ b/schemas/channels/twitter-feed.schema.json
@@ -8,8 +8,7 @@
   "$id": "https://ns.adobe.com/xdm/channels/twitter-feed",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Twitter Feed",
-  "description":
-    "The Twitter Feed, i.e. the stream of user-generated tweets. This does not include Twitter direct messages.",
+  "description": "The Twitter Feed, i.e. the stream of user-generated tweets. This does not include Twitter direct messages.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
@@ -23,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/twitter-feed",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "pull",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/social",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -72,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -89,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/twitter-feed.schema.json
+++ b/schemas/channels/twitter-feed.schema.json
@@ -8,7 +8,8 @@
   "$id": "https://ns.adobe.com/xdm/channels/twitter-feed",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Twitter Feed",
-  "description": "The Twitter Feed, i.e. the stream of user-generated tweets. This does not include Twitter direct messages.",
+  "description":
+    "The Twitter Feed, i.e. the stream of user-generated tweets. This does not include Twitter direct messages.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
@@ -22,30 +23,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/twitter-feed",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "pull",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/social",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +72,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +89,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/web.schema.json
+++ b/schemas/channels/web.schema.json
@@ -8,7 +8,8 @@
   "$id": "https://ns.adobe.com/xdm/channels/web",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Web",
-  "description": "The world wide web and mobile web. Pages delivered via HTTP to a web browser or in-app browser.",
+  "description":
+    "The world wide web and mobile web. Pages delivered via HTTP to a web browser or in-app browser.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
@@ -22,30 +23,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/web",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "pull",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/web",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +72,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +89,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/web.schema.json
+++ b/schemas/channels/web.schema.json
@@ -8,8 +8,7 @@
   "$id": "https://ns.adobe.com/xdm/channels/web",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Web",
-  "description":
-    "The world wide web and mobile web. Pages delivered via HTTP to a web browser or in-app browser.",
+  "description": "The world wide web and mobile web. Pages delivered via HTTP to a web browser or in-app browser.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
@@ -23,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/web",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "pull",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/web",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -72,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -89,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/webpage.schema.json
+++ b/schemas/channels/webpage.schema.json
@@ -74,5 +74,6 @@
     {
       "$ref": "#/definitions/webpage"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/wechat.schema.json
+++ b/schemas/channels/wechat.schema.json
@@ -22,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/wechat",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/messaging",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -71,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -88,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/wechat.schema.json
+++ b/schemas/channels/wechat.schema.json
@@ -22,30 +22,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/wechat",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/messaging",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +71,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +88,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/channels/wns.schema.json
+++ b/schemas/channels/wns.schema.json
@@ -22,40 +22,30 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/wns",
-          "description":
-            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push":
-              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull":
-              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional":
-              "Both `push` and `pull` interaction modes are supported by the channel."
+            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web":
-              "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social":
-              "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile":
-              "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging":
-              "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline":
-              "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -71,8 +61,7 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description":
-            "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -88,5 +77,8 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/channels/wns.schema.json
+++ b/schemas/channels/wns.schema.json
@@ -22,30 +22,40 @@
           "type": "string",
           "format": "uri",
           "const": "https://ns.adobe.com/xdm/channels/wns",
-          "description": "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
+          "description":
+            "The ID uniquely identifies the channel. Each specific experience channel defines a constant `@id`."
         },
         "xdm:mode": {
           "type": "string",
           "const": "push",
           "description": "How experiences are delivered in this channel.",
           "meta:enum": {
-            "push": "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
-            "pull": "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
-            "bidirectional": "Both `push` and `pull` interaction modes are supported by the channel."
+            "push":
+              "The publisher of an experience can initiate an experience by sending a message into the channel. Most `push` channels involve some form of subscription or opt-in.",
+            "pull":
+              "The consumer can initiate an experience by requesting a location in the channel. Most `pull` channels give publishers some control how the experience is then delivered.",
+            "bidirectional":
+              "Both `push` and `pull` interaction modes are supported by the channel."
           }
         },
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "The `@type` property is used to provide a rough classification of channels with similar properties.",
+          "description":
+            "The `@type` property is used to provide a rough classification of channels with similar properties.",
           "const": "https://ns.adobe.com/xdm/channel-types/mobile",
           "meta:enum": {
-            "https://ns.adobe.com/xdm/channel-types/web": "The world wide web, including mobile web",
-            "https://ns.adobe.com/xdm/channel-types/social": "Social media platforms",
-            "https://ns.adobe.com/xdm/channel-types/mobile": "Mobile applications",
-            "https://ns.adobe.com/xdm/channel-types/messaging": "Instant Messaging",
+            "https://ns.adobe.com/xdm/channel-types/web":
+              "The world wide web, including mobile web",
+            "https://ns.adobe.com/xdm/channel-types/social":
+              "Social media platforms",
+            "https://ns.adobe.com/xdm/channel-types/mobile":
+              "Mobile applications",
+            "https://ns.adobe.com/xdm/channel-types/messaging":
+              "Instant Messaging",
             "https://ns.adobe.com/xdm/channel-types/email": "E-Mail",
-            "https://ns.adobe.com/xdm/channel-types/offline": "Non-Digital experience channels"
+            "https://ns.adobe.com/xdm/channel-types/offline":
+              "Non-Digital experience channels"
           }
         },
         "xdm:contentTypes": {
@@ -61,7 +71,8 @@
         "xdm:locationTypes": {
           "type": "array",
           "const": [],
-          "description": "The types of locations (virtual places) that this channel consists of and can deliver content to."
+          "description":
+            "The types of locations (virtual places) that this channel consists of and can deliver content to."
         }
       }
     }
@@ -77,8 +88,6 @@
       "$ref": "#/definitions/channel"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/common/address.schema.json
+++ b/schemas/common/address.schema.json
@@ -14,14 +14,16 @@
     "http://schema.org/GeoCoordinates",
     "https://ns.adobe.com/xdm/common/geo"
   ],
-  "description": "A postal address. Address could relate to a person's home, work, preferred store location etc.",
+  "description":
+    "A postal address. Address could relate to a person's home, work, preferred store location etc.",
   "definitions": {
     "address": {
       "properties": {
         "xdm:primary": {
           "title": "Primary",
           "type": "boolean",
-          "description": "Primary address indicator. A Profile can have only one `primary` address at a given point of time.\n"
+          "description":
+            "Primary address indicator. A Profile can have only one `primary` address at a given point of time.\n"
         },
         "xdm:label": {
           "title": "Label",
@@ -31,7 +33,8 @@
         "xdm:street1": {
           "title": "Street 1",
           "type": "string",
-          "description": "Primary Street level information, apartment number, street number and street name."
+          "description":
+            "Primary Street level information, apartment number, street number and street name."
         },
         "xdm:street2": {
           "title": "Street 2",
@@ -51,12 +54,14 @@
         "xdm:region": {
           "title": "Region",
           "type": "string",
-          "description": "The region, county, or district portion of the address."
+          "description":
+            "The region, county, or district portion of the address."
         },
         "xdm:country": {
           "title": "Country",
           "type": "string",
-          "description": "The name of the government-administered territory. Other than `xdm:countryCode`, this is a free-form field that can have the country name in any language."
+          "description":
+            "The name of the government-administered territory. Other than `xdm:countryCode`, this is a free-form field that can have the country name in any language."
         },
         "xdm:status": {
           "title": "Status",
@@ -80,7 +85,8 @@
           "title": "Last Verified Date",
           "type": "string",
           "format": "date",
-          "description": "The date that the address was last verified as still belonging to the person."
+          "description":
+            "The date that the address was last verified as still belonging to the person."
         }
       }
     }

--- a/schemas/common/address.schema.json
+++ b/schemas/common/address.schema.json
@@ -14,16 +14,14 @@
     "http://schema.org/GeoCoordinates",
     "https://ns.adobe.com/xdm/common/geo"
   ],
-  "description":
-    "A postal address. Address could relate to a person's home, work, preferred store location etc.",
+  "description": "A postal address. Address could relate to a person's home, work, preferred store location etc.",
   "definitions": {
     "address": {
       "properties": {
         "xdm:primary": {
           "title": "Primary",
           "type": "boolean",
-          "description":
-            "Primary address indicator. A Profile can have only one `primary` address at a given point of time.\n"
+          "description": "Primary address indicator. A Profile can have only one `primary` address at a given point of time.\n"
         },
         "xdm:label": {
           "title": "Label",
@@ -33,8 +31,7 @@
         "xdm:street1": {
           "title": "Street 1",
           "type": "string",
-          "description":
-            "Primary Street level information, apartment number, street number and street name."
+          "description": "Primary Street level information, apartment number, street number and street name."
         },
         "xdm:street2": {
           "title": "Street 2",
@@ -54,14 +51,12 @@
         "xdm:region": {
           "title": "Region",
           "type": "string",
-          "description":
-            "The region, county, or district portion of the address."
+          "description": "The region, county, or district portion of the address."
         },
         "xdm:country": {
           "title": "Country",
           "type": "string",
-          "description":
-            "The name of the government-administered territory. Other than `xdm:countryCode`, this is a free-form field that can have the country name in any language."
+          "description": "The name of the government-administered territory. Other than `xdm:countryCode`, this is a free-form field that can have the country name in any language."
         },
         "xdm:status": {
           "title": "Status",
@@ -85,8 +80,7 @@
           "title": "Last Verified Date",
           "type": "string",
           "format": "date",
-          "description":
-            "The date that the address was last verified as still belonging to the person."
+          "description": "The date that the address was last verified as still belonging to the person."
         }
       }
     }
@@ -104,5 +98,6 @@
     {
       "$ref": "#/definitions/address"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/auditable.schema.json
+++ b/schemas/common/auditable.schema.json
@@ -9,11 +9,10 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Audit Trail",
   "type": "object",
-  "meta:extends": [
-    "http://ns.adobe.com/adobecloud/core/1.0"
-  ],
+  "meta:extends": ["http://ns.adobe.com/adobecloud/core/1.0"],
   "meta:abstract": true,
-  "description": "Inheriting this schema using `allOf` indicates that the data record is auditable, i.e. it can be determined when the record has last been modified and by whom.",
+  "description":
+    "Inheriting this schema using `allOf` indicates that the data record is auditable, i.e. it can be determined when the record has last been modified and by whom.",
   "definitions": {
     "auditlog": {
       "properties": {
@@ -25,19 +24,22 @@
         "xdm:repositoryLastModifiedBy": {
           "title": "Modified by User Identifier",
           "type": "string",
-          "description": "User id who last modified the entity.\nAt creation time, `modifiedByUser` is set as `createdByUser`.\n"
+          "description":
+            "User id who last modified the entity.\nAt creation time, `modifiedByUser` is set as `createdByUser`.\n"
         },
         "xdm:createdByBatchID": {
           "title": "Created by Batch Identifier",
           "type": "string",
           "format": "uri",
-          "description": "The Data Set Files in Catalog Services which has been originating the creation of the entity.\n"
+          "description":
+            "The Data Set Files in Catalog Services which has been originating the creation of the entity.\n"
         },
         "xdm:modifiedByBatchID": {
           "title": "Modified by Batch Identifier",
           "type": "string",
           "format": "uri",
-          "description": "The last Data Set Files in Catalog Services which has modified the entity.\nAt creation time, `modifiedByBatchID` is set as `createdByBatchID`.\n"
+          "description":
+            "The last Data Set Files in Catalog Services which has modified the entity.\nAt creation time, `modifiedByBatchID` is set as `createdByBatchID`.\n"
         }
       }
     }
@@ -47,7 +49,8 @@
       "$ref": "#/definitions/auditlog"
     },
     {
-      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
+      "$ref":
+        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
     }
   ],
   "meta:status": "experimental"

--- a/schemas/common/auditable.schema.json
+++ b/schemas/common/auditable.schema.json
@@ -9,10 +9,11 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Audit Trail",
   "type": "object",
-  "meta:extends": ["http://ns.adobe.com/adobecloud/core/1.0"],
+  "meta:extends": [
+    "http://ns.adobe.com/adobecloud/core/1.0"
+  ],
   "meta:abstract": true,
-  "description":
-    "Inheriting this schema using `allOf` indicates that the data record is auditable, i.e. it can be determined when the record has last been modified and by whom.",
+  "description": "Inheriting this schema using `allOf` indicates that the data record is auditable, i.e. it can be determined when the record has last been modified and by whom.",
   "definitions": {
     "auditlog": {
       "properties": {
@@ -24,22 +25,19 @@
         "xdm:repositoryLastModifiedBy": {
           "title": "Modified by User Identifier",
           "type": "string",
-          "description":
-            "User id who last modified the entity.\nAt creation time, `modifiedByUser` is set as `createdByUser`.\n"
+          "description": "User id who last modified the entity.\nAt creation time, `modifiedByUser` is set as `createdByUser`.\n"
         },
         "xdm:createdByBatchID": {
           "title": "Created by Batch Identifier",
           "type": "string",
           "format": "uri",
-          "description":
-            "The Data Set Files in Catalog Services which has been originating the creation of the entity.\n"
+          "description": "The Data Set Files in Catalog Services which has been originating the creation of the entity.\n"
         },
         "xdm:modifiedByBatchID": {
           "title": "Modified by Batch Identifier",
           "type": "string",
           "format": "uri",
-          "description":
-            "The last Data Set Files in Catalog Services which has modified the entity.\nAt creation time, `modifiedByBatchID` is set as `createdByBatchID`.\n"
+          "description": "The last Data Set Files in Catalog Services which has modified the entity.\nAt creation time, `modifiedByBatchID` is set as `createdByBatchID`.\n"
         }
       }
     }
@@ -49,8 +47,8 @@
       "$ref": "#/definitions/auditlog"
     },
     {
-      "$ref":
-        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
+      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/event/created.schema.json
+++ b/schemas/common/event/created.schema.json
@@ -23,5 +23,6 @@
         }
       }
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/event/deleted.schema.json
+++ b/schemas/common/event/deleted.schema.json
@@ -23,5 +23,6 @@
         }
       }
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/event/emitted.schema.json
+++ b/schemas/common/event/emitted.schema.json
@@ -23,5 +23,6 @@
         }
       }
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/event/published.schema.json
+++ b/schemas/common/event/published.schema.json
@@ -23,5 +23,6 @@
         }
       }
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/event/rejected.schema.json
+++ b/schemas/common/event/rejected.schema.json
@@ -23,5 +23,6 @@
         }
       }
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/event/unpublished.schema.json
+++ b/schemas/common/event/unpublished.schema.json
@@ -23,5 +23,6 @@
         }
       }
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/event/updated.schema.json
+++ b/schemas/common/event/updated.schema.json
@@ -23,5 +23,6 @@
         }
       }
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/eventenvelope.schema.json
+++ b/schemas/common/eventenvelope.schema.json
@@ -8,18 +8,14 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "https://ns.adobe.com/xdm/common/eventenvelope",
   "title": "EventEnvelope",
-  "meta:extends":
-    "https://ns.adobe.com/xdm/external/activity-streams-2/activity",
-  "description":
-    "An `EventEnvelope` is a type of `Activity` (in the sense of [W3C Activity Streams 2.0](https://www.w3.org/TR/activitystreams-core/) that applies to digital experiences in general, and to entities of the Experience Data Model in particular. It is being used to track or audit changes to core entities like assets, pages, or campaigns, but also to track observed interactions of consumers of digital experiences. These observed interactions can range from simple technical loading, to passive consumption, to active engagement. Through the `EventEnvelope`, a varied set of observable entities can be tracked in a common way, enabling the establishment of publish-subscribe or event bus systems that dispatch `EventEnvelopes` based on the metadata that is part of the envelope, without having to inspect the payload `object`.",
+  "meta:extends": "https://ns.adobe.com/xdm/external/activity-streams-2/activity",
+  "description": "An `EventEnvelope` is a type of `Activity` (in the sense of [W3C Activity Streams 2.0](https://www.w3.org/TR/activitystreams-core/) that applies to digital experiences in general, and to entities of the Experience Data Model in particular. It is being used to track or audit changes to core entities like assets, pages, or campaigns, but also to track observed interactions of consumers of digital experiences. These observed interactions can range from simple technical loading, to passive consumption, to active engagement. Through the `EventEnvelope`, a varied set of observable entities can be tracked in a common way, enabling the establishment of publish-subscribe or event bus systems that dispatch `EventEnvelopes` based on the metadata that is part of the envelope, without having to inspect the payload `object`.",
   "definitions": {
     "extra-properties": {
       "properties": {
         "xdm:objectType": {
-          "description":
-            "This is the type of the `object` that has been emitting this event. The value of this field MUST be exactly same as the value of the `object.type` field. Making the type available in the event envelope allows routing systems to dispatch events based on the object type without inspecting the object itself.",
-          "$ref":
-            "https://ns.adobe.com/xdm/external/activity-streams-2/type#/definitions/type"
+          "description": "This is the type of the `object` that has been emitting this event. The value of this field MUST be exactly same as the value of the `object.type` field. Making the type available in the event envelope allows routing systems to dispatch events based on the object type without inspecting the object itself.",
+          "$ref": "https://ns.adobe.com/xdm/external/activity-streams-2/type#/definitions/type"
         }
       }
     }
@@ -42,5 +38,6 @@
         "activitystreams:object"
       ]
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/eventenvelope.schema.json
+++ b/schemas/common/eventenvelope.schema.json
@@ -8,14 +8,18 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "https://ns.adobe.com/xdm/common/eventenvelope",
   "title": "EventEnvelope",
-  "meta:extends": "https://ns.adobe.com/xdm/external/activity-streams-2/activity",
-  "description": "An `EventEnvelope` is a type of `Activity` (in the sense of [W3C Activity Streams 2.0](https://www.w3.org/TR/activitystreams-core/) that applies to digital experiences in general, and to entities of the Experience Data Model in particular. It is being used to track or audit changes to core entities like assets, pages, or campaigns, but also to track observed interactions of consumers of digital experiences. These observed interactions can range from simple technical loading, to passive consumption, to active engagement. Through the `EventEnvelope`, a varied set of observable entities can be tracked in a common way, enabling the establishment of publish-subscribe or event bus systems that dispatch `EventEnvelopes` based on the metadata that is part of the envelope, without having to inspect the payload `object`.",
+  "meta:extends":
+    "https://ns.adobe.com/xdm/external/activity-streams-2/activity",
+  "description":
+    "An `EventEnvelope` is a type of `Activity` (in the sense of [W3C Activity Streams 2.0](https://www.w3.org/TR/activitystreams-core/) that applies to digital experiences in general, and to entities of the Experience Data Model in particular. It is being used to track or audit changes to core entities like assets, pages, or campaigns, but also to track observed interactions of consumers of digital experiences. These observed interactions can range from simple technical loading, to passive consumption, to active engagement. Through the `EventEnvelope`, a varied set of observable entities can be tracked in a common way, enabling the establishment of publish-subscribe or event bus systems that dispatch `EventEnvelopes` based on the metadata that is part of the envelope, without having to inspect the payload `object`.",
   "definitions": {
     "extra-properties": {
       "properties": {
         "xdm:objectType": {
-          "description": "This is the type of the `object` that has been emitting this event. The value of this field MUST be exactly same as the value of the `object.type` field. Making the type available in the event envelope allows routing systems to dispatch events based on the object type without inspecting the object itself.",
-          "$ref": "https://ns.adobe.com/xdm/external/activity-streams-2/type#/definitions/type"
+          "description":
+            "This is the type of the `object` that has been emitting this event. The value of this field MUST be exactly same as the value of the `object.type` field. Making the type available in the event envelope allows routing systems to dispatch events based on the object type without inspecting the object itself.",
+          "$ref":
+            "https://ns.adobe.com/xdm/external/activity-streams-2/type#/definitions/type"
         }
       }
     }

--- a/schemas/common/extensible.schema.json
+++ b/schemas/common/extensible.schema.json
@@ -205,7 +205,9 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["xdm"]
+              "required": [
+                "xdm"
+              ]
             }
           },
           "patternProperties": {
@@ -240,7 +242,9 @@
             "^repo:.*$": {},
             ".+://.+": {}
           },
-          "required": ["@context"],
+          "required": [
+            "@context"
+          ],
           "additionalProperties": false
         }
       ]
@@ -250,5 +254,6 @@
     {
       "$ref": "#/definitions/@context"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/extensible.schema.json
+++ b/schemas/common/extensible.schema.json
@@ -205,9 +205,7 @@
                 }
               },
               "additionalProperties": false,
-              "required": [
-                "xdm"
-              ]
+              "required": ["xdm"]
             }
           },
           "patternProperties": {
@@ -242,9 +240,7 @@
             "^repo:.*$": {},
             ".+://.+": {}
           },
-          "required": [
-            "@context"
-          ],
+          "required": ["@context"],
           "additionalProperties": false
         }
       ]

--- a/schemas/common/geo.schema.json
+++ b/schemas/common/geo.schema.json
@@ -9,9 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "http://schema.org/GeoCoordinates"
-  ],
+  "meta:extends": ["http://schema.org/GeoCoordinates"],
   "title": "Geo",
   "description": "The geographic related data where an event was observed.",
   "definitions": {
@@ -21,17 +19,15 @@
           "title": "Country code",
           "type": "string",
           "pattern": "^[A-Z]{2}$",
-          "description": "The two-character [ISO 3166-1 alpha-2](https://datahub.io/core/country-list) code for the country."
+          "description":
+            "The two-character [ISO 3166-1 alpha-2](https://datahub.io/core/country-list) code for the country."
         },
         "xdm:stateProvince": {
           "title": "State or province",
           "type": "string",
-          "description": "The state, or province portion of the observation. The format follows the [ISO 3166-2 (country and subdivision)][http://www.unece.org/cefact/locode/subdivisions.html] standard.",
-          "examples": [
-            "US-CA",
-            "DE-BB",
-            "JP-13"
-          ],
+          "description":
+            "The state, or province portion of the observation. The format follows the [ISO 3166-2 (country and subdivision)][http://www.unece.org/cefact/locode/subdivisions.html] standard.",
+          "examples": ["US-CA", "DE-BB", "JP-13"],
           "pattern": "([A-Z]{2}-[A-Z0-9]{1,3}|)"
         },
         "xdm:city": {
@@ -42,7 +38,8 @@
         "xdm:postalCode": {
           "title": "Postal code",
           "type": "string",
-          "description": "The postal code of the location. Postal codes are not available for all countries. In some countries, this will only contain part of the postal code."
+          "description":
+            "The postal code of the location. Postal codes are not available for all countries. In some countries, this will only contain part of the postal code."
         },
         "xdm:dmaID": {
           "title": "Designated Market Area",
@@ -52,7 +49,8 @@
         "xdm:msaID": {
           "title": "Metropolitan Statistical Area",
           "type": "integer",
-          "description": "The Metropolitan Statistical Area in the USA where the observation occurred."
+          "description":
+            "The Metropolitan Statistical Area in the USA where the observation occurred."
         }
       }
     }

--- a/schemas/common/geo.schema.json
+++ b/schemas/common/geo.schema.json
@@ -9,7 +9,9 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["http://schema.org/GeoCoordinates"],
+  "meta:extends": [
+    "http://schema.org/GeoCoordinates"
+  ],
   "title": "Geo",
   "description": "The geographic related data where an event was observed.",
   "definitions": {
@@ -19,15 +21,17 @@
           "title": "Country code",
           "type": "string",
           "pattern": "^[A-Z]{2}$",
-          "description":
-            "The two-character [ISO 3166-1 alpha-2](https://datahub.io/core/country-list) code for the country."
+          "description": "The two-character [ISO 3166-1 alpha-2](https://datahub.io/core/country-list) code for the country."
         },
         "xdm:stateProvince": {
           "title": "State or province",
           "type": "string",
-          "description":
-            "The state, or province portion of the observation. The format follows the [ISO 3166-2 (country and subdivision)][http://www.unece.org/cefact/locode/subdivisions.html] standard.",
-          "examples": ["US-CA", "DE-BB", "JP-13"],
+          "description": "The state, or province portion of the observation. The format follows the [ISO 3166-2 (country and subdivision)][http://www.unece.org/cefact/locode/subdivisions.html] standard.",
+          "examples": [
+            "US-CA",
+            "DE-BB",
+            "JP-13"
+          ],
           "pattern": "([A-Z]{2}-[A-Z0-9]{1,3}|)"
         },
         "xdm:city": {
@@ -38,8 +42,7 @@
         "xdm:postalCode": {
           "title": "Postal code",
           "type": "string",
-          "description":
-            "The postal code of the location. Postal codes are not available for all countries. In some countries, this will only contain part of the postal code."
+          "description": "The postal code of the location. Postal codes are not available for all countries. In some countries, this will only contain part of the postal code."
         },
         "xdm:dmaID": {
           "title": "Designated Market Area",
@@ -49,8 +52,7 @@
         "xdm:msaID": {
           "title": "Metropolitan Statistical Area",
           "type": "integer",
-          "description":
-            "The Metropolitan Statistical Area in the USA where the observation occurred."
+          "description": "The Metropolitan Statistical Area in the USA where the observation occurred."
         }
       }
     }
@@ -62,5 +64,6 @@
     {
       "$ref": "#/definitions/geo"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/identity-provider.schema.json
+++ b/schemas/common/identity-provider.schema.json
@@ -9,16 +9,14 @@
   "$id": "https://ns.adobe.com/xdm/common/identity-provider",
   "title": "Identity Provider",
   "meta:extensible": true,
-  "description":
-    "An identity provider (abbreviated IdP) is a system entity that creates, maintains, and manages identity information for principals while providing authentication services to relying party applications within a federation or distributed network. An identity provider offers subject authentication as a service.",
+  "description": "An identity provider (abbreviated IdP) is a system entity that creates, maintains, and manages identity information for principals while providing authentication services to relying party applications within a federation or distributed network. An identity provider offers subject authentication as a service.",
   "definitions": {
     "name": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "description":
-            "A unique (uniqueness is defined on the same lines as defined [here](https://tools.ietf.org/html/rfc8141#section-5)) and persistent identifier for the identity provider. Ideally, this identifier should be a [URI](https://tools.ietf.org/html/rfc3986)."
+          "description": "A unique (uniqueness is defined on the same lines as defined [here](https://tools.ietf.org/html/rfc8141#section-5)) and persistent identifier for the identity provider. Ideally, this identifier should be a [URI](https://tools.ietf.org/html/rfc3986)."
         }
       }
     }
@@ -29,5 +27,8 @@
       "$ref": "#/definitions/name"
     }
   ],
-  "required": ["@id"]
+  "required": [
+    "@id"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/identity-provider.schema.json
+++ b/schemas/common/identity-provider.schema.json
@@ -9,14 +9,16 @@
   "$id": "https://ns.adobe.com/xdm/common/identity-provider",
   "title": "Identity Provider",
   "meta:extensible": true,
-  "description": "An identity provider (abbreviated IdP) is a system entity that creates, maintains, and manages identity information for principals while providing authentication services to relying party applications within a federation or distributed network. An identity provider offers subject authentication as a service.",
+  "description":
+    "An identity provider (abbreviated IdP) is a system entity that creates, maintains, and manages identity information for principals while providing authentication services to relying party applications within a federation or distributed network. An identity provider offers subject authentication as a service.",
   "definitions": {
     "name": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "description": "A unique (uniqueness is defined on the same lines as defined [here](https://tools.ietf.org/html/rfc8141#section-5)) and persistent identifier for the identity provider. Ideally, this identifier should be a [URI](https://tools.ietf.org/html/rfc3986)."
+          "description":
+            "A unique (uniqueness is defined on the same lines as defined [here](https://tools.ietf.org/html/rfc8141#section-5)) and persistent identifier for the identity provider. Ideally, this identifier should be a [URI](https://tools.ietf.org/html/rfc3986)."
         }
       }
     }
@@ -27,8 +29,6 @@
       "$ref": "#/definitions/name"
     }
   ],
-  "required": [
-    "@id"
-  ],
+  "required": ["@id"],
   "meta:status": "experimental"
 }

--- a/schemas/common/organization.schema.json
+++ b/schemas/common/organization.schema.json
@@ -37,8 +37,7 @@
         "xdm:industry": {
           "title": "Industry",
           "type": "string",
-          "description":
-            "The the industry that this organization is a part of. This is a free-form field, and it is advisable to use a structured value for queries or to use the `xdm:classifier` property."
+          "description": "The the industry that this organization is a part of. This is a free-form field, and it is advisable to use a structured value for queries or to use the `xdm:classifier` property."
         },
         "xdm:website": {
           "title": "Web Site",
@@ -49,8 +48,7 @@
         "xdm:marketSegment": {
           "title": "Market Segment",
           "type": "string",
-          "description":
-            "The named market segment that the organization participates in. This is a free-form field, and it is advisable to use a structured value for queries or to use the `xdm:identifier` property."
+          "description": "The named market segment that the organization participates in. This is a free-form field, and it is advisable to use a structured value for queries or to use the `xdm:identifier` property."
         },
         "xdm:location": {
           "title": "Location",
@@ -62,8 +60,7 @@
           "type": "number",
           "minimum": 0,
           "maximum": 1,
-          "description":
-            "The calculated score or star rating for this organization. `1` indicates the maximum possible rating, `0` the minumum possible rating."
+          "description": "The calculated score or star rating for this organization. `1` indicates the maximum possible rating, `0` the minumum possible rating."
         },
         "xdm:identifier": {
           "title": "Organization Identifier",
@@ -81,29 +78,23 @@
           "examples": [
             {
               "https://ns.adobe.com/external/dnb": "1234",
-              "https://ns.adobe.com/external/angellist":
-                "https://angel.co/adobe"
+              "https://ns.adobe.com/external/angellist": "https://angel.co/adobe"
             }
           ],
-          "description":
-            "This object contains unambiguous identifiers for the organization. Each key is the URI of an identification service, each value is the unique ID (or preferrably URI) of the organization as defined by the identification service."
+          "description": "This object contains unambiguous identifiers for the organization. Each key is the URI of an identification service, each value is the unique ID (or preferrably URI) of the organization as defined by the identification service."
         },
         "xdm:classifier": {
           "title": "Market/Industry Classifier",
           "type": "object",
           "meta:keys": {
-            "https://ns.adobe.com/external/isic4":
-              "International Standard of Industrial Classification of All Economic Activities (ISIC)",
-            "https://ns.adobe.com/external/sic":
-              "Standard Industrial Classification",
-            "https://ns.adobe.com/external/naics":
-              "North American Industry Classification System"
+            "https://ns.adobe.com/external/isic4": "International Standard of Industrial Classification of All Economic Activities (ISIC)",
+            "https://ns.adobe.com/external/sic": "Standard Industrial Classification",
+            "https://ns.adobe.com/external/naics": "North American Industry Classification System"
           },
           "patternProperties": {
             ".+://.+": {
               "type": "string",
-              "description":
-                "ID of the market or industry according to the service."
+              "description": "ID of the market or industry according to the service."
             }
           },
           "examples": [
@@ -112,8 +103,7 @@
               "https://ns.adobe.com/external/naics": "1234"
             }
           ],
-          "description":
-            "This object contains unambiguous classifiers for the organization. Each key is the URI of an classification service or standard, each value is the unique ID (or preferrably URI) of the organization as defined by the classification service."
+          "description": "This object contains unambiguous classifiers for the organization. Each key is the URI of an classification service or standard, each value is the unique ID (or preferrably URI) of the organization as defined by the classification service."
         }
       }
     }
@@ -122,5 +112,6 @@
     {
       "$ref": "#/definitions/organization"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/organization.schema.json
+++ b/schemas/common/organization.schema.json
@@ -37,7 +37,8 @@
         "xdm:industry": {
           "title": "Industry",
           "type": "string",
-          "description": "The the industry that this organization is a part of. This is a free-form field, and it is advisable to use a structured value for queries or to use the `xdm:classifier` property."
+          "description":
+            "The the industry that this organization is a part of. This is a free-form field, and it is advisable to use a structured value for queries or to use the `xdm:classifier` property."
         },
         "xdm:website": {
           "title": "Web Site",
@@ -48,7 +49,8 @@
         "xdm:marketSegment": {
           "title": "Market Segment",
           "type": "string",
-          "description": "The named market segment that the organization participates in. This is a free-form field, and it is advisable to use a structured value for queries or to use the `xdm:identifier` property."
+          "description":
+            "The named market segment that the organization participates in. This is a free-form field, and it is advisable to use a structured value for queries or to use the `xdm:identifier` property."
         },
         "xdm:location": {
           "title": "Location",
@@ -60,7 +62,8 @@
           "type": "number",
           "minimum": 0,
           "maximum": 1,
-          "description": "The calculated score or star rating for this organization. `1` indicates the maximum possible rating, `0` the minumum possible rating."
+          "description":
+            "The calculated score or star rating for this organization. `1` indicates the maximum possible rating, `0` the minumum possible rating."
         },
         "xdm:identifier": {
           "title": "Organization Identifier",
@@ -78,23 +81,29 @@
           "examples": [
             {
               "https://ns.adobe.com/external/dnb": "1234",
-              "https://ns.adobe.com/external/angellist": "https://angel.co/adobe"
+              "https://ns.adobe.com/external/angellist":
+                "https://angel.co/adobe"
             }
           ],
-          "description": "This object contains unambiguous identifiers for the organization. Each key is the URI of an identification service, each value is the unique ID (or preferrably URI) of the organization as defined by the identification service."
+          "description":
+            "This object contains unambiguous identifiers for the organization. Each key is the URI of an identification service, each value is the unique ID (or preferrably URI) of the organization as defined by the identification service."
         },
         "xdm:classifier": {
           "title": "Market/Industry Classifier",
           "type": "object",
           "meta:keys": {
-            "https://ns.adobe.com/external/isic4": "International Standard of Industrial Classification of All Economic Activities (ISIC)",
-            "https://ns.adobe.com/external/sic": "Standard Industrial Classification",
-            "https://ns.adobe.com/external/naics": "North American Industry Classification System"
+            "https://ns.adobe.com/external/isic4":
+              "International Standard of Industrial Classification of All Economic Activities (ISIC)",
+            "https://ns.adobe.com/external/sic":
+              "Standard Industrial Classification",
+            "https://ns.adobe.com/external/naics":
+              "North American Industry Classification System"
           },
           "patternProperties": {
             ".+://.+": {
               "type": "string",
-              "description": "ID of the market or industry according to the service."
+              "description":
+                "ID of the market or industry according to the service."
             }
           },
           "examples": [
@@ -103,7 +112,8 @@
               "https://ns.adobe.com/external/naics": "1234"
             }
           ],
-          "description": "This object contains unambiguous classifiers for the organization. Each key is the URI of an classification service or standard, each value is the unique ID (or preferrably URI) of the organization as defined by the classification service."
+          "description":
+            "This object contains unambiguous classifiers for the organization. Each key is the URI of an classification service or standard, each value is the unique ID (or preferrably URI) of the organization as defined by the classification service."
         }
       }
     }

--- a/schemas/common/page.schema.json
+++ b/schemas/common/page.schema.json
@@ -9,19 +9,22 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Page",
   "type": "object",
-  "description": "Page object contains paging information for related resource when resource result is paginated.",
+  "description":
+    "Page object contains paging information for related resource when resource result is paginated.",
   "definitions": {
     "page": {
       "properties": {
         "orderBy": {
           "title": "Order by property",
           "type": "string",
-          "description": "The `orderBy` parameter specifies the comma-separated (no spaces after comma) list of properties by which the resource should be sorted. The properties by which to sort are listed in priority order. The first property is used for primary sorting, the second property to resolve ties in primary sorting, etc. The name of a property may be prefixed with a `+` to indicate ascending ordering or `-` to indicate descending ordering by that property. If the property name is not prefixed the result is sorted in asceding order. If `orderBy` is not given or does not name a property supported to sort by, the order is indeterminate and the service may return the elements in any order."
+          "description":
+            "The `orderBy` parameter specifies the comma-separated (no spaces after comma) list of properties by which the resource should be sorted. The properties by which to sort are listed in priority order. The first property is used for primary sorting, the second property to resolve ties in primary sorting, etc. The name of a property may be prefixed with a `+` to indicate ascending ordering or `-` to indicate descending ordering by that property. If the property name is not prefixed the result is sorted in asceding order. If `orderBy` is not given or does not name a property supported to sort by, the order is indeterminate and the service may return the elements in any order."
         },
         "start": {
           "title": "First value",
           "type": "string",
-          "description": "The first value, in sorted order, of the orderby property on this page."
+          "description":
+            "The first value, in sorted order, of the orderby property on this page."
         },
         "next": {
           "title": "Next page start value",
@@ -31,12 +34,14 @@
         "property": {
           "title": "Filter properties",
           "type": "string",
-          "description": "The list of properties by which the result is filtered, if any.\nThis list is comma-separated (no spaces after comma). The resulting list will only include entries for which the filtered property has been defined. "
+          "description":
+            "The list of properties by which the result is filtered, if any.\nThis list is comma-separated (no spaces after comma). The resulting list will only include entries for which the filtered property has been defined. "
         },
         "type": {
           "title": "Filter type value",
           "type": "string",
-          "description": "The applied type filtering value, if any. Unlike `property` which allows to filter for presence of any property, `type` filters only for the specific value of the `type` attribute, i.e. the media type. This is a literal filter without any globbing or pattern matching."
+          "description":
+            "The applied type filtering value, if any. Unlike `property` which allows to filter for presence of any property, `type` filters only for the specific value of the `type` attribute, i.e. the media type. This is a literal filter without any globbing or pattern matching."
         },
         "count": {
           "title": "Number of items",
@@ -52,11 +57,6 @@
       "$ref": "#/definitions/page"
     }
   ],
-  "required": [
-    "orderBy",
-    "start",
-    "next",
-    "count"
-  ],
+  "required": ["orderBy", "start", "next", "count"],
   "meta:status": "experimental"
 }

--- a/schemas/common/page.schema.json
+++ b/schemas/common/page.schema.json
@@ -9,22 +9,19 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Page",
   "type": "object",
-  "description":
-    "Page object contains paging information for related resource when resource result is paginated.",
+  "description": "Page object contains paging information for related resource when resource result is paginated.",
   "definitions": {
     "page": {
       "properties": {
         "orderBy": {
           "title": "Order by property",
           "type": "string",
-          "description":
-            "The `orderBy` parameter specifies the comma-separated (no spaces after comma) list of properties by which the resource should be sorted. The properties by which to sort are listed in priority order. The first property is used for primary sorting, the second property to resolve ties in primary sorting, etc. The name of a property may be prefixed with a `+` to indicate ascending ordering or `-` to indicate descending ordering by that property. If the property name is not prefixed the result is sorted in asceding order. If `orderBy` is not given or does not name a property supported to sort by, the order is indeterminate and the service may return the elements in any order."
+          "description": "The `orderBy` parameter specifies the comma-separated (no spaces after comma) list of properties by which the resource should be sorted. The properties by which to sort are listed in priority order. The first property is used for primary sorting, the second property to resolve ties in primary sorting, etc. The name of a property may be prefixed with a `+` to indicate ascending ordering or `-` to indicate descending ordering by that property. If the property name is not prefixed the result is sorted in asceding order. If `orderBy` is not given or does not name a property supported to sort by, the order is indeterminate and the service may return the elements in any order."
         },
         "start": {
           "title": "First value",
           "type": "string",
-          "description":
-            "The first value, in sorted order, of the orderby property on this page."
+          "description": "The first value, in sorted order, of the orderby property on this page."
         },
         "next": {
           "title": "Next page start value",
@@ -34,14 +31,12 @@
         "property": {
           "title": "Filter properties",
           "type": "string",
-          "description":
-            "The list of properties by which the result is filtered, if any.\nThis list is comma-separated (no spaces after comma). The resulting list will only include entries for which the filtered property has been defined. "
+          "description": "The list of properties by which the result is filtered, if any.\nThis list is comma-separated (no spaces after comma). The resulting list will only include entries for which the filtered property has been defined. "
         },
         "type": {
           "title": "Filter type value",
           "type": "string",
-          "description":
-            "The applied type filtering value, if any. Unlike `property` which allows to filter for presence of any property, `type` filters only for the specific value of the `type` attribute, i.e. the media type. This is a literal filter without any globbing or pattern matching."
+          "description": "The applied type filtering value, if any. Unlike `property` which allows to filter for presence of any property, `type` filters only for the specific value of the `type` attribute, i.e. the media type. This is a literal filter without any globbing or pattern matching."
         },
         "count": {
           "title": "Number of items",
@@ -57,5 +52,11 @@
       "$ref": "#/definitions/page"
     }
   ],
-  "required": ["orderBy", "start", "next", "count"]
+  "required": [
+    "orderBy",
+    "start",
+    "next",
+    "count"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/principal.schema.json
+++ b/schemas/common/principal.schema.json
@@ -8,7 +8,8 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "https://ns.adobe.com/xdm/common/principal",
   "title": "Principal",
-  "description": "This model represents a principal in an access control system. Principals are entities that have been authenticated against an identity provider.",
+  "description":
+    "This model represents a principal in an access control system. Principals are entities that have been authenticated against an identity provider.",
   "type": "object",
   "meta:extensible": false,
   "properties": {
@@ -18,18 +19,16 @@
     },
     "@id": {
       "type": "string",
-      "description": "A unique (uniqueness is defined on the same lines as defined [here](https://tools.ietf.org/html/rfc8141#section-5)) and persistent identifier for the principal. Ideally, this identifier should be a [URI](https://tools.ietf.org/html/rfc3986)."
+      "description":
+        "A unique (uniqueness is defined on the same lines as defined [here](https://tools.ietf.org/html/rfc8141#section-5)) and persistent identifier for the principal. Ideally, this identifier should be a [URI](https://tools.ietf.org/html/rfc3986)."
     },
     "@type": {
       "type": "string",
       "format": "uri",
-      "description": "The type of the principal. Acts as a processing hint to the client. Ideally, each value should be identified as a [URI](https://tools.ietf.org/html/rfc3986)."
+      "description":
+        "The type of the principal. Acts as a processing hint to the client. Ideally, each value should be identified as a [URI](https://tools.ietf.org/html/rfc3986)."
     }
   },
-  "required": [
-    "xdm:provider",
-    "@id",
-    "@type"
-  ],
+  "required": ["xdm:provider", "@id", "@type"],
   "meta:status": "experimental"
 }

--- a/schemas/common/principal.schema.json
+++ b/schemas/common/principal.schema.json
@@ -8,8 +8,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "https://ns.adobe.com/xdm/common/principal",
   "title": "Principal",
-  "description":
-    "This model represents a principal in an access control system. Principals are entities that have been authenticated against an identity provider.",
+  "description": "This model represents a principal in an access control system. Principals are entities that have been authenticated against an identity provider.",
   "type": "object",
   "meta:extensible": false,
   "properties": {
@@ -19,15 +18,18 @@
     },
     "@id": {
       "type": "string",
-      "description":
-        "A unique (uniqueness is defined on the same lines as defined [here](https://tools.ietf.org/html/rfc8141#section-5)) and persistent identifier for the principal. Ideally, this identifier should be a [URI](https://tools.ietf.org/html/rfc3986)."
+      "description": "A unique (uniqueness is defined on the same lines as defined [here](https://tools.ietf.org/html/rfc8141#section-5)) and persistent identifier for the principal. Ideally, this identifier should be a [URI](https://tools.ietf.org/html/rfc3986)."
     },
     "@type": {
       "type": "string",
       "format": "uri",
-      "description":
-        "The type of the principal. Acts as a processing hint to the client. Ideally, each value should be identified as a [URI](https://tools.ietf.org/html/rfc3986)."
+      "description": "The type of the principal. Acts as a processing hint to the client. Ideally, each value should be identified as a [URI](https://tools.ietf.org/html/rfc3986)."
     }
   },
-  "required": ["xdm:provider", "@id", "@type"]
+  "required": [
+    "xdm:provider",
+    "@id",
+    "@type"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/common/selfservice.schema.json
+++ b/schemas/common/selfservice.schema.json
@@ -8,128 +8,152 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "https://ns.adobe.com/xdm/selfservice",
   "title": "Customer Managed Environment",
-  "description": "A Customer Managed Environment is an environment that allows a system integration or deployer to manage applications. This is also known as selfservice.",
+  "description":
+    "A Customer Managed Environment is an environment that allows a system integration or deployer to manage applications. This is also known as selfservice.",
   "type": "object",
   "definitions": {
     "selfservice": {
       "properties": {
         "xdm:tenant": {
           "name": "Tenant",
-          "description": "A description of a customer having a agreement to use a specific set of services (see `xdm:service`). A tenant will typically have a URI which can be used to reference the tenant, and should be resovable by an identity provider.",
+          "description":
+            "A description of a customer having a agreement to use a specific set of services (see `xdm:service`). A tenant will typically have a URI which can be used to reference the tenant, and should be resovable by an identity provider.",
           "type": "string",
           "format": "uri"
         },
         "xdm:applicationOwner": {
           "name": "Application Owner",
-          "description": "An application owner, distinct from a tenant  (`xdm:tenant`), owns an application (see `xdm:application`) and manages its state. The application owner may be a individual user or roll. Typically the application owner will be a member of the tenant, however that is not a requirement.",
+          "description":
+            "An application owner, distinct from a tenant  (`xdm:tenant`), owns an application (see `xdm:application`) and manages its state. The application owner may be a individual user or roll. Typically the application owner will be a member of the tenant, however that is not a requirement.",
           "type": "string",
           "format": "uri"
         },
         "xdm:application": {
           "name": "Application",
-          "description": "A set of code, content, and data that together implement an experience. Some applications do not allow a system integrator, partner or customer to perform customisation. Other applications may allow customisation on a per instance basis. These may be applications managed by the system integrator, partner or customer. An application be defined by a uri referencing the definition of the application.",
+          "description":
+            "A set of code, content, and data that together implement an experience. Some applications do not allow a system integrator, partner or customer to perform customisation. Other applications may allow customisation on a per instance basis. These may be applications managed by the system integrator, partner or customer. An application be defined by a uri referencing the definition of the application.",
           "type": "string",
           "format": "uri"
         },
         "xdm:environment": {
           "name": "Environment",
-          "description": "A tenant (see `xdm:tenant`) may work with 1..n environments where the application (see `xdm:application`) runs. Each environment serves a purpose in the CI/CD chain providing a structure whereby changes  to the application can be rolled out. Typically the owner of the application manages transitions between environments. A system integratior, partner or customer may be the owner of the application expecially where the application has  been extended and customised. An environment may have a uri referencing the definition of the environment. ",
+          "description":
+            "A tenant (see `xdm:tenant`) may work with 1..n environments where the application (see `xdm:application`) runs. Each environment serves a purpose in the CI/CD chain providing a structure whereby changes  to the application can be rolled out. Typically the owner of the application manages transitions between environments. A system integratior, partner or customer may be the owner of the application expecially where the application has  been extended and customised. An environment may have a uri referencing the definition of the environment. ",
           "type": "string",
           "meta:enum": {
-            "dev": "A development environment for engineering teams to develop and test against prior to releasing to the QE teams.",
-            "qe": "A deployment provisioned to statisfy the Quality Engineering process",
-            "stage": "A final deployment environment before production. Typically used to perform final testing and give a reference  deployment to the last production deployment",
-            "beta": "A production deployment environment used to introduce end users of the `application` to new features.",
+            "dev":
+              "A development environment for engineering teams to develop and test against prior to releasing to the QE teams.",
+            "qe":
+              "A deployment provisioned to statisfy the Quality Engineering process",
+            "stage":
+              "A final deployment environment before production. Typically used to perform final testing and give a reference  deployment to the last production deployment",
+            "beta":
+              "A production deployment environment used to introduce end users of the `application` to new features.",
             "prod": "The production deployment environment"
           }
         },
         "xdm:cluster": {
           "name": "Cluster",
-          "description": "A group of instances deployed within a environment (see `xdm:environment` ) as part of a topology (see `xdm:topology`) that deliver a service  within an application (see `xdm:application`) often using a single source of persistence. A topology may have one or more clusters (see `xdm:cluster`). A service (see `xdm:service`) is typically delivered by a single cluster. Members of the cluster are typically stateless and disposable, meaning they are created and destroyed to maintain a suitable cluster size to deliver the service against the agreed SLA. A cluster will have a uri refencing the definition of the cluster, including parameters defining its scaling behaviour.",
+          "description":
+            "A group of instances deployed within a environment (see `xdm:environment` ) as part of a topology (see `xdm:topology`) that deliver a service  within an application (see `xdm:application`) often using a single source of persistence. A topology may have one or more clusters (see `xdm:cluster`). A service (see `xdm:service`) is typically delivered by a single cluster. Members of the cluster are typically stateless and disposable, meaning they are created and destroyed to maintain a suitable cluster size to deliver the service against the agreed SLA. A cluster will have a uri refencing the definition of the cluster, including parameters defining its scaling behaviour.",
           "type": "string",
           "format": "uri"
         },
         "xdm:CICDPipeline": {
           "name": "CI/CD Pipeline",
-          "description": "A Continuous Deployment Continuous Integration pipeline (xdm:CICDPipeline) is used to deploy an application (see `xdm:application`) conforming to a defined topology (see `xdm:topology`) into an environment (see `xdm:environment`). The pipleline runs a standard process that understands the definingion of the topology, environment and application. The pipeline is a shared resource used by many applications and tenants (see `xdm:tenant`), although special tenants may have customised pipelines. A pipleline will have a URI which defines the API.",
+          "description":
+            "A Continuous Deployment Continuous Integration pipeline (xdm:CICDPipeline) is used to deploy an application (see `xdm:application`) conforming to a defined topology (see `xdm:topology`) into an environment (see `xdm:environment`). The pipleline runs a standard process that understands the definingion of the topology, environment and application. The pipeline is a shared resource used by many applications and tenants (see `xdm:tenant`), although special tenants may have customised pipelines. A pipleline will have a URI which defines the API.",
           "type": "string",
           "format": "uri"
         },
         "xdm:service": {
           "name": "Service",
-          "description": "An application (see `xdm:application`) consists of one or more services, deployed into a topology (see `xdm:topology`) and implemented as a cluster (see `xdm:cluster`). The service will generally expose an API to consumers however that service may be private to the application. The implimentation of a service my be changed without changing the specification of the service. A service will have a URI defining it.",
+          "description":
+            "An application (see `xdm:application`) consists of one or more services, deployed into a topology (see `xdm:topology`) and implemented as a cluster (see `xdm:cluster`). The service will generally expose an API to consumers however that service may be private to the application. The implimentation of a service my be changed without changing the specification of the service. A service will have a URI defining it.",
           "type": "string",
           "format": "uri"
         },
         "xdm:topology": {
           "name": "Topology",
-          "description": "A topology is a logical group of services (see `xdm:service`) and their implementations that together form an application (see `xdm:application`). The topology may consist of services and service implementations at different layers throughout an application. Some services within a topology may be satisfied by shared components, for instance many applications may share an edge traffic load balancer. A service will have a URI defining it.",
+          "description":
+            "A topology is a logical group of services (see `xdm:service`) and their implementations that together form an application (see `xdm:application`). The topology may consist of services and service implementations at different layers throughout an application. Some services within a topology may be satisfied by shared components, for instance many applications may share an edge traffic load balancer. A service will have a URI defining it.",
           "type": "string",
           "format": "uri"
         },
         "xdm:codeRepository": {
           "name": "Code Repository",
-          "description": "A Code Repostitory stores the application (see `xdm:application`) code and any definitions for topologies (see `xdm:topology`), services (see `xdm:service`), clusters (see `xdm:cluster`) and environments (see `(see `xdm:environment`). The CI/CD Pipeline (see `xdm:CICDPipeline`) will read the Code repository to perform integration and deploy the application.",
+          "description":
+            "A Code Repostitory stores the application (see `xdm:application`) code and any definitions for topologies (see `xdm:topology`), services (see `xdm:service`), clusters (see `xdm:cluster`) and environments (see `(see `xdm:environment`). The CI/CD Pipeline (see `xdm:CICDPipeline`) will read the Code repository to perform integration and deploy the application.",
           "type": "string",
           "format": "uri"
         },
         "xdm:provisioning": {
           "name": "Provisioning",
-          "description": "Provisioning is the operation which sets up everything required to allow a tenant (see `xdm:tenant`) to deploy an application (see `xdm:application`). This includes setting up the Code Repository (see `xdm:codeRepository`), and allocating any resources that the CI/CD pipeline (see `xdm:CICDPipeline`) might require to deploy the application. Provisioning will ensure that any costs or charges are appropriately registerd as being related to the tenant so that billing systems can ensure the tenant is billed. Where the infrastrucutre is dedicated to the tenant, provisioning will ensure that sufficient infratructure is available when the first deployment (see `xdm:deployment`) is being performed. If the infratructure is to be provisioned from a pool, provisioning will ensure that the pool is notified of the level of future demand. Provisioning will understand any legal or juristrictional requirements and constraints that the tenant may have expressed in the contract and ensure that those requiremetns and constraints are satisfied.",
+          "description":
+            "Provisioning is the operation which sets up everything required to allow a tenant (see `xdm:tenant`) to deploy an application (see `xdm:application`). This includes setting up the Code Repository (see `xdm:codeRepository`), and allocating any resources that the CI/CD pipeline (see `xdm:CICDPipeline`) might require to deploy the application. Provisioning will ensure that any costs or charges are appropriately registerd as being related to the tenant so that billing systems can ensure the tenant is billed. Where the infrastrucutre is dedicated to the tenant, provisioning will ensure that sufficient infratructure is available when the first deployment (see `xdm:deployment`) is being performed. If the infratructure is to be provisioned from a pool, provisioning will ensure that the pool is notified of the level of future demand. Provisioning will understand any legal or juristrictional requirements and constraints that the tenant may have expressed in the contract and ensure that those requiremetns and constraints are satisfied.",
           "type": "string",
           "format": "uri"
         },
         "xdm:deployment": {
           "name": "Deployment",
-          "description": "Deployment is the final act of deploying an application (see `xdm:application`) into an environment (see `xdm:environment`) prior to going live in that enviroment. This should be achieved via an automated process working from specifcation and configuration stored in the codeRepository (see `xdm:codeRepository`). Some applications may require the installation of packages directly into a service (see `xdm:service`) or API provided by the application. Where this is the case the deployment process must be capable of supporting that style of deployment and must not make the application or any of its parts available to serve requests while the deployment is incomplete. The deployment process should include stepts to validate that the depoloyment was sucessfull. Deployment is not the same as provisioning (see `xdm:provisioning`), which is a pre-requisite for deployment. Typically a deployment will be perfomed every time changes in the code repository needs to be made available in the environment` Typically the deployment process is implemented by the CICDPipeline (see `xdm:CICDPipeline`)",
+          "description":
+            "Deployment is the final act of deploying an application (see `xdm:application`) into an environment (see `xdm:environment`) prior to going live in that enviroment. This should be achieved via an automated process working from specifcation and configuration stored in the codeRepository (see `xdm:codeRepository`). Some applications may require the installation of packages directly into a service (see `xdm:service`) or API provided by the application. Where this is the case the deployment process must be capable of supporting that style of deployment and must not make the application or any of its parts available to serve requests while the deployment is incomplete. The deployment process should include stepts to validate that the depoloyment was sucessfull. Deployment is not the same as provisioning (see `xdm:provisioning`), which is a pre-requisite for deployment. Typically a deployment will be perfomed every time changes in the code repository needs to be made available in the environment` Typically the deployment process is implemented by the CICDPipeline (see `xdm:CICDPipeline`)",
           "type": "string",
           "format": "uri"
         },
         "xdm:artifact": {
           "name": "Artifact",
-          "description": "An artifact is a package forming the implementation of a service (see `xdm:service`). It is is stored in the artifactRepository (see `xdm:artifactRepository`) publised to the artifactRepository by the CICDPipeline (see `xdm:CICDPipeline`). An artifact has a version. Once an artifact with a version is published it becomes immutable. A version may be a unique string such as a SHA identifying a commit in a Git repository, or a semantic version number. Which is chosen depends on the prefered versioning mechanism.",
+          "description":
+            "An artifact is a package forming the implementation of a service (see `xdm:service`). It is is stored in the artifactRepository (see `xdm:artifactRepository`) publised to the artifactRepository by the CICDPipeline (see `xdm:CICDPipeline`). An artifact has a version. Once an artifact with a version is published it becomes immutable. A version may be a unique string such as a SHA identifying a commit in a Git repository, or a semantic version number. Which is chosen depends on the prefered versioning mechanism.",
           "type": "string",
           "format": "uri"
         },
         "xdm:artifactRepository": {
           "name": "Artifact Repository",
-          "description": "An artifact repository stores released binaries including artifacts (see `xdm:artifact`) either from vendors or created by the CICDPipeline (see `xdm:CICDPipeline`). These artifacts are used by the deployment pipleine to deploy an application (see `xdm:application`) into an environment (see `xdm:environment`). The artifactRepository will allow many versions of an artifact to exist and will be organised in a way that will allow artifacts specific to a tenant (see `xdm:tenant`), application, topology (see `xdm:topology`) and environment to be stored. The artifact repsitory must not be used to store any sensitive data.",
+          "description":
+            "An artifact repository stores released binaries including artifacts (see `xdm:artifact`) either from vendors or created by the CICDPipeline (see `xdm:CICDPipeline`). These artifacts are used by the deployment pipleine to deploy an application (see `xdm:application`) into an environment (see `xdm:environment`). The artifactRepository will allow many versions of an artifact to exist and will be organised in a way that will allow artifacts specific to a tenant (see `xdm:tenant`), application, topology (see `xdm:topology`) and environment to be stored. The artifact repsitory must not be used to store any sensitive data.",
           "type": "string",
           "format": "uri"
         },
         "xdm:selfServiceAPI": {
           "name": "Self Service API",
-          "description": "The Self Serivce API is a well defined API that will, using the model defined in XDM expose to a suitably authorised client a service implemenation that allows that client to one or more applications (see `xdm:application`) within a tenant (see `xdm:tenant`). The API must maintain tenant boundaries, as defined and controlled by an identity provider.",
+          "description":
+            "The Self Serivce API is a well defined API that will, using the model defined in XDM expose to a suitably authorised client a service implemenation that allows that client to one or more applications (see `xdm:application`) within a tenant (see `xdm:tenant`). The API must maintain tenant boundaries, as defined and controlled by an identity provider.",
           "type": "string",
           "format": "uri"
         },
         "xdm:selfServiceUI": {
           "name": "Self Service UI",
-          "description": "A User interface or potal containg all the functionality of the selfServiceAPI (see `xdm:selfServiceAPI`) presented for use byt a human in a web browsesr interface. Typically this UI will use the selfServiceAPI and be implemented as a browser applicaiton or SPA.",
+          "description":
+            "A User interface or potal containg all the functionality of the selfServiceAPI (see `xdm:selfServiceAPI`) presented for use byt a human in a web browsesr interface. Typically this UI will use the selfServiceAPI and be implemented as a browser applicaiton or SPA.",
           "type": "string",
           "format": "uri"
         },
         "xdm:selfServiceBuild": {
           "name": "Build",
-          "description": "The process by which the CICDPipeline (see `xdm:CICDPipeline`) creates a artifact (see `xdm:artifact`). How the build is performed and what the build creates depends on the source code stored in the codeRepository , which will also contain instructions to perform the build. In the case of a java artifact, the build would typically be performed by maven or gradle. In the case of a docker image, the build might be performed by make.",
+          "description":
+            "The process by which the CICDPipeline (see `xdm:CICDPipeline`) creates a artifact (see `xdm:artifact`). How the build is performed and what the build creates depends on the source code stored in the codeRepository , which will also contain instructions to perform the build. In the case of a java artifact, the build would typically be performed by maven or gradle. In the case of a docker image, the build might be performed by make.",
           "type": "string",
           "format": "uri"
         },
         "xdm:runningInstance": {
           "name": "Instance",
-          "description": "An instance is 1 copy of a service (see `xdm:service`) implementation running within a cluster (see `xdm:cluster`) within a topology (see `xdm:topology`) deployed to an environment (see `xdm:environment`) as an application (see `xdm:application`) for a tenant (see `xdm:tenant`). Where the application is a java application, deployed to a provisioned virtual machine, the instance will be the java process, however where the application has been deployed as part of a container based application the instance will be the running container.",
+          "description":
+            "An instance is 1 copy of a service (see `xdm:service`) implementation running within a cluster (see `xdm:cluster`) within a topology (see `xdm:topology`) deployed to an environment (see `xdm:environment`) as an application (see `xdm:application`) for a tenant (see `xdm:tenant`). Where the application is a java application, deployed to a provisioned virtual machine, the instance will be the java process, however where the application has been deployed as part of a container based application the instance will be the running container.",
           "type": "string",
           "format": "uri"
         },
         "xdm:qualityGateState": {
           "name": "Quality Gate",
-          "description": "The customer CICDPipeline (see `xdm:CICDPipeline`) defines a number of quality gates that will determine the success or fail of the entire process. If any Pass property being false indicates the quality gate has failed.",
+          "description":
+            "The customer CICDPipeline (see `xdm:CICDPipeline`) defines a number of quality gates that will determine the success or fail of the entire process. If any Pass property being false indicates the quality gate has failed.",
           "type": "object",
           "properties": {
             "*Pass": {
               "type": "boolean",
               "name": "*Pass",
-              "description": "A quality gate test, false means it failed, true means it passed."
+              "description":
+                "A quality gate test, false means it failed, true means it passed."
             }
           }
         }
@@ -141,12 +165,7 @@
       "$ref": "#/definitions/selfservice"
     },
     {
-      "required": [
-        "id",
-        "xdm:tenant",
-        "xdm:application",
-        "xdm:environment"
-      ]
+      "required": ["id", "xdm:tenant", "xdm:application", "xdm:environment"]
     }
   ],
   "meta:status": "experimental"

--- a/schemas/common/selfservice.schema.json
+++ b/schemas/common/selfservice.schema.json
@@ -8,152 +8,128 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "https://ns.adobe.com/xdm/selfservice",
   "title": "Customer Managed Environment",
-  "description":
-    "A Customer Managed Environment is an environment that allows a system integration or deployer to manage applications. This is also known as selfservice.",
+  "description": "A Customer Managed Environment is an environment that allows a system integration or deployer to manage applications. This is also known as selfservice.",
   "type": "object",
   "definitions": {
     "selfservice": {
       "properties": {
         "xdm:tenant": {
           "name": "Tenant",
-          "description":
-            "A description of a customer having a agreement to use a specific set of services (see `xdm:service`). A tenant will typically have a URI which can be used to reference the tenant, and should be resovable by an identity provider.",
+          "description": "A description of a customer having a agreement to use a specific set of services (see `xdm:service`). A tenant will typically have a URI which can be used to reference the tenant, and should be resovable by an identity provider.",
           "type": "string",
           "format": "uri"
         },
         "xdm:applicationOwner": {
           "name": "Application Owner",
-          "description":
-            "An application owner, distinct from a tenant  (`xdm:tenant`), owns an application (see `xdm:application`) and manages its state. The application owner may be a individual user or roll. Typically the application owner will be a member of the tenant, however that is not a requirement.",
+          "description": "An application owner, distinct from a tenant  (`xdm:tenant`), owns an application (see `xdm:application`) and manages its state. The application owner may be a individual user or roll. Typically the application owner will be a member of the tenant, however that is not a requirement.",
           "type": "string",
           "format": "uri"
         },
         "xdm:application": {
           "name": "Application",
-          "description":
-            "A set of code, content, and data that together implement an experience. Some applications do not allow a system integrator, partner or customer to perform customisation. Other applications may allow customisation on a per instance basis. These may be applications managed by the system integrator, partner or customer. An application be defined by a uri referencing the definition of the application.",
+          "description": "A set of code, content, and data that together implement an experience. Some applications do not allow a system integrator, partner or customer to perform customisation. Other applications may allow customisation on a per instance basis. These may be applications managed by the system integrator, partner or customer. An application be defined by a uri referencing the definition of the application.",
           "type": "string",
           "format": "uri"
         },
         "xdm:environment": {
           "name": "Environment",
-          "description":
-            "A tenant (see `xdm:tenant`) may work with 1..n environments where the application (see `xdm:application`) runs. Each environment serves a purpose in the CI/CD chain providing a structure whereby changes  to the application can be rolled out. Typically the owner of the application manages transitions between environments. A system integratior, partner or customer may be the owner of the application expecially where the application has  been extended and customised. An environment may have a uri referencing the definition of the environment. ",
+          "description": "A tenant (see `xdm:tenant`) may work with 1..n environments where the application (see `xdm:application`) runs. Each environment serves a purpose in the CI/CD chain providing a structure whereby changes  to the application can be rolled out. Typically the owner of the application manages transitions between environments. A system integratior, partner or customer may be the owner of the application expecially where the application has  been extended and customised. An environment may have a uri referencing the definition of the environment. ",
           "type": "string",
           "meta:enum": {
-            "dev":
-              "A development environment for engineering teams to develop and test against prior to releasing to the QE teams.",
-            "qe":
-              "A deployment provisioned to statisfy the Quality Engineering process",
-            "stage":
-              "A final deployment environment before production. Typically used to perform final testing and give a reference  deployment to the last production deployment",
-            "beta":
-              "A production deployment environment used to introduce end users of the `application` to new features.",
+            "dev": "A development environment for engineering teams to develop and test against prior to releasing to the QE teams.",
+            "qe": "A deployment provisioned to statisfy the Quality Engineering process",
+            "stage": "A final deployment environment before production. Typically used to perform final testing and give a reference  deployment to the last production deployment",
+            "beta": "A production deployment environment used to introduce end users of the `application` to new features.",
             "prod": "The production deployment environment"
           }
         },
         "xdm:cluster": {
           "name": "Cluster",
-          "description":
-            "A group of instances deployed within a environment (see `xdm:environment` ) as part of a topology (see `xdm:topology`) that deliver a service  within an application (see `xdm:application`) often using a single source of persistence. A topology may have one or more clusters (see `xdm:cluster`). A service (see `xdm:service`) is typically delivered by a single cluster. Members of the cluster are typically stateless and disposable, meaning they are created and destroyed to maintain a suitable cluster size to deliver the service against the agreed SLA. A cluster will have a uri refencing the definition of the cluster, including parameters defining its scaling behaviour.",
+          "description": "A group of instances deployed within a environment (see `xdm:environment` ) as part of a topology (see `xdm:topology`) that deliver a service  within an application (see `xdm:application`) often using a single source of persistence. A topology may have one or more clusters (see `xdm:cluster`). A service (see `xdm:service`) is typically delivered by a single cluster. Members of the cluster are typically stateless and disposable, meaning they are created and destroyed to maintain a suitable cluster size to deliver the service against the agreed SLA. A cluster will have a uri refencing the definition of the cluster, including parameters defining its scaling behaviour.",
           "type": "string",
           "format": "uri"
         },
         "xdm:CICDPipeline": {
           "name": "CI/CD Pipeline",
-          "description":
-            "A Continuous Deployment Continuous Integration pipeline (xdm:CICDPipeline) is used to deploy an application (see `xdm:application`) conforming to a defined topology (see `xdm:topology`) into an environment (see `xdm:environment`). The pipleline runs a standard process that understands the definingion of the topology, environment and application. The pipeline is a shared resource used by many applications and tenants (see `xdm:tenant`), although special tenants may have customised pipelines. A pipleline will have a URI which defines the API.",
+          "description": "A Continuous Deployment Continuous Integration pipeline (xdm:CICDPipeline) is used to deploy an application (see `xdm:application`) conforming to a defined topology (see `xdm:topology`) into an environment (see `xdm:environment`). The pipleline runs a standard process that understands the definingion of the topology, environment and application. The pipeline is a shared resource used by many applications and tenants (see `xdm:tenant`), although special tenants may have customised pipelines. A pipleline will have a URI which defines the API.",
           "type": "string",
           "format": "uri"
         },
         "xdm:service": {
           "name": "Service",
-          "description":
-            "An application (see `xdm:application`) consists of one or more services, deployed into a topology (see `xdm:topology`) and implemented as a cluster (see `xdm:cluster`). The service will generally expose an API to consumers however that service may be private to the application. The implimentation of a service my be changed without changing the specification of the service. A service will have a URI defining it.",
+          "description": "An application (see `xdm:application`) consists of one or more services, deployed into a topology (see `xdm:topology`) and implemented as a cluster (see `xdm:cluster`). The service will generally expose an API to consumers however that service may be private to the application. The implimentation of a service my be changed without changing the specification of the service. A service will have a URI defining it.",
           "type": "string",
           "format": "uri"
         },
         "xdm:topology": {
           "name": "Topology",
-          "description":
-            "A topology is a logical group of services (see `xdm:service`) and their implementations that together form an application (see `xdm:application`). The topology may consist of services and service implementations at different layers throughout an application. Some services within a topology may be satisfied by shared components, for instance many applications may share an edge traffic load balancer. A service will have a URI defining it.",
+          "description": "A topology is a logical group of services (see `xdm:service`) and their implementations that together form an application (see `xdm:application`). The topology may consist of services and service implementations at different layers throughout an application. Some services within a topology may be satisfied by shared components, for instance many applications may share an edge traffic load balancer. A service will have a URI defining it.",
           "type": "string",
           "format": "uri"
         },
         "xdm:codeRepository": {
           "name": "Code Repository",
-          "description":
-            "A Code Repostitory stores the application (see `xdm:application`) code and any definitions for topologies (see `xdm:topology`), services (see `xdm:service`), clusters (see `xdm:cluster`) and environments (see `(see `xdm:environment`). The CI/CD Pipeline (see `xdm:CICDPipeline`) will read the Code repository to perform integration and deploy the application.",
+          "description": "A Code Repostitory stores the application (see `xdm:application`) code and any definitions for topologies (see `xdm:topology`), services (see `xdm:service`), clusters (see `xdm:cluster`) and environments (see `(see `xdm:environment`). The CI/CD Pipeline (see `xdm:CICDPipeline`) will read the Code repository to perform integration and deploy the application.",
           "type": "string",
           "format": "uri"
         },
         "xdm:provisioning": {
           "name": "Provisioning",
-          "description":
-            "Provisioning is the operation which sets up everything required to allow a tenant (see `xdm:tenant`) to deploy an application (see `xdm:application`). This includes setting up the Code Repository (see `xdm:codeRepository`), and allocating any resources that the CI/CD pipeline (see `xdm:CICDPipeline`) might require to deploy the application. Provisioning will ensure that any costs or charges are appropriately registerd as being related to the tenant so that billing systems can ensure the tenant is billed. Where the infrastrucutre is dedicated to the tenant, provisioning will ensure that sufficient infratructure is available when the first deployment (see `xdm:deployment`) is being performed. If the infratructure is to be provisioned from a pool, provisioning will ensure that the pool is notified of the level of future demand. Provisioning will understand any legal or juristrictional requirements and constraints that the tenant may have expressed in the contract and ensure that those requiremetns and constraints are satisfied.",
+          "description": "Provisioning is the operation which sets up everything required to allow a tenant (see `xdm:tenant`) to deploy an application (see `xdm:application`). This includes setting up the Code Repository (see `xdm:codeRepository`), and allocating any resources that the CI/CD pipeline (see `xdm:CICDPipeline`) might require to deploy the application. Provisioning will ensure that any costs or charges are appropriately registerd as being related to the tenant so that billing systems can ensure the tenant is billed. Where the infrastrucutre is dedicated to the tenant, provisioning will ensure that sufficient infratructure is available when the first deployment (see `xdm:deployment`) is being performed. If the infratructure is to be provisioned from a pool, provisioning will ensure that the pool is notified of the level of future demand. Provisioning will understand any legal or juristrictional requirements and constraints that the tenant may have expressed in the contract and ensure that those requiremetns and constraints are satisfied.",
           "type": "string",
           "format": "uri"
         },
         "xdm:deployment": {
           "name": "Deployment",
-          "description":
-            "Deployment is the final act of deploying an application (see `xdm:application`) into an environment (see `xdm:environment`) prior to going live in that enviroment. This should be achieved via an automated process working from specifcation and configuration stored in the codeRepository (see `xdm:codeRepository`). Some applications may require the installation of packages directly into a service (see `xdm:service`) or API provided by the application. Where this is the case the deployment process must be capable of supporting that style of deployment and must not make the application or any of its parts available to serve requests while the deployment is incomplete. The deployment process should include stepts to validate that the depoloyment was sucessfull. Deployment is not the same as provisioning (see `xdm:provisioning`), which is a pre-requisite for deployment. Typically a deployment will be perfomed every time changes in the code repository needs to be made available in the environment` Typically the deployment process is implemented by the CICDPipeline (see `xdm:CICDPipeline`)",
+          "description": "Deployment is the final act of deploying an application (see `xdm:application`) into an environment (see `xdm:environment`) prior to going live in that enviroment. This should be achieved via an automated process working from specifcation and configuration stored in the codeRepository (see `xdm:codeRepository`). Some applications may require the installation of packages directly into a service (see `xdm:service`) or API provided by the application. Where this is the case the deployment process must be capable of supporting that style of deployment and must not make the application or any of its parts available to serve requests while the deployment is incomplete. The deployment process should include stepts to validate that the depoloyment was sucessfull. Deployment is not the same as provisioning (see `xdm:provisioning`), which is a pre-requisite for deployment. Typically a deployment will be perfomed every time changes in the code repository needs to be made available in the environment` Typically the deployment process is implemented by the CICDPipeline (see `xdm:CICDPipeline`)",
           "type": "string",
           "format": "uri"
         },
         "xdm:artifact": {
           "name": "Artifact",
-          "description":
-            "An artifact is a package forming the implementation of a service (see `xdm:service`). It is is stored in the artifactRepository (see `xdm:artifactRepository`) publised to the artifactRepository by the CICDPipeline (see `xdm:CICDPipeline`). An artifact has a version. Once an artifact with a version is published it becomes immutable. A version may be a unique string such as a SHA identifying a commit in a Git repository, or a semantic version number. Which is chosen depends on the prefered versioning mechanism.",
+          "description": "An artifact is a package forming the implementation of a service (see `xdm:service`). It is is stored in the artifactRepository (see `xdm:artifactRepository`) publised to the artifactRepository by the CICDPipeline (see `xdm:CICDPipeline`). An artifact has a version. Once an artifact with a version is published it becomes immutable. A version may be a unique string such as a SHA identifying a commit in a Git repository, or a semantic version number. Which is chosen depends on the prefered versioning mechanism.",
           "type": "string",
           "format": "uri"
         },
         "xdm:artifactRepository": {
           "name": "Artifact Repository",
-          "description":
-            "An artifact repository stores released binaries including artifacts (see `xdm:artifact`) either from vendors or created by the CICDPipeline (see `xdm:CICDPipeline`). These artifacts are used by the deployment pipleine to deploy an application (see `xdm:application`) into an environment (see `xdm:environment`). The artifactRepository will allow many versions of an artifact to exist and will be organised in a way that will allow artifacts specific to a tenant (see `xdm:tenant`), application, topology (see `xdm:topology`) and environment to be stored. The artifact repsitory must not be used to store any sensitive data.",
+          "description": "An artifact repository stores released binaries including artifacts (see `xdm:artifact`) either from vendors or created by the CICDPipeline (see `xdm:CICDPipeline`). These artifacts are used by the deployment pipleine to deploy an application (see `xdm:application`) into an environment (see `xdm:environment`). The artifactRepository will allow many versions of an artifact to exist and will be organised in a way that will allow artifacts specific to a tenant (see `xdm:tenant`), application, topology (see `xdm:topology`) and environment to be stored. The artifact repsitory must not be used to store any sensitive data.",
           "type": "string",
           "format": "uri"
         },
         "xdm:selfServiceAPI": {
           "name": "Self Service API",
-          "description":
-            "The Self Serivce API is a well defined API that will, using the model defined in XDM expose to a suitably authorised client a service implemenation that allows that client to one or more applications (see `xdm:application`) within a tenant (see `xdm:tenant`). The API must maintain tenant boundaries, as defined and controlled by an identity provider.",
+          "description": "The Self Serivce API is a well defined API that will, using the model defined in XDM expose to a suitably authorised client a service implemenation that allows that client to one or more applications (see `xdm:application`) within a tenant (see `xdm:tenant`). The API must maintain tenant boundaries, as defined and controlled by an identity provider.",
           "type": "string",
           "format": "uri"
         },
         "xdm:selfServiceUI": {
           "name": "Self Service UI",
-          "description":
-            "A User interface or potal containg all the functionality of the selfServiceAPI (see `xdm:selfServiceAPI`) presented for use byt a human in a web browsesr interface. Typically this UI will use the selfServiceAPI and be implemented as a browser applicaiton or SPA.",
+          "description": "A User interface or potal containg all the functionality of the selfServiceAPI (see `xdm:selfServiceAPI`) presented for use byt a human in a web browsesr interface. Typically this UI will use the selfServiceAPI and be implemented as a browser applicaiton or SPA.",
           "type": "string",
           "format": "uri"
         },
         "xdm:selfServiceBuild": {
           "name": "Build",
-          "description":
-            "The process by which the CICDPipeline (see `xdm:CICDPipeline`) creates a artifact (see `xdm:artifact`). How the build is performed and what the build creates depends on the source code stored in the codeRepository , which will also contain instructions to perform the build. In the case of a java artifact, the build would typically be performed by maven or gradle. In the case of a docker image, the build might be performed by make.",
+          "description": "The process by which the CICDPipeline (see `xdm:CICDPipeline`) creates a artifact (see `xdm:artifact`). How the build is performed and what the build creates depends on the source code stored in the codeRepository , which will also contain instructions to perform the build. In the case of a java artifact, the build would typically be performed by maven or gradle. In the case of a docker image, the build might be performed by make.",
           "type": "string",
           "format": "uri"
         },
         "xdm:runningInstance": {
           "name": "Instance",
-          "description":
-            "An instance is 1 copy of a service (see `xdm:service`) implementation running within a cluster (see `xdm:cluster`) within a topology (see `xdm:topology`) deployed to an environment (see `xdm:environment`) as an application (see `xdm:application`) for a tenant (see `xdm:tenant`). Where the application is a java application, deployed to a provisioned virtual machine, the instance will be the java process, however where the application has been deployed as part of a container based application the instance will be the running container.",
+          "description": "An instance is 1 copy of a service (see `xdm:service`) implementation running within a cluster (see `xdm:cluster`) within a topology (see `xdm:topology`) deployed to an environment (see `xdm:environment`) as an application (see `xdm:application`) for a tenant (see `xdm:tenant`). Where the application is a java application, deployed to a provisioned virtual machine, the instance will be the java process, however where the application has been deployed as part of a container based application the instance will be the running container.",
           "type": "string",
           "format": "uri"
         },
         "xdm:qualityGateState": {
           "name": "Quality Gate",
-          "description":
-            "The customer CICDPipeline (see `xdm:CICDPipeline`) defines a number of quality gates that will determine the success or fail of the entire process. If any Pass property being false indicates the quality gate has failed.",
+          "description": "The customer CICDPipeline (see `xdm:CICDPipeline`) defines a number of quality gates that will determine the success or fail of the entire process. If any Pass property being false indicates the quality gate has failed.",
           "type": "object",
           "properties": {
             "*Pass": {
               "type": "boolean",
               "name": "*Pass",
-              "description":
-                "A quality gate test, false means it failed, true means it passed."
+              "description": "A quality gate test, false means it failed, true means it passed."
             }
           }
         }
@@ -165,7 +141,13 @@
       "$ref": "#/definitions/selfservice"
     },
     {
-      "required": ["id", "xdm:tenant", "xdm:application", "xdm:environment"]
+      "required": [
+        "id",
+        "xdm:tenant",
+        "xdm:application",
+        "xdm:environment"
+      ]
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/content/component-container.schema.json
+++ b/schemas/content/component-container.schema.json
@@ -17,7 +17,8 @@
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "Type of the container. Acts as processing hint for the client."
+          "description":
+            "Type of the container. Acts as processing hint for the client."
         },
         "xdm:items": {
           "type": "object",
@@ -27,7 +28,8 @@
               "$ref": "#/definitions/container"
             },
             {
-              "$ref": "https://ns.adobe.com/xdm/content/page-component#/definitions/component"
+              "$ref":
+                "https://ns.adobe.com/xdm/content/page-component#/definitions/component"
             }
           ]
         },
@@ -37,7 +39,8 @@
           "items": {
             "type": "string"
           },
-          "description": "Defines the order of the items in the container. Can be omitted if the order is not important."
+          "description":
+            "Defines the order of the items in the container. Can be omitted if the order is not important."
         }
       }
     }
@@ -47,9 +50,6 @@
       "$ref": "#/definitions/container"
     }
   ],
-  "required": [
-    "@type",
-    "xdm:items"
-  ],
+  "required": ["@type", "xdm:items"],
   "meta:status": "experimental"
 }

--- a/schemas/content/component-container.schema.json
+++ b/schemas/content/component-container.schema.json
@@ -17,8 +17,7 @@
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "Type of the container. Acts as processing hint for the client."
+          "description": "Type of the container. Acts as processing hint for the client."
         },
         "xdm:items": {
           "type": "object",
@@ -28,8 +27,7 @@
               "$ref": "#/definitions/container"
             },
             {
-              "$ref":
-                "https://ns.adobe.com/xdm/content/page-component#/definitions/component"
+              "$ref": "https://ns.adobe.com/xdm/content/page-component#/definitions/component"
             }
           ]
         },
@@ -39,8 +37,7 @@
           "items": {
             "type": "string"
           },
-          "description":
-            "Defines the order of the items in the container. Can be omitted if the order is not important."
+          "description": "Defines the order of the items in the container. Can be omitted if the order is not important."
         }
       }
     }
@@ -50,5 +47,9 @@
       "$ref": "#/definitions/container"
     }
   ],
-  "required": ["@type", "xdm:items"]
+  "required": [
+    "@type",
+    "xdm:items"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/content/componentized-page.schema.json
+++ b/schemas/content/componentized-page.schema.json
@@ -42,13 +42,11 @@
       "properties": {
         "repo:path": {
           "type": "string",
-          "description":
-            "Shows the hierarchy of the page. The path semantics should be same as that defined in [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.3). In case a repository is not path based then it can return the information which will help in browsing. It could be just an document id, or something like `{catalog}/{id}` in case of a document database."
+          "description": "Shows the hierarchy of the page. The path semantics should be same as that defined in [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.3). In case a repository is not path based then it can return the information which will help in browsing. It could be just an document id, or something like `{catalog}/{id}` in case of a document database."
         },
         "repo:name": {
           "type": "string",
-          "description":
-            "Name of the page in the repository. This could be a file name or any name provided by the repository to the page."
+          "description": "Name of the page in the repository. This could be a file name or any name provided by the repository to the page."
         },
         "dc:title": {
           "type": "string",
@@ -56,13 +54,11 @@
         },
         "xdm:shortTitle": {
           "type": "string",
-          "description":
-            "Short title of the page that is suitable to be displayed in navigation links."
+          "description": "Short title of the page that is suitable to be displayed in navigation links."
         },
         "xdm:unlisted": {
           "type": "boolean",
-          "description":
-            "Indicates if this page should be hidden by default in navigational collections."
+          "description": "Indicates if this page should be hidden by default in navigational collections."
         },
         "xdm:template": {
           "type": "string",
@@ -71,22 +67,18 @@
         },
         "xdm:language": {
           "type": "string",
-          "pattern":
-            "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
-          "description":
-            "Specifies the language of this page. the language property should conform to BPC 47, for example `en-GB`"
+          "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
+          "description": "Specifies the language of this page. the language property should conform to BPC 47, for example `en-GB`"
         },
         "xdm:navOrder": {
           "type": "integer",
           "minimum": 0,
-          "description":
-            "When this page is shown in a collection of pages, use `nav_order` to sort. The smallest `nav_order` should be the first item in the sorted collection."
+          "description": "When this page is shown in a collection of pages, use `nav_order` to sort. The smallest `nav_order` should be the first item in the sorted collection."
         }
       }
     },
     "residuals": {
-      "description":
-        "Defines the set of residual properties allowed on a page or component.",
+      "description": "Defines the set of residual properties allowed on a page or component.",
       "additionalProperties": {
         "anyOf": [
           {
@@ -108,15 +100,14 @@
             "type": "boolean"
           },
           {
-            "$ref":
-              "https://ns.adobe.com/xdm/content/page-component#/definitions/component"
+            "$ref": "https://ns.adobe.com/xdm/content/page-component#/definitions/component"
           },
           {
-            "$ref":
-              "https://ns.adobe.com/xdm/content/component-container#/definitions/container"
+            "$ref": "https://ns.adobe.com/xdm/content/component-container#/definitions/container"
           }
         ]
       }
     }
-  }
+  },
+  "meta:status": "experimental"
 }

--- a/schemas/content/componentized-page.schema.json
+++ b/schemas/content/componentized-page.schema.json
@@ -42,11 +42,13 @@
       "properties": {
         "repo:path": {
           "type": "string",
-          "description": "Shows the hierarchy of the page. The path semantics should be same as that defined in [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.3). In case a repository is not path based then it can return the information which will help in browsing. It could be just an document id, or something like `{catalog}/{id}` in case of a document database."
+          "description":
+            "Shows the hierarchy of the page. The path semantics should be same as that defined in [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.3). In case a repository is not path based then it can return the information which will help in browsing. It could be just an document id, or something like `{catalog}/{id}` in case of a document database."
         },
         "repo:name": {
           "type": "string",
-          "description": "Name of the page in the repository. This could be a file name or any name provided by the repository to the page."
+          "description":
+            "Name of the page in the repository. This could be a file name or any name provided by the repository to the page."
         },
         "dc:title": {
           "type": "string",
@@ -54,11 +56,13 @@
         },
         "xdm:shortTitle": {
           "type": "string",
-          "description": "Short title of the page that is suitable to be displayed in navigation links."
+          "description":
+            "Short title of the page that is suitable to be displayed in navigation links."
         },
         "xdm:unlisted": {
           "type": "boolean",
-          "description": "Indicates if this page should be hidden by default in navigational collections."
+          "description":
+            "Indicates if this page should be hidden by default in navigational collections."
         },
         "xdm:template": {
           "type": "string",
@@ -67,18 +71,22 @@
         },
         "xdm:language": {
           "type": "string",
-          "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
-          "description": "Specifies the language of this page. the language property should conform to BPC 47, for example `en-GB`"
+          "pattern":
+            "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
+          "description":
+            "Specifies the language of this page. the language property should conform to BPC 47, for example `en-GB`"
         },
         "xdm:navOrder": {
           "type": "integer",
           "minimum": 0,
-          "description": "When this page is shown in a collection of pages, use `nav_order` to sort. The smallest `nav_order` should be the first item in the sorted collection."
+          "description":
+            "When this page is shown in a collection of pages, use `nav_order` to sort. The smallest `nav_order` should be the first item in the sorted collection."
         }
       }
     },
     "residuals": {
-      "description": "Defines the set of residual properties allowed on a page or component.",
+      "description":
+        "Defines the set of residual properties allowed on a page or component.",
       "additionalProperties": {
         "anyOf": [
           {
@@ -100,10 +108,12 @@
             "type": "boolean"
           },
           {
-            "$ref": "https://ns.adobe.com/xdm/content/page-component#/definitions/component"
+            "$ref":
+              "https://ns.adobe.com/xdm/content/page-component#/definitions/component"
           },
           {
-            "$ref": "https://ns.adobe.com/xdm/content/component-container#/definitions/container"
+            "$ref":
+              "https://ns.adobe.com/xdm/content/component-container#/definitions/container"
           }
         ]
       }

--- a/schemas/content/content.schema.json
+++ b/schemas/content/content.schema.json
@@ -23,21 +23,18 @@
         "@id": {
           "type": "string",
           "format": "uri",
-          "description":
-            "A unique identifier given to every addressable piece of content in a given repository."
+          "description": "A unique identifier given to every addressable piece of content in a given repository."
         },
         "xdm:repositoryCreatedBy": {
           "type": "string",
           "meta:immutable": true,
           "meta:usereditable": false,
-          "description":
-            "ID of the user who initiated the action that caused the resource to be created in the repository."
+          "description": "ID of the user who initiated the action that caused the resource to be created in the repository."
         },
         "xdm:repositoryLastModifiedBy": {
           "type": "string",
           "meta:usereditable": false,
-          "description":
-            "ID of the user who initiated the action that most recently caused the resource to be modified in the repository."
+          "description": "ID of the user who initiated the action that most recently caused the resource to be modified in the repository."
         }
       }
     }
@@ -47,12 +44,10 @@
       "$ref": "http://ns.adobe.com/adobecloud/core/1.0/asset#/definitions/asset"
     },
     {
-      "$ref":
-        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/common-properties"
+      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/common-properties"
     },
     {
-      "$ref":
-        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
+      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/external/hal/resource#/definitions/hal"
@@ -60,5 +55,6 @@
     {
       "$ref": "#/definitions/content"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/content/content.schema.json
+++ b/schemas/content/content.schema.json
@@ -23,18 +23,21 @@
         "@id": {
           "type": "string",
           "format": "uri",
-          "description": "A unique identifier given to every addressable piece of content in a given repository."
+          "description":
+            "A unique identifier given to every addressable piece of content in a given repository."
         },
         "xdm:repositoryCreatedBy": {
           "type": "string",
           "meta:immutable": true,
           "meta:usereditable": false,
-          "description": "ID of the user who initiated the action that caused the resource to be created in the repository."
+          "description":
+            "ID of the user who initiated the action that caused the resource to be created in the repository."
         },
         "xdm:repositoryLastModifiedBy": {
           "type": "string",
           "meta:usereditable": false,
-          "description": "ID of the user who initiated the action that most recently caused the resource to be modified in the repository."
+          "description":
+            "ID of the user who initiated the action that most recently caused the resource to be modified in the repository."
         }
       }
     }
@@ -44,10 +47,12 @@
       "$ref": "http://ns.adobe.com/adobecloud/core/1.0/asset#/definitions/asset"
     },
     {
-      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/common-properties"
+      "$ref":
+        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/common-properties"
     },
     {
-      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
+      "$ref":
+        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/external/hal/resource#/definitions/hal"

--- a/schemas/content/page-component.schema.json
+++ b/schemas/content/page-component.schema.json
@@ -17,7 +17,8 @@
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "Type of the component. Acts as processing hint for the client."
+          "description":
+            "Type of the component. Acts as processing hint for the client."
         }
       }
     }
@@ -27,7 +28,8 @@
       "$ref": "#/definitions/component"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/content/componentized-page#/definitions/residuals"
+      "$ref":
+        "https://ns.adobe.com/xdm/content/componentized-page#/definitions/residuals"
     }
   ],
   "meta:status": "experimental"

--- a/schemas/content/page-component.schema.json
+++ b/schemas/content/page-component.schema.json
@@ -17,8 +17,7 @@
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "Type of the component. Acts as processing hint for the client."
+          "description": "Type of the component. Acts as processing hint for the client."
         }
       }
     }
@@ -28,8 +27,8 @@
       "$ref": "#/definitions/component"
     },
     {
-      "$ref":
-        "https://ns.adobe.com/xdm/content/componentized-page#/definitions/residuals"
+      "$ref": "https://ns.adobe.com/xdm/content/componentized-page#/definitions/residuals"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/content/product.schema.json
+++ b/schemas/content/product.schema.json
@@ -9,7 +9,8 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Product",
   "type": "object",
-  "description": "XDM product variant, master product and key attributes of product in the product catalog.",
+  "description":
+    "XDM product variant, master product and key attributes of product in the product catalog.",
   "definitions": {
     "product": {
       "properties": {
@@ -17,12 +18,14 @@
           "title": "Identifier",
           "type": "string",
           "format": "uri",
-          "description": "The internal unique ID of the variant in the commerce backend system."
+          "description":
+            "The internal unique ID of the variant in the commerce backend system."
         },
         "xdm:SKU": {
           "title": "SKU",
           "type": "string",
-          "description": "The unique SKU (Stock Keeping Unit) of the variant assigned by the vendor."
+          "description":
+            "The unique SKU (Stock Keeping Unit) of the variant assigned by the vendor."
         },
         "xdm:name": {
           "title": "Name",
@@ -37,7 +40,8 @@
         "xdm:category": {
           "title": "Category",
           "type": "string",
-          "description": "Primary categorization (category) name of the Master/variant."
+          "description":
+            "Primary categorization (category) name of the Master/variant."
         },
         "xdm:department": {
           "title": "Department",
@@ -53,12 +57,14 @@
           "title": "Master Product Identifier",
           "type": "string",
           "format": "uri",
-          "description": "The internal unique ID of the product in the commerce backend system."
+          "description":
+            "The internal unique ID of the product in the commerce backend system."
         },
         "xdm:masterProductSKU": {
           "title": "Master Product SKU",
           "type": "string",
-          "description": "The unique SKU (Stock Keeping Unit) of the master product assigned by the vendor or manufacturer(to update)."
+          "description":
+            "The unique SKU (Stock Keeping Unit) of the master product assigned by the vendor or manufacturer(to update)."
         },
         "xdm:masterProductName": {
           "title": "Master Product Name",
@@ -94,13 +100,15 @@
         "xdm:unitOfMeasure": {
           "title": "Unit of Measure",
           "type": "string",
-          "description": "Standard unit of measure of the variant. Denotes the units for the size measurement."
+          "description":
+            "Standard unit of measure of the variant. Denotes the units for the size measurement."
         },
         "xdm:countryOfOrigin": {
           "title": "Country of Origin",
           "type": "string",
           "pattern": "^[A-Z]{2}$",
-          "description": "The two-character [ISO 3166-1 alpha-2](https://datahub.io/core/country-list) code for the country of origin of the product as defined by customs requirements."
+          "description":
+            "The two-character [ISO 3166-1 alpha-2](https://datahub.io/core/country-list) code for the country of origin of the product as defined by customs requirements."
         },
         "xdm:COGS": {
           "title": "Cost of Good Sold",
@@ -110,40 +118,43 @@
         "xdm:listPrice": {
           "title": "List Price",
           "type": "number",
-          "description": "Default price of the product before sales and discounting. In the `currencyCode` currency."
+          "description":
+            "Default price of the product before sales and discounting. In the `currencyCode` currency."
         },
         "xdm:currencyCode": {
           "title": "Currency Code",
           "type": "string",
-          "examples": [
-            "USD",
-            "EUR"
-          ],
+          "examples": ["USD", "EUR"],
           "pattern": "^[A-Z]{3}$",
-          "description": "The ISO 4217 alphabetic currency code used for cost and pricing, including `listPrice` and `COGS`."
+          "description":
+            "The ISO 4217 alphabetic currency code used for cost and pricing, including `listPrice` and `COGS`."
         },
         "xdm:originalSaleDate": {
           "title": "Original Sale Date",
           "type": "string",
           "format": "date",
-          "description": "First date the product was made available for sale. The time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
+          "description":
+            "First date the product was made available for sale. The time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
         },
         "xdm:productCreateDate": {
           "title": "Product Creation Date",
           "format": "date",
           "type": "string",
-          "description": "The date when this product variant was created. The time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
+          "description":
+            "The date when this product variant was created. The time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
         },
         "xdm:productLastModified": {
           "title": "Product Last Modified",
           "format": "date",
           "type": "string",
-          "description": "The date when this product variant was last modified. The time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
+          "description":
+            "The date when this product variant was last modified. The time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
         },
         "xdm:productURL": {
           "title": "Product URL",
           "type": "string",
-          "description": "The URL for the primary Product View of the product variant page."
+          "description":
+            "The URL for the primary Product View of the product variant page."
         },
         "xdm:manufacturerName": {
           "title": "Manufacturer Name",

--- a/schemas/content/product.schema.json
+++ b/schemas/content/product.schema.json
@@ -9,8 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Product",
   "type": "object",
-  "description":
-    "XDM product variant, master product and key attributes of product in the product catalog.",
+  "description": "XDM product variant, master product and key attributes of product in the product catalog.",
   "definitions": {
     "product": {
       "properties": {
@@ -18,14 +17,12 @@
           "title": "Identifier",
           "type": "string",
           "format": "uri",
-          "description":
-            "The internal unique ID of the variant in the commerce backend system."
+          "description": "The internal unique ID of the variant in the commerce backend system."
         },
         "xdm:SKU": {
           "title": "SKU",
           "type": "string",
-          "description":
-            "The unique SKU (Stock Keeping Unit) of the variant assigned by the vendor."
+          "description": "The unique SKU (Stock Keeping Unit) of the variant assigned by the vendor."
         },
         "xdm:name": {
           "title": "Name",
@@ -40,8 +37,7 @@
         "xdm:category": {
           "title": "Category",
           "type": "string",
-          "description":
-            "Primary categorization (category) name of the Master/variant."
+          "description": "Primary categorization (category) name of the Master/variant."
         },
         "xdm:department": {
           "title": "Department",
@@ -57,14 +53,12 @@
           "title": "Master Product Identifier",
           "type": "string",
           "format": "uri",
-          "description":
-            "The internal unique ID of the product in the commerce backend system."
+          "description": "The internal unique ID of the product in the commerce backend system."
         },
         "xdm:masterProductSKU": {
           "title": "Master Product SKU",
           "type": "string",
-          "description":
-            "The unique SKU (Stock Keeping Unit) of the master product assigned by the vendor or manufacturer(to update)."
+          "description": "The unique SKU (Stock Keeping Unit) of the master product assigned by the vendor or manufacturer(to update)."
         },
         "xdm:masterProductName": {
           "title": "Master Product Name",
@@ -100,15 +94,13 @@
         "xdm:unitOfMeasure": {
           "title": "Unit of Measure",
           "type": "string",
-          "description":
-            "Standard unit of measure of the variant. Denotes the units for the size measurement."
+          "description": "Standard unit of measure of the variant. Denotes the units for the size measurement."
         },
         "xdm:countryOfOrigin": {
           "title": "Country of Origin",
           "type": "string",
           "pattern": "^[A-Z]{2}$",
-          "description":
-            "The two-character [ISO 3166-1 alpha-2](https://datahub.io/core/country-list) code for the country of origin of the product as defined by customs requirements."
+          "description": "The two-character [ISO 3166-1 alpha-2](https://datahub.io/core/country-list) code for the country of origin of the product as defined by customs requirements."
         },
         "xdm:COGS": {
           "title": "Cost of Good Sold",
@@ -118,43 +110,40 @@
         "xdm:listPrice": {
           "title": "List Price",
           "type": "number",
-          "description":
-            "Default price of the product before sales and discounting. In the `currencyCode` currency."
+          "description": "Default price of the product before sales and discounting. In the `currencyCode` currency."
         },
         "xdm:currencyCode": {
           "title": "Currency Code",
           "type": "string",
-          "examples": ["USD", "EUR"],
+          "examples": [
+            "USD",
+            "EUR"
+          ],
           "pattern": "^[A-Z]{3}$",
-          "description":
-            "The ISO 4217 alphabetic currency code used for cost and pricing, including `listPrice` and `COGS`."
+          "description": "The ISO 4217 alphabetic currency code used for cost and pricing, including `listPrice` and `COGS`."
         },
         "xdm:originalSaleDate": {
           "title": "Original Sale Date",
           "type": "string",
           "format": "date",
-          "description":
-            "First date the product was made available for sale. The time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
+          "description": "First date the product was made available for sale. The time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
         },
         "xdm:productCreateDate": {
           "title": "Product Creation Date",
           "format": "date",
           "type": "string",
-          "description":
-            "The date when this product variant was created. The time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
+          "description": "The date when this product variant was created. The time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
         },
         "xdm:productLastModified": {
           "title": "Product Last Modified",
           "format": "date",
           "type": "string",
-          "description":
-            "The date when this product variant was last modified. The time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
+          "description": "The date when this product variant was last modified. The time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
         },
         "xdm:productURL": {
           "title": "Product URL",
           "type": "string",
-          "description":
-            "The URL for the primary Product View of the product variant page."
+          "description": "The URL for the primary Product View of the product variant page."
         },
         "xdm:manufacturerName": {
           "title": "Manufacturer Name",
@@ -176,5 +165,6 @@
     {
       "$ref": "#/definitions/product"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/content/productlistitem.schema.json
+++ b/schemas/content/productlistitem.schema.json
@@ -9,23 +9,20 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Product List Item",
   "type": "object",
-  "description":
-    "The product list item is a list item representing a product selected by a customer with specific options and pricing that are for that usage context at a specific point of time and may differ from the product record. For example the product record contains details from the product information system that are consistent for all customers, where the product list item has the actual price offered to the customer at that time which may vary due to sales campaigns or seasonal pricing.",
+  "description": "The product list item is a list item representing a product selected by a customer with specific options and pricing that are for that usage context at a specific point of time and may differ from the product record. For example the product record contains details from the product information system that are consistent for all customers, where the product list item has the actual price offered to the customer at that time which may vary due to sales campaigns or seasonal pricing.",
   "definitions": {
     "productlistitem": {
       "properties": {
         "xdm:SKU": {
           "title": "SKU",
           "type": "string",
-          "description":
-            "Stock Keeping Unit, the unique identifier for a product defined by the vendor."
+          "description": "Stock Keeping Unit, the unique identifier for a product defined by the vendor."
         },
         "@id": {
           "title": "Line Item ID.",
           "type": "string",
           "format": "uri",
-          "description":
-            "The line item identifier for this product entry. The product itself is identified through `xdm:product`."
+          "description": "The line item identifier for this product entry. The product itself is identified through `xdm:product`."
         },
         "xdm:product": {
           "title": "Product",
@@ -36,28 +33,27 @@
         "xdm:name": {
           "title": "Name",
           "type": "string",
-          "description":
-            "The display name for the product as presented to the user for this product view."
+          "description": "The display name for the product as presented to the user for this product view."
         },
         "xdm:productAddMethod": {
           "title": "Product Add Method",
           "type": "string",
-          "description":
-            "The method that was used to add a product item to the list by the visitor. Set with product list add metrics."
+          "description": "The method that was used to add a product item to the list by the visitor. Set with product list add metrics."
         },
         "xdm:currencyCode": {
           "title": "Currency Code",
           "type": "string",
-          "examples": ["USD", "EUR"],
+          "examples": [
+            "USD",
+            "EUR"
+          ],
           "pattern": "^[A-Z]{3}$",
-          "description":
-            "The ISO 4217 alphabetic currency code used for pricing the product."
+          "description": "The ISO 4217 alphabetic currency code used for pricing the product."
         },
         "xdm:quantity": {
           "title": "Quantity",
           "type": "integer",
-          "description":
-            "The number of units the customer has indicated they require of the product."
+          "description": "The number of units the customer has indicated they require of the product."
         },
         "xdm:priceTotal": {
           "title": "Price Total",
@@ -65,12 +61,15 @@
           "description": "The total price for the product line item."
         }
       },
-      "required": ["xdm:SKU"]
+      "required": [
+        "xdm:SKU"
+      ]
     }
   },
   "allOf": [
     {
       "$ref": "#/definitions/productlistitem"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/content/productlistitem.schema.json
+++ b/schemas/content/productlistitem.schema.json
@@ -9,20 +9,23 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Product List Item",
   "type": "object",
-  "description": "The product list item is a list item representing a product selected by a customer with specific options and pricing that are for that usage context at a specific point of time and may differ from the product record. For example the product record contains details from the product information system that are consistent for all customers, where the product list item has the actual price offered to the customer at that time which may vary due to sales campaigns or seasonal pricing.",
+  "description":
+    "The product list item is a list item representing a product selected by a customer with specific options and pricing that are for that usage context at a specific point of time and may differ from the product record. For example the product record contains details from the product information system that are consistent for all customers, where the product list item has the actual price offered to the customer at that time which may vary due to sales campaigns or seasonal pricing.",
   "definitions": {
     "productlistitem": {
       "properties": {
         "xdm:SKU": {
           "title": "SKU",
           "type": "string",
-          "description": "Stock Keeping Unit, the unique identifier for a product defined by the vendor."
+          "description":
+            "Stock Keeping Unit, the unique identifier for a product defined by the vendor."
         },
         "@id": {
           "title": "Line Item ID.",
           "type": "string",
           "format": "uri",
-          "description": "The line item identifier for this product entry. The product itself is identified through `xdm:product`."
+          "description":
+            "The line item identifier for this product entry. The product itself is identified through `xdm:product`."
         },
         "xdm:product": {
           "title": "Product",
@@ -33,27 +36,28 @@
         "xdm:name": {
           "title": "Name",
           "type": "string",
-          "description": "The display name for the product as presented to the user for this product view."
+          "description":
+            "The display name for the product as presented to the user for this product view."
         },
         "xdm:productAddMethod": {
           "title": "Product Add Method",
           "type": "string",
-          "description": "The method that was used to add a product item to the list by the visitor. Set with product list add metrics."
+          "description":
+            "The method that was used to add a product item to the list by the visitor. Set with product list add metrics."
         },
         "xdm:currencyCode": {
           "title": "Currency Code",
           "type": "string",
-          "examples": [
-            "USD",
-            "EUR"
-          ],
+          "examples": ["USD", "EUR"],
           "pattern": "^[A-Z]{3}$",
-          "description": "The ISO 4217 alphabetic currency code used for pricing the product."
+          "description":
+            "The ISO 4217 alphabetic currency code used for pricing the product."
         },
         "xdm:quantity": {
           "title": "Quantity",
           "type": "integer",
-          "description": "The number of units the customer has indicated they require of the product."
+          "description":
+            "The number of units the customer has indicated they require of the product."
         },
         "xdm:priceTotal": {
           "title": "Price Total",
@@ -61,9 +65,7 @@
           "description": "The total price for the product line item."
         }
       },
-      "required": [
-        "xdm:SKU"
-      ]
+      "required": ["xdm:SKU"]
     }
   },
   "allOf": [

--- a/schemas/content/repository-policies/encryption.schema.json
+++ b/schemas/content/repository-policies/encryption.schema.json
@@ -38,5 +38,6 @@
       }
     }
   },
-  "$ref": "#/definitions/encryption"
+  "$ref": "#/definitions/encryption",
+  "meta:status": "experimental"
 }

--- a/schemas/content/repository-policies/quota.schema.json
+++ b/schemas/content/repository-policies/quota.schema.json
@@ -50,5 +50,6 @@
     }
   },
   "type": "object",
-  "$ref": "#/definitions/quota"
+  "$ref": "#/definitions/quota",
+  "meta:status": "experimental"
 }

--- a/schemas/content/repository-policies/versioning.schema.json
+++ b/schemas/content/repository-policies/versioning.schema.json
@@ -28,5 +28,6 @@
     }
   },
   "type": "object",
-  "$ref": "#/definitions/versioning"
+  "$ref": "#/definitions/versioning",
+  "meta:status": "experimental"
 }

--- a/schemas/content/repository.schema.json
+++ b/schemas/content/repository.schema.json
@@ -8,17 +8,18 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "https://ns.adobe.com/xdm/content/repository",
   "title": "Content Repository",
-  "description":
-    "A Content Repository that is compliant with the Adobe Cloud Platform API specification.",
+  "description": "A Content Repository that is compliant with the Adobe Cloud Platform API specification.",
   "type": "object",
   "properties": {
     "xdm:root": {
       "name": "Root resource",
-      "decription":
-        "The location of the root resource of the repository. The root resource is of significance because it defines the entry point into the repository, in an hypermedia sense.",
+      "decription": "The location of the root resource of the repository. The root resource is of significance because it defines the entry point into the repository, in an hypermedia sense.",
       "type": "string",
       "format": "uri"
     }
   },
-  "required": ["xdm:root"]
+  "required": [
+    "xdm:root"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/content/repository.schema.json
+++ b/schemas/content/repository.schema.json
@@ -8,18 +8,18 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "https://ns.adobe.com/xdm/content/repository",
   "title": "Content Repository",
-  "description": "A Content Repository that is compliant with the Adobe Cloud Platform API specification.",
+  "description":
+    "A Content Repository that is compliant with the Adobe Cloud Platform API specification.",
   "type": "object",
   "properties": {
     "xdm:root": {
       "name": "Root resource",
-      "decription": "The location of the root resource of the repository. The root resource is of significance because it defines the entry point into the repository, in an hypermedia sense.",
+      "decription":
+        "The location of the root resource of the repository. The root resource is of significance because it defines the entry point into the repository, in an hypermedia sense.",
       "type": "string",
       "format": "uri"
     }
   },
-  "required": [
-    "xdm:root"
-  ],
+  "required": ["xdm:root"],
   "meta:status": "experimental"
 }

--- a/schemas/context/browserdetails.schema.json
+++ b/schemas/context/browserdetails.schema.json
@@ -36,22 +36,26 @@
         "xdm:cookiesEnabled": {
           "title": "Allows Cookies",
           "type": "boolean",
-          "description": "The current user agent settings allow for the writing of cookies.'"
+          "description":
+            "The current user agent settings allow for the writing of cookies.'"
         },
         "xdm:javaScriptEnabled": {
           "title": "JavaScript Enabled",
           "type": "boolean",
-          "description": "If JavaScript was enabled in the device this observation was made from."
+          "description":
+            "If JavaScript was enabled in the device this observation was made from."
         },
         "xdm:javaScriptVersion": {
           "title": "JavaScript Version",
           "type": "string",
-          "description": "The version of JavaScript supported during the observation."
+          "description":
+            "The version of JavaScript supported during the observation."
         },
         "xdm:javaEnabled": {
           "title": "Java Enabled",
           "type": "boolean",
-          "description": "If Java was enabled in the device this observation was made from."
+          "description":
+            "If Java was enabled in the device this observation was made from."
         },
         "xdm:javaVersion": {
           "title": "Java Version",
@@ -61,23 +65,27 @@
         "xdm:quicktimeVersion": {
           "title": "Quicktime Version",
           "type": "string",
-          "description": "The version of Apple Quicktime supported during the observation."
+          "description":
+            "The version of Apple Quicktime supported during the observation."
         },
         "xdm:thirdPartyCookiesEnabled": {
           "title": "Allows Third-party Cookies",
           "type": "boolean",
-          "description": "If third-party cookies were enabled when this observation was made."
+          "description":
+            "If third-party cookies were enabled when this observation was made."
         },
         "xdm:viewportHeight": {
           "title": "Viewport Height",
           "type": "integer",
-          "description": "The vertical size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport height.",
+          "description":
+            "The vertical size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport height.",
           "minimum": 0
         },
         "xdm:viewportWidth": {
           "title": "Viewport Width",
           "type": "integer",
-          "description": "The horizontal size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport width.",
+          "description":
+            "The horizontal size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport width.",
           "minimum": 0
         }
       }

--- a/schemas/context/browserdetails.schema.json
+++ b/schemas/context/browserdetails.schema.json
@@ -36,26 +36,22 @@
         "xdm:cookiesEnabled": {
           "title": "Allows Cookies",
           "type": "boolean",
-          "description":
-            "The current user agent settings allow for the writing of cookies.'"
+          "description": "The current user agent settings allow for the writing of cookies.'"
         },
         "xdm:javaScriptEnabled": {
           "title": "JavaScript Enabled",
           "type": "boolean",
-          "description":
-            "If JavaScript was enabled in the device this observation was made from."
+          "description": "If JavaScript was enabled in the device this observation was made from."
         },
         "xdm:javaScriptVersion": {
           "title": "JavaScript Version",
           "type": "string",
-          "description":
-            "The version of JavaScript supported during the observation."
+          "description": "The version of JavaScript supported during the observation."
         },
         "xdm:javaEnabled": {
           "title": "Java Enabled",
           "type": "boolean",
-          "description":
-            "If Java was enabled in the device this observation was made from."
+          "description": "If Java was enabled in the device this observation was made from."
         },
         "xdm:javaVersion": {
           "title": "Java Version",
@@ -65,27 +61,23 @@
         "xdm:quicktimeVersion": {
           "title": "Quicktime Version",
           "type": "string",
-          "description":
-            "The version of Apple Quicktime supported during the observation."
+          "description": "The version of Apple Quicktime supported during the observation."
         },
         "xdm:thirdPartyCookiesEnabled": {
           "title": "Allows Third-party Cookies",
           "type": "boolean",
-          "description":
-            "If third-party cookies were enabled when this observation was made."
+          "description": "If third-party cookies were enabled when this observation was made."
         },
         "xdm:viewportHeight": {
           "title": "Viewport Height",
           "type": "integer",
-          "description":
-            "The vertical size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport height.",
+          "description": "The vertical size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport height.",
           "minimum": 0
         },
         "xdm:viewportWidth": {
           "title": "Viewport Width",
           "type": "integer",
-          "description":
-            "The horizontal size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport width.",
+          "description": "The horizontal size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport width.",
           "minimum": 0
         }
       }
@@ -95,5 +87,6 @@
     {
       "$ref": "#/definitions/browserdetails"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/commerce.schema.json
+++ b/schemas/context/commerce.schema.json
@@ -25,5 +25,6 @@
     {
       "$ref": "#/definitions/commerce"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/device.schema.json
+++ b/schemas/context/device.schema.json
@@ -9,20 +9,23 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Device",
   "type": "object",
-  "description": "An identified device that is an application or browser instance that is trackable across sessions, normally by cookies.",
+  "description":
+    "An identified device that is an application or browser instance that is trackable across sessions, normally by cookies.",
   "definitions": {
     "device": {
       "properties": {
         "xdm:typeID": {
           "title": "Type Identifier",
           "type": "string",
-          "description": "An identifier for the device. This may be an identifier from Device Atlas or another service that identifies the hardware that is being used."
+          "description":
+            "An identifier for the device. This may be an identifier from Device Atlas or another service that identifies the hardware that is being used."
         },
         "xdm:typeIDService": {
           "title": "Type Identifier Service",
           "type": "string",
           "format": "uri",
-          "description": "The namespace of the service that is used to identify the device type.",
+          "description":
+            "The namespace of the service that is used to identify the device type.",
           "meta:enum": {
             "https://ns.adobe.com/external/deviceatlas": "Device Atlas"
           }
@@ -45,32 +48,38 @@
         "xdm:manufacturer": {
           "title": "Manufacturer",
           "type": "string",
-          "description": "The name of the organization who owns the design and creation of the Device. For example, 'Apple' is the manufacturer of the iPhone."
+          "description":
+            "The name of the organization who owns the design and creation of the Device. For example, 'Apple' is the manufacturer of the iPhone."
         },
         "xdm:model": {
           "title": "Model",
           "type": "string",
-          "description": "The name of the model for the Device. This is the common, human-readable or marketing name for the Device. The 'iPhone 6S' is a particular model of mobile phone."
+          "description":
+            "The name of the model for the Device. This is the common, human-readable or marketing name for the Device. The 'iPhone 6S' is a particular model of mobile phone."
         },
         "xdm:modelNumber": {
           "title": "Model Number",
           "type": "string",
-          "description": "The unique model number designation assigned by the manufacturer for this Device. Model numbers are not versions, but unique identifiers that identify a particular model configuration. While the model for a particular phone might be 'iPhone 6S' the model number would be 'A1633', or 'A1634' based on configuration at the time of sale."
+          "description":
+            "The unique model number designation assigned by the manufacturer for this Device. Model numbers are not versions, but unique identifiers that identify a particular model configuration. While the model for a particular phone might be 'iPhone 6S' the model number would be 'A1633', or 'A1634' based on configuration at the time of sale."
         },
         "xdm:screenHeight": {
           "title": "Screen Height",
           "type": "integer",
-          "description": "The number of veritcal pixels of the device's active display in its default orientation."
+          "description":
+            "The number of veritcal pixels of the device's active display in its default orientation."
         },
         "xdm:screenWidth": {
           "title": "Screen Width",
           "type": "integer",
-          "description": "The number of horizontal pixels of the device's active display in its default orientation."
+          "description":
+            "The number of horizontal pixels of the device's active display in its default orientation."
         },
         "xdm:colorDepth": {
           "title": "Color Depth",
           "type": "integer",
-          "description": "The number of colors the display is able to represent."
+          "description":
+            "The number of colors the display is able to represent."
         }
       }
     }

--- a/schemas/context/device.schema.json
+++ b/schemas/context/device.schema.json
@@ -9,23 +9,20 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Device",
   "type": "object",
-  "description":
-    "An identified device that is an application or browser instance that is trackable across sessions, normally by cookies.",
+  "description": "An identified device that is an application or browser instance that is trackable across sessions, normally by cookies.",
   "definitions": {
     "device": {
       "properties": {
         "xdm:typeID": {
           "title": "Type Identifier",
           "type": "string",
-          "description":
-            "An identifier for the device. This may be an identifier from Device Atlas or another service that identifies the hardware that is being used."
+          "description": "An identifier for the device. This may be an identifier from Device Atlas or another service that identifies the hardware that is being used."
         },
         "xdm:typeIDService": {
           "title": "Type Identifier Service",
           "type": "string",
           "format": "uri",
-          "description":
-            "The namespace of the service that is used to identify the device type.",
+          "description": "The namespace of the service that is used to identify the device type.",
           "meta:enum": {
             "https://ns.adobe.com/external/deviceatlas": "Device Atlas"
           }
@@ -48,38 +45,32 @@
         "xdm:manufacturer": {
           "title": "Manufacturer",
           "type": "string",
-          "description":
-            "The name of the organization who owns the design and creation of the Device. For example, 'Apple' is the manufacturer of the iPhone."
+          "description": "The name of the organization who owns the design and creation of the Device. For example, 'Apple' is the manufacturer of the iPhone."
         },
         "xdm:model": {
           "title": "Model",
           "type": "string",
-          "description":
-            "The name of the model for the Device. This is the common, human-readable or marketing name for the Device. The 'iPhone 6S' is a particular model of mobile phone."
+          "description": "The name of the model for the Device. This is the common, human-readable or marketing name for the Device. The 'iPhone 6S' is a particular model of mobile phone."
         },
         "xdm:modelNumber": {
           "title": "Model Number",
           "type": "string",
-          "description":
-            "The unique model number designation assigned by the manufacturer for this Device. Model numbers are not versions, but unique identifiers that identify a particular model configuration. While the model for a particular phone might be 'iPhone 6S' the model number would be 'A1633', or 'A1634' based on configuration at the time of sale."
+          "description": "The unique model number designation assigned by the manufacturer for this Device. Model numbers are not versions, but unique identifiers that identify a particular model configuration. While the model for a particular phone might be 'iPhone 6S' the model number would be 'A1633', or 'A1634' based on configuration at the time of sale."
         },
         "xdm:screenHeight": {
           "title": "Screen Height",
           "type": "integer",
-          "description":
-            "The number of veritcal pixels of the device's active display in its default orientation."
+          "description": "The number of veritcal pixels of the device's active display in its default orientation."
         },
         "xdm:screenWidth": {
           "title": "Screen Width",
           "type": "integer",
-          "description":
-            "The number of horizontal pixels of the device's active display in its default orientation."
+          "description": "The number of horizontal pixels of the device's active display in its default orientation."
         },
         "xdm:colorDepth": {
           "title": "Color Depth",
           "type": "integer",
-          "description":
-            "The number of colors the display is able to represent."
+          "description": "The number of colors the display is able to represent."
         }
       }
     }
@@ -88,5 +79,6 @@
     {
       "$ref": "#/definitions/device"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/emailaddress.schema.json
+++ b/schemas/context/emailaddress.schema.json
@@ -17,27 +17,23 @@
         "xdm:primary": {
           "title": "Primary",
           "type": "boolean",
-          "description":
-            "Primary email indicator.\n\nA Profile can have only one `primary` email address at a given point of time.\n"
+          "description": "Primary email indicator.\n\nA Profile can have only one `primary` email address at a given point of time.\n"
         },
         "xdm:address": {
           "title": "Address",
           "type": "string",
           "format": "email",
-          "description":
-            "The technical address, e.g 'name@domain.com' as commonly defined in RFC2822 and subsequent standards."
+          "description": "The technical address, e.g 'name@domain.com' as commonly defined in RFC2822 and subsequent standards."
         },
         "xdm:label": {
           "title": "Label",
           "type": "string",
-          "description":
-            "Additional display information that maybe available, e.g MS Outlook rich address controls display 'John Smith smithjr@company.uk', the 'John Smith' part is data that would be placed in the label."
+          "description": "Additional display information that maybe available, e.g MS Outlook rich address controls display 'John Smith smithjr@company.uk', the 'John Smith' part is data that would be placed in the label."
         },
         "xdm:type": {
           "title": "Type",
           "type": "string",
-          "description":
-            "The way the account relates to the person. e.g 'work' or 'personal'",
+          "description": "The way the account relates to the person. e.g 'work' or 'personal'",
           "meta:enum": {
             "unknown": "Unknown",
             "personal": "Personal",
@@ -48,8 +44,7 @@
         "xdm:status": {
           "title": "Status",
           "type": "string",
-          "description":
-            "An indication as to the ability to use the email address.",
+          "description": "An indication as to the ability to use the email address.",
           "default": "active",
           "meta:enum": {
             "active": "Active",
@@ -74,5 +69,6 @@
     {
       "$ref": "https://ns.adobe.com/xdm/common/auditable#/definitions/auditlog"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/emailaddress.schema.json
+++ b/schemas/context/emailaddress.schema.json
@@ -17,23 +17,27 @@
         "xdm:primary": {
           "title": "Primary",
           "type": "boolean",
-          "description": "Primary email indicator.\n\nA Profile can have only one `primary` email address at a given point of time.\n"
+          "description":
+            "Primary email indicator.\n\nA Profile can have only one `primary` email address at a given point of time.\n"
         },
         "xdm:address": {
           "title": "Address",
           "type": "string",
           "format": "email",
-          "description": "The technical address, e.g 'name@domain.com' as commonly defined in RFC2822 and subsequent standards."
+          "description":
+            "The technical address, e.g 'name@domain.com' as commonly defined in RFC2822 and subsequent standards."
         },
         "xdm:label": {
           "title": "Label",
           "type": "string",
-          "description": "Additional display information that maybe available, e.g MS Outlook rich address controls display 'John Smith smithjr@company.uk', the 'John Smith' part is data that would be placed in the label."
+          "description":
+            "Additional display information that maybe available, e.g MS Outlook rich address controls display 'John Smith smithjr@company.uk', the 'John Smith' part is data that would be placed in the label."
         },
         "xdm:type": {
           "title": "Type",
           "type": "string",
-          "description": "The way the account relates to the person. e.g 'work' or 'personal'",
+          "description":
+            "The way the account relates to the person. e.g 'work' or 'personal'",
           "meta:enum": {
             "unknown": "Unknown",
             "personal": "Personal",
@@ -44,7 +48,8 @@
         "xdm:status": {
           "title": "Status",
           "type": "string",
-          "description": "An indication as to the ability to use the email address.",
+          "description":
+            "An indication as to the ability to use the email address.",
           "default": "active",
           "meta:enum": {
             "active": "Active",

--- a/schemas/context/enduserids.schema.json
+++ b/schemas/context/enduserids.schema.json
@@ -9,7 +9,8 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "End User IDs",
   "type": "object",
-  "description": "Condensed, normalized encapsulation of all end user identifiers. NOTE: At least one of the fields is required.\n",
+  "description":
+    "Condensed, normalized encapsulation of all end user identifiers. NOTE: At least one of the fields is required.\n",
   "minProperties": 1,
   "properties": {
     "https://ns.adobe.com/experience/mcid": {
@@ -32,11 +33,13 @@
     "https://ns.adobe.com/experience/target": "Adobe Target",
     "https://ns.adobe.com/experience/campaign": "Adobe Campaign",
     "https://ns.adobe.com/experience/analytics": "Adobe Analytics",
-    "https://ns.adobe.com/experience/mcid": "Marketing Cloud Identity Core Service"
+    "https://ns.adobe.com/experience/mcid":
+      "Marketing Cloud Identity Core Service"
   },
   "patternProperties": {
     ".+://.+": {
-      "description": "The identifier, including data source (`@id` must be identical to the property value), foreign ID, and confidence.",
+      "description":
+        "The identifier, including data source (`@id` must be identical to the property value), foreign ID, and confidence.",
       "type": "object",
       "$ref": "https://ns.adobe.com/xdm/context/identity"
     }

--- a/schemas/context/enduserids.schema.json
+++ b/schemas/context/enduserids.schema.json
@@ -9,8 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "End User IDs",
   "type": "object",
-  "description":
-    "Condensed, normalized encapsulation of all end user identifiers. NOTE: At least one of the fields is required.\n",
+  "description": "Condensed, normalized encapsulation of all end user identifiers. NOTE: At least one of the fields is required.\n",
   "minProperties": 1,
   "properties": {
     "https://ns.adobe.com/experience/mcid": {
@@ -33,15 +32,14 @@
     "https://ns.adobe.com/experience/target": "Adobe Target",
     "https://ns.adobe.com/experience/campaign": "Adobe Campaign",
     "https://ns.adobe.com/experience/analytics": "Adobe Analytics",
-    "https://ns.adobe.com/experience/mcid":
-      "Marketing Cloud Identity Core Service"
+    "https://ns.adobe.com/experience/mcid": "Marketing Cloud Identity Core Service"
   },
   "patternProperties": {
     ".+://.+": {
-      "description":
-        "The identifier, including data source (`@id` must be identical to the property value), foreign ID, and confidence.",
+      "description": "The identifier, including data source (`@id` must be identical to the property value), foreign ID, and confidence.",
       "type": "object",
       "$ref": "https://ns.adobe.com/xdm/context/identity"
     }
-  }
+  },
+  "meta:status": "experimental"
 }

--- a/schemas/context/environment.schema.json
+++ b/schemas/context/environment.schema.json
@@ -9,7 +9,8 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Environment",
   "type": "object",
-  "description": "Information about the surrounding situation the event observation occurred in, specifically detailing transitory information such as the network or software versions. > IMPORTANT: All values should be aligned with the [DeviceAtlas](https://deviceatlas.com) database licensed by Adobe. ",
+  "description":
+    "Information about the surrounding situation the event observation occurred in, specifically detailing transitory information such as the network or software versions. > IMPORTANT: All values should be aligned with the [DeviceAtlas](https://deviceatlas.com) database licensed by Adobe. ",
   "definitions": {
     "environment": {
       "properties": {
@@ -17,12 +18,7 @@
           "title": "Type",
           "type": "string",
           "description": "The type of the application environment.",
-          "enum": [
-            "browser",
-            "application",
-            "iot",
-            "external"
-          ],
+          "enum": ["browser", "application", "iot", "external"],
           "meta:enum": {
             "browser": "Browser",
             "application": "Application",
@@ -33,34 +29,40 @@
         "xdm:browserDetails": {
           "title": "Browser Details",
           "$ref": "https://ns.adobe.com/xdm/context/browserdetails",
-          "description": "The browser specific details such as brwoser name, version, javascript version, user agent string, accept language."
+          "description":
+            "The browser specific details such as brwoser name, version, javascript version, user agent string, accept language."
         },
         "xdm:operatingSystem": {
           "title": "Operating System",
           "type": "string",
-          "description": "The name of the operating system used when the observation was made. This attribute should not contain any version information i.e. 10.5.3, but can contain *edition* designations such as 'Ultimate', or 'Professional'."
+          "description":
+            "The name of the operating system used when the observation was made. This attribute should not contain any version information i.e. 10.5.3, but can contain *edition* designations such as 'Ultimate', or 'Professional'."
         },
         "xdm:operatingSystemVersion": {
           "title": "Operating System Version",
           "type": "string",
-          "description": "The full version identifier for the operating system used when the observation was made. Versions are generally numerically composed, but may be in a vendor defined format."
+          "description":
+            "The full version identifier for the operating system used when the observation was made. Versions are generally numerically composed, but may be in a vendor defined format."
         },
         "xdm:colorDepth": {
           "title": "Color Depth",
           "type": "integer",
-          "description": "The number of bits used for each color component of a single pixel.",
+          "description":
+            "The number of bits used for each color component of a single pixel.",
           "minimum": 0
         },
         "xdm:viewportHeight": {
           "title": "Viewport Height",
           "type": "integer",
-          "description": "The vertical size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport height.",
+          "description":
+            "The vertical size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport height.",
           "minimum": 0
         },
         "xdm:viewportWidth": {
           "title": "Viewport Width",
           "type": "integer",
-          "description": "The horizontal size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport width.",
+          "description":
+            "The horizontal size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport width.",
           "minimum": 0
         },
         "xdm:connectionType": {
@@ -108,19 +110,22 @@
         "xdm:carrier": {
           "title": "Mobile Network Carrier",
           "type": "string",
-          "description": "A mobile network carrier or MNO, also known as a wireless service provider, wireless carrier, cellular company, or mobile network carrier, is a provider of services wireless communications that owns or controls all the elements necessary to sell and deliver services to an end user."
+          "description":
+            "A mobile network carrier or MNO, also known as a wireless service provider, wireless carrier, cellular company, or mobile network carrier, is a provider of services wireless communications that owns or controls all the elements necessary to sell and deliver services to an end user."
         },
         "xdm:ipV4": {
           "title": "IPv4",
           "type": "string",
           "format": "ipv4",
-          "description": "The numerical label assigned to a device participating in a computer network that uses the Internet Protocol for communication. "
+          "description":
+            "The numerical label assigned to a device participating in a computer network that uses the Internet Protocol for communication. "
         },
         "xdm:ipV6": {
           "title": "IPv6",
           "type": "string",
           "format": "ipv6",
-          "description": "The numerical label assigned to a device participating in a computer network that uses the Internet Protocol for communication. "
+          "description":
+            "The numerical label assigned to a device participating in a computer network that uses the Internet Protocol for communication. "
         }
       }
     }

--- a/schemas/context/environment.schema.json
+++ b/schemas/context/environment.schema.json
@@ -9,8 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Environment",
   "type": "object",
-  "description":
-    "Information about the surrounding situation the event observation occurred in, specifically detailing transitory information such as the network or software versions. > IMPORTANT: All values should be aligned with the [DeviceAtlas](https://deviceatlas.com) database licensed by Adobe. ",
+  "description": "Information about the surrounding situation the event observation occurred in, specifically detailing transitory information such as the network or software versions. > IMPORTANT: All values should be aligned with the [DeviceAtlas](https://deviceatlas.com) database licensed by Adobe. ",
   "definitions": {
     "environment": {
       "properties": {
@@ -18,7 +17,12 @@
           "title": "Type",
           "type": "string",
           "description": "The type of the application environment.",
-          "enum": ["browser", "application", "iot", "external"],
+          "enum": [
+            "browser",
+            "application",
+            "iot",
+            "external"
+          ],
           "meta:enum": {
             "browser": "Browser",
             "application": "Application",
@@ -29,40 +33,34 @@
         "xdm:browserDetails": {
           "title": "Browser Details",
           "$ref": "https://ns.adobe.com/xdm/context/browserdetails",
-          "description":
-            "The browser specific details such as brwoser name, version, javascript version, user agent string, accept language."
+          "description": "The browser specific details such as brwoser name, version, javascript version, user agent string, accept language."
         },
         "xdm:operatingSystem": {
           "title": "Operating System",
           "type": "string",
-          "description":
-            "The name of the operating system used when the observation was made. This attribute should not contain any version information i.e. 10.5.3, but can contain *edition* designations such as 'Ultimate', or 'Professional'."
+          "description": "The name of the operating system used when the observation was made. This attribute should not contain any version information i.e. 10.5.3, but can contain *edition* designations such as 'Ultimate', or 'Professional'."
         },
         "xdm:operatingSystemVersion": {
           "title": "Operating System Version",
           "type": "string",
-          "description":
-            "The full version identifier for the operating system used when the observation was made. Versions are generally numerically composed, but may be in a vendor defined format."
+          "description": "The full version identifier for the operating system used when the observation was made. Versions are generally numerically composed, but may be in a vendor defined format."
         },
         "xdm:colorDepth": {
           "title": "Color Depth",
           "type": "integer",
-          "description":
-            "The number of bits used for each color component of a single pixel.",
+          "description": "The number of bits used for each color component of a single pixel.",
           "minimum": 0
         },
         "xdm:viewportHeight": {
           "title": "Viewport Height",
           "type": "integer",
-          "description":
-            "The vertical size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport height.",
+          "description": "The vertical size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport height.",
           "minimum": 0
         },
         "xdm:viewportWidth": {
           "title": "Viewport Width",
           "type": "integer",
-          "description":
-            "The horizontal size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport width.",
+          "description": "The horizontal size (in pixels) of the window the experience was displayed inside. For a web view event, the browser viewport width.",
           "minimum": 0
         },
         "xdm:connectionType": {
@@ -110,22 +108,19 @@
         "xdm:carrier": {
           "title": "Mobile Network Carrier",
           "type": "string",
-          "description":
-            "A mobile network carrier or MNO, also known as a wireless service provider, wireless carrier, cellular company, or mobile network carrier, is a provider of services wireless communications that owns or controls all the elements necessary to sell and deliver services to an end user."
+          "description": "A mobile network carrier or MNO, also known as a wireless service provider, wireless carrier, cellular company, or mobile network carrier, is a provider of services wireless communications that owns or controls all the elements necessary to sell and deliver services to an end user."
         },
         "xdm:ipV4": {
           "title": "IPv4",
           "type": "string",
           "format": "ipv4",
-          "description":
-            "The numerical label assigned to a device participating in a computer network that uses the Internet Protocol for communication. "
+          "description": "The numerical label assigned to a device participating in a computer network that uses the Internet Protocol for communication. "
         },
         "xdm:ipV6": {
           "title": "IPv6",
           "type": "string",
           "format": "ipv6",
-          "description":
-            "The numerical label assigned to a device participating in a computer network that uses the Internet Protocol for communication. "
+          "description": "The numerical label assigned to a device participating in a computer network that uses the Internet Protocol for communication. "
         }
       }
     }
@@ -134,5 +129,6 @@
     {
       "$ref": "#/definitions/environment"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/experienceevent.schema.json
+++ b/schemas/context/experienceevent.schema.json
@@ -9,7 +9,8 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "ExperienceEvent",
   "type": "object",
-  "description": "The core ExperienceEvent XDM is used to capture observations that are altering one or more related XDMs/entities. The ExperienceEvent captures information about the observation taking place and when it is occurring. It is critical for time domain analytics as it allows observation and analysis of changes that occur in windows of time and comparison with other windows of time to track trends. ExperienceEvent are either explicit or implicit. Explicit events are direct observations of a human action taking place during a session. Implicit events are events that are being raised without a direct human action. Examples of implicit events are scheduled email sending of newsletters, battery voltage reaching a certain threshold, a person entering into range of a proximity sensor. While not all events are easily categorized across all data sources, it is extremely valuable to harmonize similar events into similar types for processing where possible, and the XDM specifications does this by defining a set of enumerated **type** attribute values with specific semantic meanings. Where possible events must be constrained to these enumerated values to facilitate interoperability.",
+  "description":
+    "The core ExperienceEvent XDM is used to capture observations that are altering one or more related XDMs/entities. The ExperienceEvent captures information about the observation taking place and when it is occurring. It is critical for time domain analytics as it allows observation and analysis of changes that occur in windows of time and comparison with other windows of time to track trends. ExperienceEvent are either explicit or implicit. Explicit events are direct observations of a human action taking place during a session. Implicit events are events that are being raised without a direct human action. Examples of implicit events are scheduled email sending of newsletters, battery voltage reaching a certain threshold, a person entering into range of a proximity sensor. While not all events are easily categorized across all data sources, it is extremely valuable to harmonize similar events into similar types for processing where possible, and the XDM specifications does this by defining a set of enumerated **type** attribute values with specific semantic meanings. Where possible events must be constrained to these enumerated values to facilitate interoperability.",
   "definitions": {
     "experienceevent": {
       "properties": {
@@ -28,27 +29,32 @@
           "title": "Timestamp",
           "type": "string",
           "format": "date-time",
-          "description": "The time when the first event of the interaction occurred."
+          "description":
+            "The time when the first event of the interaction occurred."
         },
         "xdm:endUserIDs": {
           "title": "End User IDs",
           "$ref": "https://ns.adobe.com/xdm/context/enduserids",
-          "description": "Condensed, normalized encapsulation of all end user identifiers.\n"
+          "description":
+            "Condensed, normalized encapsulation of all end user identifiers.\n"
         },
         "xdm:metrics": {
           "title": "Metrics",
           "$ref": "https://ns.adobe.com/xdm/data/metrics",
-          "description": "The metrics for actions performed during this observation."
+          "description":
+            "The metrics for actions performed during this observation."
         },
         "xdm:environment": {
           "title": "Environment",
           "$ref": "https://ns.adobe.com/xdm/context/environment",
-          "description": "Information about the surrounding situation the event observation occurred in, specifically detailing transitory information such as the network or software versions."
+          "description":
+            "Information about the surrounding situation the event observation occurred in, specifically detailing transitory information such as the network or software versions."
         },
         "xdm:productListItems": {
           "title": "Product List Items",
           "type": "array",
-          "description": "A list of items representing a product selected by a customer with specific options and pricing that are for that usage context at a specific point of time and may differ from the product record.",
+          "description":
+            "A list of items representing a product selected by a customer with specific options and pricing that are for that usage context at a specific point of time and may differ from the product record.",
           "items": {
             "$ref": "https://ns.adobe.com/xdm/content/productlistitem"
           }
@@ -56,17 +62,20 @@
         "xdm:device": {
           "title": "Device",
           "$ref": "https://ns.adobe.com/xdm/context/device",
-          "description": "An identified Device/Application or Device/Browser instance that is trackable across sessions, normally by cookies."
+          "description":
+            "An identified Device/Application or Device/Browser instance that is trackable across sessions, normally by cookies."
         },
         "xdm:commerce": {
           "title": "Commerce",
           "$ref": "https://ns.adobe.com/xdm/context/commerce",
-          "description": "The commerce specific data related to this interaction."
+          "description":
+            "The commerce specific data related to this interaction."
         },
         "xdm:application": {
           "title": "Application",
           "$ref": "https://ns.adobe.com/xdm/channels/application",
-          "description": "The application related to the event observation. It could be either the application targeted by the event like the send of a push notification or the application originating the event such as a click, or a login."
+          "description":
+            "The application related to the event observation. It could be either the application targeted by the event like the send of a push notification or the application originating the event such as a click, or a login."
         },
         "xdm:search": {
           "title": "Search",
@@ -76,25 +85,23 @@
         "xdm:web": {
           "title": "Web",
           "$ref": "https://ns.adobe.com/xdm/channels/web",
-          "description": "The information related to web page and link of the ExperienceEvent."
+          "description":
+            "The information related to web page and link of the ExperienceEvent."
         },
         "xdm:marketing": {
           "title": "Marketing",
           "$ref": "https://ns.adobe.com/xdm/context/marketing",
-          "description": "The information related to marketing activities that are active with the touchpoint."
+          "description":
+            "The information related to marketing activities that are active with the touchpoint."
         },
         "xdm:locationContext": {
           "title": "Location Context",
           "$ref": "https://ns.adobe.com/xdm/context/locationcontext",
-          "description": "The transient circumstances related to the observation. Examples include locale specific information such as weather, local time, traffic, day of the week, workday vs. holiday, working hours."
+          "description":
+            "The transient circumstances related to the observation. Examples include locale specific information such as weather, local time, traffic, day of the week, workday vs. holiday, working hours."
         }
       },
-      "required": [
-        "@id",
-        "xdm:dataSource",
-        "xdm:timestamp",
-        "xdm:endUserIDs"
-      ]
+      "required": ["@id", "xdm:dataSource", "xdm:timestamp", "xdm:endUserIDs"]
     }
   },
   "allOf": [

--- a/schemas/context/experienceevent.schema.json
+++ b/schemas/context/experienceevent.schema.json
@@ -9,8 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "ExperienceEvent",
   "type": "object",
-  "description":
-    "The core ExperienceEvent XDM is used to capture observations that are altering one or more related XDMs/entities. The ExperienceEvent captures information about the observation taking place and when it is occurring. It is critical for time domain analytics as it allows observation and analysis of changes that occur in windows of time and comparison with other windows of time to track trends. ExperienceEvent are either explicit or implicit. Explicit events are direct observations of a human action taking place during a session. Implicit events are events that are being raised without a direct human action. Examples of implicit events are scheduled email sending of newsletters, battery voltage reaching a certain threshold, a person entering into range of a proximity sensor. While not all events are easily categorized across all data sources, it is extremely valuable to harmonize similar events into similar types for processing where possible, and the XDM specifications does this by defining a set of enumerated **type** attribute values with specific semantic meanings. Where possible events must be constrained to these enumerated values to facilitate interoperability.",
+  "description": "The core ExperienceEvent XDM is used to capture observations that are altering one or more related XDMs/entities. The ExperienceEvent captures information about the observation taking place and when it is occurring. It is critical for time domain analytics as it allows observation and analysis of changes that occur in windows of time and comparison with other windows of time to track trends. ExperienceEvent are either explicit or implicit. Explicit events are direct observations of a human action taking place during a session. Implicit events are events that are being raised without a direct human action. Examples of implicit events are scheduled email sending of newsletters, battery voltage reaching a certain threshold, a person entering into range of a proximity sensor. While not all events are easily categorized across all data sources, it is extremely valuable to harmonize similar events into similar types for processing where possible, and the XDM specifications does this by defining a set of enumerated **type** attribute values with specific semantic meanings. Where possible events must be constrained to these enumerated values to facilitate interoperability.",
   "definitions": {
     "experienceevent": {
       "properties": {
@@ -29,32 +28,27 @@
           "title": "Timestamp",
           "type": "string",
           "format": "date-time",
-          "description":
-            "The time when the first event of the interaction occurred."
+          "description": "The time when the first event of the interaction occurred."
         },
         "xdm:endUserIDs": {
           "title": "End User IDs",
           "$ref": "https://ns.adobe.com/xdm/context/enduserids",
-          "description":
-            "Condensed, normalized encapsulation of all end user identifiers.\n"
+          "description": "Condensed, normalized encapsulation of all end user identifiers.\n"
         },
         "xdm:metrics": {
           "title": "Metrics",
           "$ref": "https://ns.adobe.com/xdm/data/metrics",
-          "description":
-            "The metrics for actions performed during this observation."
+          "description": "The metrics for actions performed during this observation."
         },
         "xdm:environment": {
           "title": "Environment",
           "$ref": "https://ns.adobe.com/xdm/context/environment",
-          "description":
-            "Information about the surrounding situation the event observation occurred in, specifically detailing transitory information such as the network or software versions."
+          "description": "Information about the surrounding situation the event observation occurred in, specifically detailing transitory information such as the network or software versions."
         },
         "xdm:productListItems": {
           "title": "Product List Items",
           "type": "array",
-          "description":
-            "A list of items representing a product selected by a customer with specific options and pricing that are for that usage context at a specific point of time and may differ from the product record.",
+          "description": "A list of items representing a product selected by a customer with specific options and pricing that are for that usage context at a specific point of time and may differ from the product record.",
           "items": {
             "$ref": "https://ns.adobe.com/xdm/content/productlistitem"
           }
@@ -62,20 +56,17 @@
         "xdm:device": {
           "title": "Device",
           "$ref": "https://ns.adobe.com/xdm/context/device",
-          "description":
-            "An identified Device/Application or Device/Browser instance that is trackable across sessions, normally by cookies."
+          "description": "An identified Device/Application or Device/Browser instance that is trackable across sessions, normally by cookies."
         },
         "xdm:commerce": {
           "title": "Commerce",
           "$ref": "https://ns.adobe.com/xdm/context/commerce",
-          "description":
-            "The commerce specific data related to this interaction."
+          "description": "The commerce specific data related to this interaction."
         },
         "xdm:application": {
           "title": "Application",
           "$ref": "https://ns.adobe.com/xdm/channels/application",
-          "description":
-            "The application related to the event observation. It could be either the application targeted by the event like the send of a push notification or the application originating the event such as a click, or a login."
+          "description": "The application related to the event observation. It could be either the application targeted by the event like the send of a push notification or the application originating the event such as a click, or a login."
         },
         "xdm:search": {
           "title": "Search",
@@ -85,23 +76,25 @@
         "xdm:web": {
           "title": "Web",
           "$ref": "https://ns.adobe.com/xdm/channels/web",
-          "description":
-            "The information related to web page and link of the ExperienceEvent."
+          "description": "The information related to web page and link of the ExperienceEvent."
         },
         "xdm:marketing": {
           "title": "Marketing",
           "$ref": "https://ns.adobe.com/xdm/context/marketing",
-          "description":
-            "The information related to marketing activities that are active with the touchpoint."
+          "description": "The information related to marketing activities that are active with the touchpoint."
         },
         "xdm:locationContext": {
           "title": "Location Context",
           "$ref": "https://ns.adobe.com/xdm/context/locationcontext",
-          "description":
-            "The transient circumstances related to the observation. Examples include locale specific information such as weather, local time, traffic, day of the week, workday vs. holiday, working hours."
+          "description": "The transient circumstances related to the observation. Examples include locale specific information such as weather, local time, traffic, day of the week, workday vs. holiday, working hours."
         }
       },
-      "required": ["@id", "xdm:dataSource", "xdm:timestamp", "xdm:endUserIDs"]
+      "required": [
+        "@id",
+        "xdm:dataSource",
+        "xdm:timestamp",
+        "xdm:endUserIDs"
+      ]
     }
   },
   "allOf": [
@@ -111,5 +104,6 @@
     {
       "$ref": "#/definitions/experienceevent"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/identity.schema.json
+++ b/schemas/context/identity.schema.json
@@ -9,8 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Identity",
   "type": "object",
-  "description":
-    "Identity is used to clearly distinguish people that are interacting with digital experiences. Identity is established by an identity provider, which itself is referenced in the `namespace` attribute. Within each `namespace`, the identity is unique.",
+  "description": "Identity is used to clearly distinguish people that are interacting with digital experiences. Identity is established by an identity provider, which itself is referenced in the `namespace` attribute. Within each `namespace`, the identity is unique.",
   "definitions": {
     "identity": {
       "properties": {
@@ -23,14 +22,12 @@
         "xdm:namespace": {
           "title": "Namespace",
           "$ref": "https://ns.adobe.com/xdm/context/namespace",
-          "description":
-            "The namespace associated with the `xid` attribute and matched up with the AAM data source integration code."
+          "description": "The namespace associated with the `xid` attribute and matched up with the AAM data source integration code."
         },
         "xdm:xid": {
           "title": "Experience Identifier",
           "type": "string",
-          "description":
-            "When present, this value represents a cross-namespace identifier that is unique across all namespace-scoped identifiers in all namespaces."
+          "description": "When present, this value represents a cross-namespace identifier that is unique across all namespace-scoped identifiers in all namespaces."
         }
       }
     }
@@ -39,5 +36,6 @@
     {
       "$ref": "#/definitions/identity"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/identity.schema.json
+++ b/schemas/context/identity.schema.json
@@ -9,7 +9,8 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Identity",
   "type": "object",
-  "description": "Identity is used to clearly distinguish people that are interacting with digital experiences. Identity is established by an identity provider, which itself is referenced in the `namespace` attribute. Within each `namespace`, the identity is unique.",
+  "description":
+    "Identity is used to clearly distinguish people that are interacting with digital experiences. Identity is established by an identity provider, which itself is referenced in the `namespace` attribute. Within each `namespace`, the identity is unique.",
   "definitions": {
     "identity": {
       "properties": {
@@ -22,12 +23,14 @@
         "xdm:namespace": {
           "title": "Namespace",
           "$ref": "https://ns.adobe.com/xdm/context/namespace",
-          "description": "The namespace associated with the `xid` attribute and matched up with the AAM data source integration code."
+          "description":
+            "The namespace associated with the `xid` attribute and matched up with the AAM data source integration code."
         },
         "xdm:xid": {
           "title": "Experience Identifier",
           "type": "string",
-          "description": "When present, this value represents a cross-namespace identifier that is unique across all namespace-scoped identifiers in all namespaces."
+          "description":
+            "When present, this value represents a cross-namespace identifier that is unique across all namespace-scoped identifiers in all namespaces."
         }
       }
     }

--- a/schemas/context/locationcontext.schema.json
+++ b/schemas/context/locationcontext.schema.json
@@ -9,8 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Location Context",
   "type": "object",
-  "description":
-    "The transient circumstances related to the observation. Examples include locale specific information such as weather, local time, traffic, day of the week, workday vs. holiday, working hours.",
+  "description": "The transient circumstances related to the observation. Examples include locale specific information such as weather, local time, traffic, day of the week, workday vs. holiday, working hours.",
   "definitions": {
     "locationcontext": {
       "properties": {
@@ -18,14 +17,12 @@
           "title": "Local Time",
           "type": "string",
           "format": "date-time",
-          "description":
-            "The local time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
+          "description": "The local time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
         },
         "xdm:geo": {
           "title": "Geo",
           "$ref": "https://ns.adobe.com/xdm/common/geo",
-          "description":
-            "The geographic location where the experience was delivered ."
+          "description": "The geographic location where the experience was delivered ."
         }
       }
     }
@@ -34,5 +31,6 @@
     {
       "$ref": "#/definitions/locationcontext"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/locationcontext.schema.json
+++ b/schemas/context/locationcontext.schema.json
@@ -9,7 +9,8 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Location Context",
   "type": "object",
-  "description": "The transient circumstances related to the observation. Examples include locale specific information such as weather, local time, traffic, day of the week, workday vs. holiday, working hours.",
+  "description":
+    "The transient circumstances related to the observation. Examples include locale specific information such as weather, local time, traffic, day of the week, workday vs. holiday, working hours.",
   "definitions": {
     "locationcontext": {
       "properties": {
@@ -17,12 +18,14 @@
           "title": "Local Time",
           "type": "string",
           "format": "date-time",
-          "description": "The local time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
+          "description":
+            "The local time using RFC3339 with a stated timezone offset such as \"2001-07-04T12:08:56-07:00\". An example formatting pattern is \"yyyy-MM-dd'T'HH:mm:ssXXX\"."
         },
         "xdm:geo": {
           "title": "Geo",
           "$ref": "https://ns.adobe.com/xdm/common/geo",
-          "description": "The geographic location where the experience was delivered ."
+          "description":
+            "The geographic location where the experience was delivered ."
         }
       }
     }

--- a/schemas/context/marketing.schema.json
+++ b/schemas/context/marketing.schema.json
@@ -9,14 +9,16 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Marketing",
   "type": "object",
-  "description": "The information related to marketing activities that are active with the touchpoint.",
+  "description":
+    "The information related to marketing activities that are active with the touchpoint.",
   "definitions": {
     "marketing": {
       "properties": {
         "xdm:trackingCode": {
           "title": "Tracking Code",
           "type": "string",
-          "description": "Tracking code that can be used to identify the marketing campaign the event is associated with."
+          "description":
+            "Tracking code that can be used to identify the marketing campaign the event is associated with."
         }
       }
     }

--- a/schemas/context/marketing.schema.json
+++ b/schemas/context/marketing.schema.json
@@ -9,16 +9,14 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Marketing",
   "type": "object",
-  "description":
-    "The information related to marketing activities that are active with the touchpoint.",
+  "description": "The information related to marketing activities that are active with the touchpoint.",
   "definitions": {
     "marketing": {
       "properties": {
         "xdm:trackingCode": {
           "title": "Tracking Code",
           "type": "string",
-          "description":
-            "Tracking code that can be used to identify the marketing campaign the event is associated with."
+          "description": "Tracking code that can be used to identify the marketing campaign the event is associated with."
         }
       }
     }
@@ -27,5 +25,6 @@
     {
       "$ref": "#/definitions/marketing"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/namespace.schema.json
+++ b/schemas/context/namespace.schema.json
@@ -9,7 +9,8 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Namespace",
   "type": "object",
-  "description": "The namespace or unique identifier associated with a collection of data. Each EndUserID is associated with a given namespace. A user can create and obtain information about a namespace during the solution onboarding.\n",
+  "description":
+    "The namespace or unique identifier associated with a collection of data. Each EndUserID is associated with a given namespace. A user can create and obtain information about a namespace during the solution onboarding.\n",
   "definitions": {
     "namespace": {
       "properties": {
@@ -17,12 +18,14 @@
           "title": "Identifier",
           "type": "string",
           "format": "uri",
-          "description": "The numeric ID associated with this namespace. This would be provided by the individual or system that created the namespace.\n"
+          "description":
+            "The numeric ID associated with this namespace. This would be provided by the individual or system that created the namespace.\n"
         },
         "xdm:code": {
           "title": "Code",
           "type": "string",
-          "description": "The code is a shortcut to the full @id and at least one of the code or @id can be used. Sometimes, this code refered to as the data source integration code."
+          "description":
+            "The code is a shortcut to the full @id and at least one of the code or @id can be used. Sometimes, this code refered to as the data source integration code."
         }
       },
       "minProperties": 1

--- a/schemas/context/namespace.schema.json
+++ b/schemas/context/namespace.schema.json
@@ -9,8 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Namespace",
   "type": "object",
-  "description":
-    "The namespace or unique identifier associated with a collection of data. Each EndUserID is associated with a given namespace. A user can create and obtain information about a namespace during the solution onboarding.\n",
+  "description": "The namespace or unique identifier associated with a collection of data. Each EndUserID is associated with a given namespace. A user can create and obtain information about a namespace during the solution onboarding.\n",
   "definitions": {
     "namespace": {
       "properties": {
@@ -18,14 +17,12 @@
           "title": "Identifier",
           "type": "string",
           "format": "uri",
-          "description":
-            "The numeric ID associated with this namespace. This would be provided by the individual or system that created the namespace.\n"
+          "description": "The numeric ID associated with this namespace. This would be provided by the individual or system that created the namespace.\n"
         },
         "xdm:code": {
           "title": "Code",
           "type": "string",
-          "description":
-            "The code is a shortcut to the full @id and at least one of the code or @id can be used. Sometimes, this code refered to as the data source integration code."
+          "description": "The code is a shortcut to the full @id and at least one of the code or @id can be used. Sometimes, this code refered to as the data source integration code."
         }
       },
       "minProperties": 1
@@ -35,5 +32,6 @@
     {
       "$ref": "#/definitions/namespace"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/optinout.schema.json
+++ b/schemas/context/optinout.schema.json
@@ -9,21 +9,23 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "OptInOut",
   "type": "object",
-  "description":
-    "Describes a users' communication preferences by channel. For each channel individually, which is a property of this object, a user's preference (opt-in, opt-out, pending) can be recorded. In addition, a global override opt-out is possible. Each property of this schema must be a valid and known URI for an XDM Channel.",
+  "description": "Describes a users' communication preferences by channel. For each channel individually, which is a property of this object, a user's preference (opt-in, opt-out, pending) can be recorded. In addition, a global override opt-out is possible. Each property of this schema must be a valid and known URI for an XDM Channel.",
   "definitions": {
     "preference": {
-      "description":
-        "Communication preference for the outbound channel identified through its URL by the name of the property.",
+      "description": "Communication preference for the outbound channel identified through its URL by the name of the property.",
       "type": "string",
       "default": "not_provided",
-      "enum": ["not_provided", "pending", "in", "out"],
+      "enum": [
+        "not_provided",
+        "pending",
+        "in",
+        "out"
+      ],
       "meta:enum": {
         "not_provided": "Not Provided",
         "pending": "Pending Verification",
         "in": "Opt-In: the user explicitly consents to receiving messages.",
-        "out":
-          "Opt-Out: the user declines to receive any messages on this channel"
+        "out": "Opt-Out: the user declines to receive any messages on this channel"
       }
     },
     "optinout": {
@@ -108,5 +110,6 @@
     {
       "$ref": "#/definitions/optinout"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/optinout.schema.json
+++ b/schemas/context/optinout.schema.json
@@ -9,23 +9,21 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "OptInOut",
   "type": "object",
-  "description": "Describes a users' communication preferences by channel. For each channel individually, which is a property of this object, a user's preference (opt-in, opt-out, pending) can be recorded. In addition, a global override opt-out is possible. Each property of this schema must be a valid and known URI for an XDM Channel.",
+  "description":
+    "Describes a users' communication preferences by channel. For each channel individually, which is a property of this object, a user's preference (opt-in, opt-out, pending) can be recorded. In addition, a global override opt-out is possible. Each property of this schema must be a valid and known URI for an XDM Channel.",
   "definitions": {
     "preference": {
-      "description": "Communication preference for the outbound channel identified through its URL by the name of the property.",
+      "description":
+        "Communication preference for the outbound channel identified through its URL by the name of the property.",
       "type": "string",
       "default": "not_provided",
-      "enum": [
-        "not_provided",
-        "pending",
-        "in",
-        "out"
-      ],
+      "enum": ["not_provided", "pending", "in", "out"],
       "meta:enum": {
         "not_provided": "Not Provided",
         "pending": "Pending Verification",
         "in": "Opt-In: the user explicitly consents to receiving messages.",
-        "out": "Opt-Out: the user declines to receive any messages on this channel"
+        "out":
+          "Opt-Out: the user declines to receive any messages on this channel"
       }
     },
     "optinout": {

--- a/schemas/context/person-name.schema.json
+++ b/schemas/context/person-name.schema.json
@@ -21,22 +21,26 @@
         "xdm:surname": {
           "title": "Surname",
           "type": "string",
-          "description": "The inherited family name, last name, surname, patronymic, or matronymic name."
+          "description":
+            "The inherited family name, last name, surname, patronymic, or matronymic name."
         },
         "xdm:middleName": {
           "title": "Middle name",
           "type": "string",
-          "description": "Middle, alternative, or additional names supplied between the given name and surnames."
+          "description":
+            "Middle, alternative, or additional names supplied between the given name and surnames."
         },
         "xdm:courtesyTitle": {
           "title": "Courtesy title",
           "type": "string",
-          "description": "Normally an abbreviation of a persons *title*, *honorific*, or *salutation*.\nThe `courtesyTitle` is used in front of full or last name in opening texts.\ne.g Mr. Miss. or Dr J. Smith.\n"
+          "description":
+            "Normally an abbreviation of a persons *title*, *honorific*, or *salutation*.\nThe `courtesyTitle` is used in front of full or last name in opening texts.\ne.g Mr. Miss. or Dr J. Smith.\n"
         },
         "xdm:name": {
           "title": "Full name",
           "type": "string",
-          "description": "The full name of the person, in writing order most commonly accepted in the language of the name."
+          "description":
+            "The full name of the person, in writing order most commonly accepted in the language of the name."
         }
       }
     }

--- a/schemas/context/person-name.schema.json
+++ b/schemas/context/person-name.schema.json
@@ -21,26 +21,22 @@
         "xdm:surname": {
           "title": "Surname",
           "type": "string",
-          "description":
-            "The inherited family name, last name, surname, patronymic, or matronymic name."
+          "description": "The inherited family name, last name, surname, patronymic, or matronymic name."
         },
         "xdm:middleName": {
           "title": "Middle name",
           "type": "string",
-          "description":
-            "Middle, alternative, or additional names supplied between the given name and surnames."
+          "description": "Middle, alternative, or additional names supplied between the given name and surnames."
         },
         "xdm:courtesyTitle": {
           "title": "Courtesy title",
           "type": "string",
-          "description":
-            "Normally an abbreviation of a persons *title*, *honorific*, or *salutation*.\nThe `courtesyTitle` is used in front of full or last name in opening texts.\ne.g Mr. Miss. or Dr J. Smith.\n"
+          "description": "Normally an abbreviation of a persons *title*, *honorific*, or *salutation*.\nThe `courtesyTitle` is used in front of full or last name in opening texts.\ne.g Mr. Miss. or Dr J. Smith.\n"
         },
         "xdm:name": {
           "title": "Full name",
           "type": "string",
-          "description":
-            "The full name of the person, in writing order most commonly accepted in the language of the name."
+          "description": "The full name of the person, in writing order most commonly accepted in the language of the name."
         }
       }
     }
@@ -49,5 +45,6 @@
     {
       "$ref": "#/definitions/personname"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/person.schema.json
+++ b/schemas/context/person.schema.json
@@ -11,8 +11,7 @@
   "type": "object",
   "meta:extensible": true,
   "meta:auditable": true,
-  "description":
-    "An individual person. May represent a person acting in various roles, such as a customer, contact, or owner.",
+  "description": "An individual person. May represent a person acting in various roles, such as a customer, contact, or owner.",
   "definitions": {
     "person": {
       "properties": {
@@ -38,15 +37,19 @@
         "xdm:birthYear": {
           "title": "Birth year",
           "type": "integer",
-          "description":
-            "The year a person was born including the century (yyyy, e.g 1983).",
+          "description": "The year a person was born including the century (yyyy, e.g 1983).",
           "minimum": 1,
           "maximum": 32767
         },
         "xdm:gender": {
           "title": "Gender",
           "type": "string",
-          "enum": ["male", "female", "not_specified", "non_specific"],
+          "enum": [
+            "male",
+            "female",
+            "not_specified",
+            "non_specific"
+          ],
           "meta:enum": {
             "male": "Male",
             "female": "Female",
@@ -66,5 +69,6 @@
     {
       "$ref": "https://ns.adobe.com/xdm/common/auditable#/definitions/auditlog"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/person.schema.json
+++ b/schemas/context/person.schema.json
@@ -11,7 +11,8 @@
   "type": "object",
   "meta:extensible": true,
   "meta:auditable": true,
-  "description": "An individual person. May represent a person acting in various roles, such as a customer, contact, or owner.",
+  "description":
+    "An individual person. May represent a person acting in various roles, such as a customer, contact, or owner.",
   "definitions": {
     "person": {
       "properties": {
@@ -37,19 +38,15 @@
         "xdm:birthYear": {
           "title": "Birth year",
           "type": "integer",
-          "description": "The year a person was born including the century (yyyy, e.g 1983).",
+          "description":
+            "The year a person was born including the century (yyyy, e.g 1983).",
           "minimum": 1,
           "maximum": 32767
         },
         "xdm:gender": {
           "title": "Gender",
           "type": "string",
-          "enum": [
-            "male",
-            "female",
-            "not_specified",
-            "non_specific"
-          ],
+          "enum": ["male", "female", "not_specified", "non_specific"],
           "meta:enum": {
             "male": "Male",
             "female": "Female",

--- a/schemas/context/phonenumber.schema.json
+++ b/schemas/context/phonenumber.schema.json
@@ -9,34 +9,29 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Phone Number",
   "type": "object",
-  "description":
-    "Information that allows the phone calling of a person. Typically an alphanumeric number, 1-222-333 4444 in North America, but can have a wide range of formats.",
+  "description": "Information that allows the phone calling of a person. Typically an alphanumeric number, 1-222-333 4444 in North America, but can have a wide range of formats.",
   "definitions": {
     "phonenumber": {
       "properties": {
         "xdm:primary": {
           "title": "Primary",
           "type": "boolean",
-          "description":
-            "Primary phone number indicator.\n\nUnlike for Address or EmailAddress, there can be multiple primary phone numbers; one per communication channel.\nThe communication channel is defined by the type:\n\n* `textMessaging`: type = `mobile`\n* `phone`: type = `home` | `work` | `unknown`\n* `fax`: type = `fax`\n"
+          "description": "Primary phone number indicator.\n\nUnlike for Address or EmailAddress, there can be multiple primary phone numbers; one per communication channel.\nThe communication channel is defined by the type:\n\n* `textMessaging`: type = `mobile`\n* `phone`: type = `home` | `work` | `unknown`\n* `fax`: type = `fax`\n"
         },
         "xdm:number": {
           "title": "Number",
           "type": "string",
-          "description":
-            "The phone number. Note the phone number is a string and may include meaningful characters such as brackets (), hyphens - or characters to indicate sub dialing identifiers like extensions x. E.g 1-353(0)18391111 or +613 9403600x1234."
+          "description": "The phone number. Note the phone number is a string and may include meaningful characters such as brackets (), hyphens - or characters to indicate sub dialing identifiers like extensions x. E.g 1-353(0)18391111 or +613 9403600x1234."
         },
         "xdm:extension": {
           "title": "Extension",
           "type": "string",
-          "description":
-            "The internal dialing number used to call from a private exchange, operator or switchboard."
+          "description": "The internal dialing number used to call from a private exchange, operator or switchboard."
         },
         "xdm:status": {
           "title": "Status",
           "type": "string",
-          "description":
-            "An indication as to the ability to use the phone number.",
+          "description": "An indication as to the ability to use the phone number.",
           "default": "active",
           "meta:enum": {
             "active": "Active",
@@ -53,8 +48,7 @@
         "xdm:validity": {
           "title": "Validity",
           "type": "string",
-          "description":
-            "A level of technical correctness of the phone number.",
+          "description": "A level of technical correctness of the phone number.",
           "meta:enum": {
             "consistent": "Consistent",
             "inconsistent": "Inconsistent",
@@ -72,5 +66,6 @@
     {
       "$ref": "https://ns.adobe.com/xdm/common/auditable#/definitions/auditlog"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/phonenumber.schema.json
+++ b/schemas/context/phonenumber.schema.json
@@ -9,29 +9,34 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Phone Number",
   "type": "object",
-  "description": "Information that allows the phone calling of a person. Typically an alphanumeric number, 1-222-333 4444 in North America, but can have a wide range of formats.",
+  "description":
+    "Information that allows the phone calling of a person. Typically an alphanumeric number, 1-222-333 4444 in North America, but can have a wide range of formats.",
   "definitions": {
     "phonenumber": {
       "properties": {
         "xdm:primary": {
           "title": "Primary",
           "type": "boolean",
-          "description": "Primary phone number indicator.\n\nUnlike for Address or EmailAddress, there can be multiple primary phone numbers; one per communication channel.\nThe communication channel is defined by the type:\n\n* `textMessaging`: type = `mobile`\n* `phone`: type = `home` | `work` | `unknown`\n* `fax`: type = `fax`\n"
+          "description":
+            "Primary phone number indicator.\n\nUnlike for Address or EmailAddress, there can be multiple primary phone numbers; one per communication channel.\nThe communication channel is defined by the type:\n\n* `textMessaging`: type = `mobile`\n* `phone`: type = `home` | `work` | `unknown`\n* `fax`: type = `fax`\n"
         },
         "xdm:number": {
           "title": "Number",
           "type": "string",
-          "description": "The phone number. Note the phone number is a string and may include meaningful characters such as brackets (), hyphens - or characters to indicate sub dialing identifiers like extensions x. E.g 1-353(0)18391111 or +613 9403600x1234."
+          "description":
+            "The phone number. Note the phone number is a string and may include meaningful characters such as brackets (), hyphens - or characters to indicate sub dialing identifiers like extensions x. E.g 1-353(0)18391111 or +613 9403600x1234."
         },
         "xdm:extension": {
           "title": "Extension",
           "type": "string",
-          "description": "The internal dialing number used to call from a private exchange, operator or switchboard."
+          "description":
+            "The internal dialing number used to call from a private exchange, operator or switchboard."
         },
         "xdm:status": {
           "title": "Status",
           "type": "string",
-          "description": "An indication as to the ability to use the phone number.",
+          "description":
+            "An indication as to the ability to use the phone number.",
           "default": "active",
           "meta:enum": {
             "active": "Active",
@@ -48,7 +53,8 @@
         "xdm:validity": {
           "title": "Validity",
           "type": "string",
-          "description": "A level of technical correctness of the phone number.",
+          "description":
+            "A level of technical correctness of the phone number.",
           "meta:enum": {
             "consistent": "Consistent",
             "inconsistent": "Inconsistent",

--- a/schemas/context/place.schema.json
+++ b/schemas/context/place.schema.json
@@ -37,7 +37,8 @@
         "schema:branchCode": {
           "title": "Location Code",
           "type": "string",
-          "description": "A short textual code (also called \"store code\") that uniquely identifies a place of business. The code is typically assigned by the parent Organization and used in structured URLs.\n\nFor example, in the URL `http://www.starbucks.co.uk/store-locator/etc/detail/3047` the code \"3047\" is a `branchCode` for a particular branch."
+          "description":
+            "A short textual code (also called \"store code\") that uniquely identifies a place of business. The code is typically assigned by the parent Organization and used in structured URLs.\n\nFor example, in the URL `http://www.starbucks.co.uk/store-locator/etc/detail/3047` the code \"3047\" is a `branchCode` for a particular branch."
         },
         "xdm:shape": {
           "title": "Geo Shape",
@@ -47,13 +48,15 @@
         "xdm:pointOfInterest": {
           "title": "Point of Interest",
           "$ref": "http://schema.org/GeoCoordinates",
-          "description": "The coordinates of the point of interest for this location."
+          "description":
+            "The coordinates of the point of interest for this location."
         },
         "xdm:containedInPlace": {
           "title": "Contained by Location",
           "type": "string",
           "format": "uri",
-          "description": "XDM URI of another `Place` that this place is contained in.\n\nThis property is based on `schema:containedInPlace`, but is using URI references instead of embedding the containing place."
+          "description":
+            "XDM URI of another `Place` that this place is contained in.\n\nThis property is based on `schema:containedInPlace`, but is using URI references instead of embedding the containing place."
         },
         "xdm:containsPlaces": {
           "title": "Contains Locations",
@@ -61,14 +64,14 @@
           "items": {
             "type": "string",
             "format": "uri",
-            "description": "The XDM URI of another `Place` that this place contains."
+            "description":
+              "The XDM URI of another `Place` that this place contains."
           },
-          "description": "An array of XDM URIs of other `Place` instances that this place is containing.\n\nThis property is based on `schema:containsPlace`, but is using URI references instead of embedding the containing place. In addition, it is an array, allowing one place to include multiple other places."
+          "description":
+            "An array of XDM URIs of other `Place` instances that this place is containing.\n\nThis property is based on `schema:containsPlace`, but is using URI references instead of embedding the containing place. In addition, it is an array, allowing one place to include multiple other places."
         }
       },
-      "required": [
-        "@id"
-      ]
+      "required": ["@id"]
     }
   },
   "allOf": [

--- a/schemas/context/place.schema.json
+++ b/schemas/context/place.schema.json
@@ -37,8 +37,7 @@
         "schema:branchCode": {
           "title": "Location Code",
           "type": "string",
-          "description":
-            "A short textual code (also called \"store code\") that uniquely identifies a place of business. The code is typically assigned by the parent Organization and used in structured URLs.\n\nFor example, in the URL `http://www.starbucks.co.uk/store-locator/etc/detail/3047` the code \"3047\" is a `branchCode` for a particular branch."
+          "description": "A short textual code (also called \"store code\") that uniquely identifies a place of business. The code is typically assigned by the parent Organization and used in structured URLs.\n\nFor example, in the URL `http://www.starbucks.co.uk/store-locator/etc/detail/3047` the code \"3047\" is a `branchCode` for a particular branch."
         },
         "xdm:shape": {
           "title": "Geo Shape",
@@ -48,15 +47,13 @@
         "xdm:pointOfInterest": {
           "title": "Point of Interest",
           "$ref": "http://schema.org/GeoCoordinates",
-          "description":
-            "The coordinates of the point of interest for this location."
+          "description": "The coordinates of the point of interest for this location."
         },
         "xdm:containedInPlace": {
           "title": "Contained by Location",
           "type": "string",
           "format": "uri",
-          "description":
-            "XDM URI of another `Place` that this place is contained in.\n\nThis property is based on `schema:containedInPlace`, but is using URI references instead of embedding the containing place."
+          "description": "XDM URI of another `Place` that this place is contained in.\n\nThis property is based on `schema:containedInPlace`, but is using URI references instead of embedding the containing place."
         },
         "xdm:containsPlaces": {
           "title": "Contains Locations",
@@ -64,14 +61,14 @@
           "items": {
             "type": "string",
             "format": "uri",
-            "description":
-              "The XDM URI of another `Place` that this place contains."
+            "description": "The XDM URI of another `Place` that this place contains."
           },
-          "description":
-            "An array of XDM URIs of other `Place` instances that this place is containing.\n\nThis property is based on `schema:containsPlace`, but is using URI references instead of embedding the containing place. In addition, it is an array, allowing one place to include multiple other places."
+          "description": "An array of XDM URIs of other `Place` instances that this place is containing.\n\nThis property is based on `schema:containsPlace`, but is using URI references instead of embedding the containing place. In addition, it is an array, allowing one place to include multiple other places."
         }
       },
-      "required": ["@id"]
+      "required": [
+        "@id"
+      ]
     }
   },
   "allOf": [
@@ -81,5 +78,6 @@
     {
       "$ref": "#/definitions/physicallocation"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/profile.schema.json
+++ b/schemas/context/profile.schema.json
@@ -10,7 +10,8 @@
   "title": "Profile",
   "type": "object",
   "auditable": true,
-  "description": "XDM Profiles are a singular representation of the attributes of identified and\npartially identified persons. Profiles that are highly identified maybe used for\npersonal communications or highly targeted engagements and can contain detailed\npersonal information such as names, gender, date of birth, locations, and contact\ninformation like phone numbers and email addresses. Profiles may range to the\nother end of the identification spectrum where only anonymous behavioral signals\nare being observed and the amount of identification is simple browser cookies.\nIn this latter case, the sparse Profile data is useful to build more knowledge\non the interests and preferences of the anonymous profile, and over time can\nbecome richer as the person interacting with brand becomes more engaged and\nultimately signs-on to notifications, subscriptions, purchases and other\nconnections with the brand that enrich and fill out the profile.\n\nXDM Profile can contain personal information, identification information, contact\ndetails and communication preferences. Over time XDM Profile will expand to cater\nfor other Profile data such as preference, propensities and other attributes.\n\n",
+  "description":
+    "XDM Profiles are a singular representation of the attributes of identified and\npartially identified persons. Profiles that are highly identified maybe used for\npersonal communications or highly targeted engagements and can contain detailed\npersonal information such as names, gender, date of birth, locations, and contact\ninformation like phone numbers and email addresses. Profiles may range to the\nother end of the identification spectrum where only anonymous behavioral signals\nare being observed and the amount of identification is simple browser cookies.\nIn this latter case, the sparse Profile data is useful to build more knowledge\non the interests and preferences of the anonymous profile, and over time can\nbecome richer as the person interacting with brand becomes more engaged and\nultimately signs-on to notifications, subscriptions, purchases and other\nconnections with the brand that enrich and fill out the profile.\n\nXDM Profile can contain personal information, identification information, contact\ndetails and communication preferences. Over time XDM Profile will expand to cater\nfor other Profile data such as preference, propensities and other attributes.\n\n",
   "definitions": {
     "profile": {
       "properties": {
@@ -21,7 +22,8 @@
             "$ref": "https://ns.adobe.com/xdm/context/identity"
           },
           "minItems": 1,
-          "description": "Array of Identities. Condensed, normalized encapsulation of all end user identifiers."
+          "description":
+            "Array of Identities. Condensed, normalized encapsulation of all end user identifiers."
         },
         "xdm:person": {
           "title": "Person",
@@ -66,12 +68,14 @@
         "xdm:optInOut": {
           "title": "OptInOut",
           "$ref": "https://ns.adobe.com/xdm/context/optinout",
-          "description": "Describes a users opting in and out preferences for communication by medium\nand communication type.\n"
+          "description":
+            "Describes a users opting in and out preferences for communication by medium\nand communication type.\n"
         },
         "xdm:pushNotificationTokens": {
           "title": "Push Notification Tokens",
           "type": "array",
-          "description": "Push notification tokens are used to communicate with applications that\nare installed on devices or SaaS application accounts.\n",
+          "description":
+            "Push notification tokens are used to communicate with applications that\nare installed on devices or SaaS application accounts.\n",
           "items": {
             "$ref": "https://ns.adobe.com/xdm/context/pushnotificationtoken"
           }
@@ -79,12 +83,14 @@
         "xdm:orgUnitID": {
           "title": "Organizational Unit Identifier",
           "type": "string",
-          "description": "The unit ID within the organization owning the profile. This ID can be used to reference the organization details maintained in another dataset."
+          "description":
+            "The unit ID within the organization owning the profile. This ID can be used to reference the organization details maintained in another dataset."
         },
         "xdm:geoUnitID": {
           "title": "Geographical Unit Identifier",
           "type": "string",
-          "description": "The geographical unit ID within the organization owning the profile. This ID can be used to reference the geographical information maintained in another dataset."
+          "description":
+            "The geographical unit ID within the organization owning the profile. This ID can be used to reference the geographical information maintained in another dataset."
         },
         "xdm:organizations": {
           "title": "Organizations",
@@ -96,7 +102,8 @@
         "xdm:subscriptions": {
           "title": "Subscriptions",
           "type": "array",
-          "description": "Subscriptions that this profile is entitled to including terminated, expired or exhausted subscriptions.",
+          "description":
+            "Subscriptions that this profile is entitled to including terminated, expired or exhausted subscriptions.",
           "items": {
             "$ref": "https://ns.adobe.com/xdm/context/subscription"
           }

--- a/schemas/context/profile.schema.json
+++ b/schemas/context/profile.schema.json
@@ -10,8 +10,7 @@
   "title": "Profile",
   "type": "object",
   "auditable": true,
-  "description":
-    "XDM Profiles are a singular representation of the attributes of identified and\npartially identified persons. Profiles that are highly identified maybe used for\npersonal communications or highly targeted engagements and can contain detailed\npersonal information such as names, gender, date of birth, locations, and contact\ninformation like phone numbers and email addresses. Profiles may range to the\nother end of the identification spectrum where only anonymous behavioral signals\nare being observed and the amount of identification is simple browser cookies.\nIn this latter case, the sparse Profile data is useful to build more knowledge\non the interests and preferences of the anonymous profile, and over time can\nbecome richer as the person interacting with brand becomes more engaged and\nultimately signs-on to notifications, subscriptions, purchases and other\nconnections with the brand that enrich and fill out the profile.\n\nXDM Profile can contain personal information, identification information, contact\ndetails and communication preferences. Over time XDM Profile will expand to cater\nfor other Profile data such as preference, propensities and other attributes.\n\n",
+  "description": "XDM Profiles are a singular representation of the attributes of identified and\npartially identified persons. Profiles that are highly identified maybe used for\npersonal communications or highly targeted engagements and can contain detailed\npersonal information such as names, gender, date of birth, locations, and contact\ninformation like phone numbers and email addresses. Profiles may range to the\nother end of the identification spectrum where only anonymous behavioral signals\nare being observed and the amount of identification is simple browser cookies.\nIn this latter case, the sparse Profile data is useful to build more knowledge\non the interests and preferences of the anonymous profile, and over time can\nbecome richer as the person interacting with brand becomes more engaged and\nultimately signs-on to notifications, subscriptions, purchases and other\nconnections with the brand that enrich and fill out the profile.\n\nXDM Profile can contain personal information, identification information, contact\ndetails and communication preferences. Over time XDM Profile will expand to cater\nfor other Profile data such as preference, propensities and other attributes.\n\n",
   "definitions": {
     "profile": {
       "properties": {
@@ -22,8 +21,7 @@
             "$ref": "https://ns.adobe.com/xdm/context/identity"
           },
           "minItems": 1,
-          "description":
-            "Array of Identities. Condensed, normalized encapsulation of all end user identifiers."
+          "description": "Array of Identities. Condensed, normalized encapsulation of all end user identifiers."
         },
         "xdm:person": {
           "title": "Person",
@@ -68,14 +66,12 @@
         "xdm:optInOut": {
           "title": "OptInOut",
           "$ref": "https://ns.adobe.com/xdm/context/optinout",
-          "description":
-            "Describes a users opting in and out preferences for communication by medium\nand communication type.\n"
+          "description": "Describes a users opting in and out preferences for communication by medium\nand communication type.\n"
         },
         "xdm:pushNotificationTokens": {
           "title": "Push Notification Tokens",
           "type": "array",
-          "description":
-            "Push notification tokens are used to communicate with applications that\nare installed on devices or SaaS application accounts.\n",
+          "description": "Push notification tokens are used to communicate with applications that\nare installed on devices or SaaS application accounts.\n",
           "items": {
             "$ref": "https://ns.adobe.com/xdm/context/pushnotificationtoken"
           }
@@ -83,14 +79,12 @@
         "xdm:orgUnitID": {
           "title": "Organizational Unit Identifier",
           "type": "string",
-          "description":
-            "The unit ID within the organization owning the profile. This ID can be used to reference the organization details maintained in another dataset."
+          "description": "The unit ID within the organization owning the profile. This ID can be used to reference the organization details maintained in another dataset."
         },
         "xdm:geoUnitID": {
           "title": "Geographical Unit Identifier",
           "type": "string",
-          "description":
-            "The geographical unit ID within the organization owning the profile. This ID can be used to reference the geographical information maintained in another dataset."
+          "description": "The geographical unit ID within the organization owning the profile. This ID can be used to reference the geographical information maintained in another dataset."
         },
         "xdm:organizations": {
           "title": "Organizations",
@@ -102,8 +96,7 @@
         "xdm:subscriptions": {
           "title": "Subscriptions",
           "type": "array",
-          "description":
-            "Subscriptions that this profile is entitled to including terminated, expired or exhausted subscriptions.",
+          "description": "Subscriptions that this profile is entitled to including terminated, expired or exhausted subscriptions.",
           "items": {
             "$ref": "https://ns.adobe.com/xdm/context/subscription"
           }
@@ -121,5 +114,6 @@
     {
       "$ref": "#/definitions/profile"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/pushnotificationtoken.schema.json
+++ b/schemas/context/pushnotificationtoken.schema.json
@@ -9,26 +9,30 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Push Notification Token",
   "type": "object",
-  "description": "Push notification tokens are used to communicate with applications that\nare installed on devices or SaaS application accounts. Examples include mobile\napplication notifications over notification services like the Apple Push\nNotification service.\n",
+  "description":
+    "Push notification tokens are used to communicate with applications that\nare installed on devices or SaaS application accounts. Examples include mobile\napplication notifications over notification services like the Apple Push\nNotification service.\n",
   "definitions": {
     "pushnotificationtoken": {
       "properties": {
         "xdm:token": {
           "title": "Token",
           "type": "string",
-          "description": "The service specific token used to address the application for\ncommunication. e.g an Apple APN ID or a Google GCM ID.\n"
+          "description":
+            "The service specific token used to address the application for\ncommunication. e.g an Apple APN ID or a Google GCM ID.\n"
         },
         "xdm:registrationDate": {
           "title": "Registration Date",
           "type": "string",
           "format": "date-time",
-          "description": "Date and time when the profile has authorized its application to receive\npush notifications.\n"
+          "description":
+            "Date and time when the profile has authorized its application to receive\npush notifications.\n"
         },
         "xdm:deregistrationDate": {
           "title": "Deregistration Date",
           "type": "string",
           "format": "date-time",
-          "description": "Date and time when the profile has disabled push notifications on the application.\n"
+          "description":
+            "Date and time when the profile has disabled push notifications on the application.\n"
         },
         "xdm:environment": {
           "title": "Environment",
@@ -43,7 +47,8 @@
         "xdm:application": {
           "title": "Application",
           "$ref": "https://ns.adobe.com/xdm/channels/application",
-          "description": "Application registered to receive Push Notifications.\n"
+          "description":
+            "Application registered to receive Push Notifications.\n"
         },
         "xdm:channel": {
           "title": "Communication Channel",

--- a/schemas/context/pushnotificationtoken.schema.json
+++ b/schemas/context/pushnotificationtoken.schema.json
@@ -9,30 +9,26 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Push Notification Token",
   "type": "object",
-  "description":
-    "Push notification tokens are used to communicate with applications that\nare installed on devices or SaaS application accounts. Examples include mobile\napplication notifications over notification services like the Apple Push\nNotification service.\n",
+  "description": "Push notification tokens are used to communicate with applications that\nare installed on devices or SaaS application accounts. Examples include mobile\napplication notifications over notification services like the Apple Push\nNotification service.\n",
   "definitions": {
     "pushnotificationtoken": {
       "properties": {
         "xdm:token": {
           "title": "Token",
           "type": "string",
-          "description":
-            "The service specific token used to address the application for\ncommunication. e.g an Apple APN ID or a Google GCM ID.\n"
+          "description": "The service specific token used to address the application for\ncommunication. e.g an Apple APN ID or a Google GCM ID.\n"
         },
         "xdm:registrationDate": {
           "title": "Registration Date",
           "type": "string",
           "format": "date-time",
-          "description":
-            "Date and time when the profile has authorized its application to receive\npush notifications.\n"
+          "description": "Date and time when the profile has authorized its application to receive\npush notifications.\n"
         },
         "xdm:deregistrationDate": {
           "title": "Deregistration Date",
           "type": "string",
           "format": "date-time",
-          "description":
-            "Date and time when the profile has disabled push notifications on the application.\n"
+          "description": "Date and time when the profile has disabled push notifications on the application.\n"
         },
         "xdm:environment": {
           "title": "Environment",
@@ -47,8 +43,7 @@
         "xdm:application": {
           "title": "Application",
           "$ref": "https://ns.adobe.com/xdm/channels/application",
-          "description":
-            "Application registered to receive Push Notifications.\n"
+          "description": "Application registered to receive Push Notifications.\n"
         },
         "xdm:channel": {
           "title": "Communication Channel",
@@ -62,5 +57,6 @@
     {
       "$ref": "#/definitions/pushnotificationtoken"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/search.schema.json
+++ b/schemas/context/search.schema.json
@@ -40,5 +40,6 @@
     {
       "$ref": "#/definitions/search"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/subscription.schema.json
+++ b/schemas/context/subscription.schema.json
@@ -9,7 +9,8 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Subscription",
   "type": "object",
-  "description": "Subscriptions are licensed entitlements to software, services or goods that are utilized in a time or usage based way.",
+  "description":
+    "Subscriptions are licensed entitlements to software, services or goods that are utilized in a time or usage based way.",
   "definitions": {
     "subscription": {
       "properties": {
@@ -31,12 +32,14 @@
         "xdm:environment": {
           "title": "Environment",
           "$ref": "https://ns.adobe.com/xdm/context/environment",
-          "description": "Environment of the subscription.\n\nThis can be either then known environment at the time of the subscription\nor the environment of the application for subscriptions related to an\nApplication.\n"
+          "description":
+            "Environment of the subscription.\n\nThis can be either then known environment at the time of the subscription\nor the environment of the application for subscriptions related to an\nApplication.\n"
         },
         "xdm:SKU": {
           "title": "SKU",
           "type": "string",
-          "description": "Stock Keeping Unit, a generally unique identifier for a product."
+          "description":
+            "Stock Keeping Unit, a generally unique identifier for a product."
         },
         "xdm:planName": {
           "title": "Plan Name",
@@ -46,12 +49,14 @@
         "xdm:type": {
           "title": "Type",
           "type": "string",
-          "description": "The scope of entitlement in relation to how many people are covered by the subscription."
+          "description":
+            "The scope of entitlement in relation to how many people are covered by the subscription."
         },
         "xdm:country": {
           "title": "Country",
           "type": "string",
-          "description": "The country that the subscription contractual/agreement terms are rooted in."
+          "description":
+            "The country that the subscription contractual/agreement terms are rooted in."
         },
         "xdm:startDate": {
           "title": "Start Date",
@@ -78,12 +83,14 @@
         "xdm:renew": {
           "title": "Renew",
           "type": "string",
-          "description": "The agreed way that the subscription may continue after the end date."
+          "description":
+            "The agreed way that the subscription may continue after the end date."
         },
         "xdm:topUp": {
           "title": "Top Up",
           "type": "string",
-          "description": "Agreed terms for how consumable aspects of a subscription are repurchased during a billing period."
+          "description":
+            "Agreed terms for how consumable aspects of a subscription are repurchased during a billing period."
         },
         "xdm:status": {
           "title": "Status",
@@ -93,7 +100,8 @@
         "xdm:contractID": {
           "title": "Contract ID",
           "type": "string",
-          "description": "Unique ID for the contract that governs this subscription."
+          "description":
+            "Unique ID for the contract that governs this subscription."
         },
         "xdm:paymentMethod": {
           "title": "Payment Method",
@@ -124,7 +132,8 @@
         "xdm:category": {
           "title": "Category",
           "type": "string",
-          "description": "The main, top level categorization of this type of subscription."
+          "description":
+            "The main, top level categorization of this type of subscription."
         },
         "xdm:subCategory": {
           "title": "Sub Category",
@@ -134,12 +143,14 @@
         "xdm:revision": {
           "title": "Revision",
           "type": "string",
-          "description": "The identification between subscriptions of the same name and category hierarchy."
+          "description":
+            "The identification between subscriptions of the same name and category hierarchy."
         },
         "xdm:reason": {
           "title": "Reason",
           "type": "string",
-          "description": "The general intent the member has for the use of the subscription."
+          "description":
+            "The general intent the member has for the use of the subscription."
         }
       }
     }

--- a/schemas/context/subscription.schema.json
+++ b/schemas/context/subscription.schema.json
@@ -9,8 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Subscription",
   "type": "object",
-  "description":
-    "Subscriptions are licensed entitlements to software, services or goods that are utilized in a time or usage based way.",
+  "description": "Subscriptions are licensed entitlements to software, services or goods that are utilized in a time or usage based way.",
   "definitions": {
     "subscription": {
       "properties": {
@@ -32,14 +31,12 @@
         "xdm:environment": {
           "title": "Environment",
           "$ref": "https://ns.adobe.com/xdm/context/environment",
-          "description":
-            "Environment of the subscription.\n\nThis can be either then known environment at the time of the subscription\nor the environment of the application for subscriptions related to an\nApplication.\n"
+          "description": "Environment of the subscription.\n\nThis can be either then known environment at the time of the subscription\nor the environment of the application for subscriptions related to an\nApplication.\n"
         },
         "xdm:SKU": {
           "title": "SKU",
           "type": "string",
-          "description":
-            "Stock Keeping Unit, a generally unique identifier for a product."
+          "description": "Stock Keeping Unit, a generally unique identifier for a product."
         },
         "xdm:planName": {
           "title": "Plan Name",
@@ -49,14 +46,12 @@
         "xdm:type": {
           "title": "Type",
           "type": "string",
-          "description":
-            "The scope of entitlement in relation to how many people are covered by the subscription."
+          "description": "The scope of entitlement in relation to how many people are covered by the subscription."
         },
         "xdm:country": {
           "title": "Country",
           "type": "string",
-          "description":
-            "The country that the subscription contractual/agreement terms are rooted in."
+          "description": "The country that the subscription contractual/agreement terms are rooted in."
         },
         "xdm:startDate": {
           "title": "Start Date",
@@ -83,14 +78,12 @@
         "xdm:renew": {
           "title": "Renew",
           "type": "string",
-          "description":
-            "The agreed way that the subscription may continue after the end date."
+          "description": "The agreed way that the subscription may continue after the end date."
         },
         "xdm:topUp": {
           "title": "Top Up",
           "type": "string",
-          "description":
-            "Agreed terms for how consumable aspects of a subscription are repurchased during a billing period."
+          "description": "Agreed terms for how consumable aspects of a subscription are repurchased during a billing period."
         },
         "xdm:status": {
           "title": "Status",
@@ -100,8 +93,7 @@
         "xdm:contractID": {
           "title": "Contract ID",
           "type": "string",
-          "description":
-            "Unique ID for the contract that governs this subscription."
+          "description": "Unique ID for the contract that governs this subscription."
         },
         "xdm:paymentMethod": {
           "title": "Payment Method",
@@ -132,8 +124,7 @@
         "xdm:category": {
           "title": "Category",
           "type": "string",
-          "description":
-            "The main, top level categorization of this type of subscription."
+          "description": "The main, top level categorization of this type of subscription."
         },
         "xdm:subCategory": {
           "title": "Sub Category",
@@ -143,14 +134,12 @@
         "xdm:revision": {
           "title": "Revision",
           "type": "string",
-          "description":
-            "The identification between subscriptions of the same name and category hierarchy."
+          "description": "The identification between subscriptions of the same name and category hierarchy."
         },
         "xdm:reason": {
           "title": "Reason",
           "type": "string",
-          "description":
-            "The general intent the member has for the use of the subscription."
+          "description": "The general intent the member has for the use of the subscription."
         }
       }
     }
@@ -159,5 +148,6 @@
     {
       "$ref": "#/definitions/subscription"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/weblink.schema.json
+++ b/schemas/context/weblink.schema.json
@@ -17,7 +17,11 @@
           "title": "Type",
           "type": "string",
           "description": "The link type.",
-          "enum": ["download", "exit", "other"],
+          "enum": [
+            "download",
+            "exit",
+            "other"
+          ],
           "meta:enum": {
             "download": "Download",
             "exit": "Exit",
@@ -41,5 +45,6 @@
     {
       "$ref": "#/definitions/weblink"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/weblink.schema.json
+++ b/schemas/context/weblink.schema.json
@@ -17,11 +17,7 @@
           "title": "Type",
           "type": "string",
           "description": "The link type.",
-          "enum": [
-            "download",
-            "exit",
-            "other"
-          ],
+          "enum": ["download", "exit", "other"],
           "meta:enum": {
             "download": "Download",
             "exit": "Exit",

--- a/schemas/data/abandons.schema.json
+++ b/schemas/data/abandons.schema.json
@@ -10,9 +10,10 @@
   "title": "abandons",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "Number of abandons for which a product list has been identified as no longer purchasable or accessible by the user without the user re-creating the product list from scratch.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "Number of abandons for which a product list has been identified as no longer purchasable or accessible by the user without the user re-creating the product list from scratch.",
   "definitions": {
     "metric": {
       "properties": {
@@ -25,8 +26,7 @@
         "schema:name": {
           "type": "string",
           "const": "commerce metric: abandons",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/abandons.schema.json
+++ b/schemas/data/abandons.schema.json
@@ -10,10 +10,9 @@
   "title": "abandons",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "Number of abandons for which a product list has been identified as no longer purchasable or accessible by the user without the user re-creating the product list from scratch.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "Number of abandons for which a product list has been identified as no longer purchasable or accessible by the user without the user re-creating the product list from scratch.",
   "definitions": {
     "metric": {
       "properties": {
@@ -26,7 +25,8 @@
         "schema:name": {
           "type": "string",
           "const": "commerce metric: abandons",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +44,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/bounces.schema.json
+++ b/schemas/data/bounces.schema.json
@@ -10,24 +10,23 @@
   "title": "bounces",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "The direct-marketing metric bounces describes the number of asynchronous messages that have been rejected by the receiving system.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "The direct-marketing metric bounces describes the number of asynchronous messages that have been rejected by the receiving system.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const":
-            "https://ns.adobe.com/xdm/data/metrics/direct-marketing/bounces",
+          "const": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/bounces",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "direct-marketing metric: bounces",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -45,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/bounces.schema.json
+++ b/schemas/data/bounces.schema.json
@@ -10,23 +10,24 @@
   "title": "bounces",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "The direct-marketing metric bounces describes the number of asynchronous messages that have been rejected by the receiving system.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "The direct-marketing metric bounces describes the number of asynchronous messages that have been rejected by the receiving system.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/bounces",
+          "const":
+            "https://ns.adobe.com/xdm/data/metrics/direct-marketing/bounces",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "direct-marketing metric: bounces",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +45,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/checkouts.schema.json
+++ b/schemas/data/checkouts.schema.json
@@ -10,10 +10,9 @@
   "title": "checkouts",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "Number of actions during a checkout process of a product list, there can be more than one checkout event if there are multiple steps in a checkout process. If there are multiple steps the event time information and referenced page or experience is used to identify the step individual events represent in order.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "Number of actions during a checkout process of a product list, there can be more than one checkout event if there are multiple steps in a checkout process. If there are multiple steps the event time information and referenced page or experience is used to identify the step individual events represent in order.",
   "definitions": {
     "metric": {
       "properties": {
@@ -26,7 +25,8 @@
         "schema:name": {
           "type": "string",
           "const": "commerce metric: checkouts",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +44,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/checkouts.schema.json
+++ b/schemas/data/checkouts.schema.json
@@ -10,9 +10,10 @@
   "title": "checkouts",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "Number of actions during a checkout process of a product list, there can be more than one checkout event if there are multiple steps in a checkout process. If there are multiple steps the event time information and referenced page or experience is used to identify the step individual events represent in order.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "Number of actions during a checkout process of a product list, there can be more than one checkout event if there are multiple steps in a checkout process. If there are multiple steps the event time information and referenced page or experience is used to identify the step individual events represent in order.",
   "definitions": {
     "metric": {
       "properties": {
@@ -25,8 +26,7 @@
         "schema:name": {
           "type": "string",
           "const": "commerce metric: checkouts",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/clicks.schema.json
+++ b/schemas/data/clicks.schema.json
@@ -10,7 +10,9 @@
   "title": "clicks",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
   "description": "The advertising metric clicks describes…",
   "definitions": {
     "metric": {
@@ -24,8 +26,7 @@
         "schema:name": {
           "type": "string",
           "const": "advertising metric: clicks",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -43,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/clicks.schema.json
+++ b/schemas/data/clicks.schema.json
@@ -10,9 +10,7 @@
   "title": "clicks",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
   "description": "The advertising metric clicks describes…",
   "definitions": {
     "metric": {
@@ -26,7 +24,8 @@
         "schema:name": {
           "type": "string",
           "const": "advertising metric: clicks",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +43,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/datasource.schema.json
+++ b/schemas/data/datasource.schema.json
@@ -9,8 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Data Source",
   "type": "object",
-  "description":
-    "The Datasource acts as a namespace or unique identifier associated with a collection of data. Each EndUserID is associated with a given Datasource. A user can create and obtain information about a Datasource during the solution onboarding.\n",
+  "description": "The Datasource acts as a namespace or unique identifier associated with a collection of data. Each EndUserID is associated with a given Datasource. A user can create and obtain information about a Datasource during the solution onboarding.\n",
   "definitions": {
     "datasource": {
       "properties": {
@@ -18,8 +17,7 @@
           "title": "Identifier",
           "type": "string",
           "format": "uri",
-          "description":
-            "The unique ID of this data source. This would be provided by the individual or system that created the Datasource.\n"
+          "description": "The unique ID of this data source. This would be provided by the individual or system that created the Datasource.\n"
         },
         "xdm:name": {
           "title": "Name",
@@ -29,20 +27,22 @@
         "xdm:tags": {
           "title": "Tags",
           "type": "array",
-          "description":
-            "Tags are used to indicate how the aliases represented by a given data\nsource should be interpreted by applications using those aliases.\n\nExamples:\n\n* `isAVID`: data sources representing Analytics visitor IDs.\n* `isCRSKey`: data sources representing aliases that should be used as keys in CRS.\n\nTags are set when the data source is created but they are also included in\npipeline messages when referencing a given data source.\n",
+          "description": "Tags are used to indicate how the aliases represented by a given data\nsource should be interpreted by applications using those aliases.\n\nExamples:\n\n* `isAVID`: data sources representing Analytics visitor IDs.\n* `isCRSKey`: data sources representing aliases that should be used as keys in CRS.\n\nTags are set when the data source is created but they are also included in\npipeline messages when referencing a given data source.\n",
           "uniqueItems": true,
           "items": {
             "type": "string"
           }
         }
       },
-      "required": ["@id"]
+      "required": [
+        "@id"
+      ]
     }
   },
   "allOf": [
     {
       "$ref": "#/definitions/datasource"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/datasource.schema.json
+++ b/schemas/data/datasource.schema.json
@@ -9,7 +9,8 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Data Source",
   "type": "object",
-  "description": "The Datasource acts as a namespace or unique identifier associated with a collection of data. Each EndUserID is associated with a given Datasource. A user can create and obtain information about a Datasource during the solution onboarding.\n",
+  "description":
+    "The Datasource acts as a namespace or unique identifier associated with a collection of data. Each EndUserID is associated with a given Datasource. A user can create and obtain information about a Datasource during the solution onboarding.\n",
   "definitions": {
     "datasource": {
       "properties": {
@@ -17,7 +18,8 @@
           "title": "Identifier",
           "type": "string",
           "format": "uri",
-          "description": "The unique ID of this data source. This would be provided by the individual or system that created the Datasource.\n"
+          "description":
+            "The unique ID of this data source. This would be provided by the individual or system that created the Datasource.\n"
         },
         "xdm:name": {
           "title": "Name",
@@ -27,16 +29,15 @@
         "xdm:tags": {
           "title": "Tags",
           "type": "array",
-          "description": "Tags are used to indicate how the aliases represented by a given data\nsource should be interpreted by applications using those aliases.\n\nExamples:\n\n* `isAVID`: data sources representing Analytics visitor IDs.\n* `isCRSKey`: data sources representing aliases that should be used as keys in CRS.\n\nTags are set when the data source is created but they are also included in\npipeline messages when referencing a given data source.\n",
+          "description":
+            "Tags are used to indicate how the aliases represented by a given data\nsource should be interpreted by applications using those aliases.\n\nExamples:\n\n* `isAVID`: data sources representing Analytics visitor IDs.\n* `isCRSKey`: data sources representing aliases that should be used as keys in CRS.\n\nTags are set when the data source is created but they are also included in\npipeline messages when referencing a given data source.\n",
           "uniqueItems": true,
           "items": {
             "type": "string"
           }
         }
       },
-      "required": [
-        "@id"
-      ]
+      "required": ["@id"]
     }
   },
   "allOf": [

--- a/schemas/data/discount.schema.json
+++ b/schemas/data/discount.schema.json
@@ -9,7 +9,8 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Discount",
   "type": "object",
-  "description": "This is an offer from the supplier to the purchaser, to reduce the payment amount if the payment is made within a certain period of time.",
+  "description":
+    "This is an offer from the supplier to the purchaser, to reduce the payment amount if the payment is made within a certain period of time.",
   "definitions": {
     "discount": {
       "properties": {
@@ -21,13 +22,15 @@
         "xdm:code": {
           "title": "Code",
           "type": "string",
-          "description": "The description of the discountValue attribute. e.g percentage, currency, 3for2 etc. Can be enumerated, custom values allowed.",
+          "description":
+            "The description of the discountValue attribute. e.g percentage, currency, 3for2 etc. Can be enumerated, custom values allowed.",
           "meta:enum": {
             "bogo": "Buy one, get one free",
             "bogoho": "Buy one, get one half off",
             "3for2": "Three for the price of two",
             "3fixed": "Any three items for a fixed price",
-            "voucher": "Save `xdm:value` when you spend more than `xdm:condition`",
+            "voucher":
+              "Save `xdm:value` when you spend more than `xdm:condition`",
             "fixed": "Fixed amount off",
             "percentage": "Percentage amount off",
             "shipping": "Free shipping"
@@ -36,11 +39,13 @@
         "xdm:value": {
           "title": "Value",
           "type": "number",
-          "description": "If the discount description indicates a percentage or similar formulaic value, it is represented here, can be percentage or currency amount."
+          "description":
+            "If the discount description indicates a percentage or similar formulaic value, it is represented here, can be percentage or currency amount."
         },
         "xdm:condition": {
           "title": "Condition",
-          "description": "The minimum amount of items or price for the dicount to qualify"
+          "description":
+            "The minimum amount of items or price for the dicount to qualify"
         }
       }
     }
@@ -50,8 +55,6 @@
       "$ref": "#/definitions/discount"
     }
   ],
-  "required": [
-    "xdm:code"
-  ],
+  "required": ["xdm:code"],
   "meta:status": "experimental"
 }

--- a/schemas/data/discount.schema.json
+++ b/schemas/data/discount.schema.json
@@ -9,8 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Discount",
   "type": "object",
-  "description":
-    "This is an offer from the supplier to the purchaser, to reduce the payment amount if the payment is made within a certain period of time.",
+  "description": "This is an offer from the supplier to the purchaser, to reduce the payment amount if the payment is made within a certain period of time.",
   "definitions": {
     "discount": {
       "properties": {
@@ -22,15 +21,13 @@
         "xdm:code": {
           "title": "Code",
           "type": "string",
-          "description":
-            "The description of the discountValue attribute. e.g percentage, currency, 3for2 etc. Can be enumerated, custom values allowed.",
+          "description": "The description of the discountValue attribute. e.g percentage, currency, 3for2 etc. Can be enumerated, custom values allowed.",
           "meta:enum": {
             "bogo": "Buy one, get one free",
             "bogoho": "Buy one, get one half off",
             "3for2": "Three for the price of two",
             "3fixed": "Any three items for a fixed price",
-            "voucher":
-              "Save `xdm:value` when you spend more than `xdm:condition`",
+            "voucher": "Save `xdm:value` when you spend more than `xdm:condition`",
             "fixed": "Fixed amount off",
             "percentage": "Percentage amount off",
             "shipping": "Free shipping"
@@ -39,13 +36,11 @@
         "xdm:value": {
           "title": "Value",
           "type": "number",
-          "description":
-            "If the discount description indicates a percentage or similar formulaic value, it is represented here, can be percentage or currency amount."
+          "description": "If the discount description indicates a percentage or similar formulaic value, it is represented here, can be percentage or currency amount."
         },
         "xdm:condition": {
           "title": "Condition",
-          "description":
-            "The minimum amount of items or price for the dicount to qualify"
+          "description": "The minimum amount of items or price for the dicount to qualify"
         }
       }
     }
@@ -55,5 +50,8 @@
       "$ref": "#/definitions/discount"
     }
   ],
-  "required": ["xdm:code"]
+  "required": [
+    "xdm:code"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/impressions.schema.json
+++ b/schemas/data/impressions.schema.json
@@ -10,7 +10,9 @@
   "title": "impressions",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
   "description": "The advertising metric impressions describes…",
   "definitions": {
     "metric": {
@@ -18,15 +20,13 @@
         "@id": {
           "type": "string",
           "format": "uri",
-          "const":
-            "https://ns.adobe.com/xdm/data/metrics/advertising/impressions",
+          "const": "https://ns.adobe.com/xdm/data/metrics/advertising/impressions",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "advertising metric: impressions",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/impressions.schema.json
+++ b/schemas/data/impressions.schema.json
@@ -10,9 +10,7 @@
   "title": "impressions",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
   "description": "The advertising metric impressions describes…",
   "definitions": {
     "metric": {
@@ -20,13 +18,15 @@
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/data/metrics/advertising/impressions",
+          "const":
+            "https://ns.adobe.com/xdm/data/metrics/advertising/impressions",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "advertising metric: impressions",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +44,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/link-clicks.schema.json
+++ b/schemas/data/link-clicks.schema.json
@@ -10,10 +10,9 @@
   "title": "link-clicks",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "The web metric link-clicks describes the number of clicks on a link on a web page.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "The web metric link-clicks describes the number of clicks on a link on a web page.",
   "definitions": {
     "metric": {
       "properties": {
@@ -26,7 +25,8 @@
         "schema:name": {
           "type": "string",
           "const": "web metric: link-clicks",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +44,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/link-clicks.schema.json
+++ b/schemas/data/link-clicks.schema.json
@@ -10,9 +10,10 @@
   "title": "link-clicks",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "The web metric link-clicks describes the number of clicks on a link on a web page.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "The web metric link-clicks describes the number of clicks on a link on a web page.",
   "definitions": {
     "metric": {
       "properties": {
@@ -25,8 +26,7 @@
         "schema:name": {
           "type": "string",
           "const": "web metric: link-clicks",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/measure.schema.json
+++ b/schemas/data/measure.schema.json
@@ -17,15 +17,13 @@
         "@type": {
           "type": "string",
           "format": "uri",
-          "description":
-            "Links to the `Metric` that this measure refers to. The `@type` can be omitted in contexts where it is obvious what metric is being referred to, for instance in the `Metrics` object that is keyed with `Metric` URIs."
+          "description": "Links to the `Metric` that this measure refers to. The `@type` can be omitted in contexts where it is obvious what metric is being referred to, for instance in the `Metrics` object that is keyed with `Metric` URIs."
         },
         "xdm:id": {
           "title": "Unique Identifier",
           "type": "string",
           "minLength": 20,
-          "description":
-            "Unique identifier of the measure. In cases of data collection using lossy communication channels, such as mobile apps or websites with offline functionality, where transmission of measures cannot be ensured, this property contains a client-generated, unique ID of the measure taken. It is best practice to make this sufficiently long to ensure enough entropy. Additionally, if information such as time stamp, device ID, IP or MAC address, or other potentially user-identifying values are incorporated in the generation of the xdm:id, the result should be hashed, so that no PII is encoded in the value, as the goal is not to identify user or device, but the specific measure in time."
+          "description": "Unique identifier of the measure. In cases of data collection using lossy communication channels, such as mobile apps or websites with offline functionality, where transmission of measures cannot be ensured, this property contains a client-generated, unique ID of the measure taken. It is best practice to make this sufficiently long to ensure enough entropy. Additionally, if information such as time stamp, device ID, IP or MAC address, or other potentially user-identifying values are incorporated in the generation of the xdm:id, the result should be hashed, so that no PII is encoded in the value, as the goal is not to identify user or device, but the specific measure in time."
         },
         "xdm:value": {
           "type": "number",
@@ -40,9 +38,13 @@
               "const": null
             }
           ],
-          "description":
-            "The (optional) unit that this measure's value is measured in. The `unit` in the `Measure` is purely informational, as the `unit` property of the referenced `Metric` determines the interpretation.",
-          "examples": ["m", "kg", "s", "USD"]
+          "description": "The (optional) unit that this measure's value is measured in. The `unit` in the `Measure` is purely informational, as the `unit` property of the referenced `Metric` determines the interpretation.",
+          "examples": [
+            "m",
+            "kg",
+            "s",
+            "USD"
+          ]
         }
       }
     }
@@ -52,5 +54,8 @@
       "$ref": "#/definitions/measure"
     }
   ],
-  "required": ["xdm:value"]
+  "required": [
+    "xdm:value"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/measure.schema.json
+++ b/schemas/data/measure.schema.json
@@ -17,13 +17,15 @@
         "@type": {
           "type": "string",
           "format": "uri",
-          "description": "Links to the `Metric` that this measure refers to. The `@type` can be omitted in contexts where it is obvious what metric is being referred to, for instance in the `Metrics` object that is keyed with `Metric` URIs."
+          "description":
+            "Links to the `Metric` that this measure refers to. The `@type` can be omitted in contexts where it is obvious what metric is being referred to, for instance in the `Metrics` object that is keyed with `Metric` URIs."
         },
         "xdm:id": {
           "title": "Unique Identifier",
           "type": "string",
           "minLength": 20,
-          "description": "Unique identifier of the measure. In cases of data collection using lossy communication channels, such as mobile apps or websites with offline functionality, where transmission of measures cannot be ensured, this property contains a client-generated, unique ID of the measure taken. It is best practice to make this sufficiently long to ensure enough entropy. Additionally, if information such as time stamp, device ID, IP or MAC address, or other potentially user-identifying values are incorporated in the generation of the xdm:id, the result should be hashed, so that no PII is encoded in the value, as the goal is not to identify user or device, but the specific measure in time."
+          "description":
+            "Unique identifier of the measure. In cases of data collection using lossy communication channels, such as mobile apps or websites with offline functionality, where transmission of measures cannot be ensured, this property contains a client-generated, unique ID of the measure taken. It is best practice to make this sufficiently long to ensure enough entropy. Additionally, if information such as time stamp, device ID, IP or MAC address, or other potentially user-identifying values are incorporated in the generation of the xdm:id, the result should be hashed, so that no PII is encoded in the value, as the goal is not to identify user or device, but the specific measure in time."
         },
         "xdm:value": {
           "type": "number",
@@ -38,13 +40,9 @@
               "const": null
             }
           ],
-          "description": "The (optional) unit that this measure's value is measured in. The `unit` in the `Measure` is purely informational, as the `unit` property of the referenced `Metric` determines the interpretation.",
-          "examples": [
-            "m",
-            "kg",
-            "s",
-            "USD"
-          ]
+          "description":
+            "The (optional) unit that this measure's value is measured in. The `unit` in the `Measure` is purely informational, as the `unit` property of the referenced `Metric` determines the interpretation.",
+          "examples": ["m", "kg", "s", "USD"]
         }
       }
     }
@@ -54,8 +52,6 @@
       "$ref": "#/definitions/measure"
     }
   ],
-  "required": [
-    "xdm:value"
-  ],
+  "required": ["xdm:value"],
   "meta:status": "experimental"
 }

--- a/schemas/data/metric.schema.json
+++ b/schemas/data/metric.schema.json
@@ -21,19 +21,27 @@
         },
         "schema:name": {
           "type": "string",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
           "description": "How to take measures of this metric.",
-          "examples": ["distance", "time", "price", "count"]
+          "examples": [
+            "distance",
+            "time",
+            "price",
+            "count"
+          ]
         },
         "xdm:unit": {
           "type": "string",
-          "description":
-            "The unit that this metric is measured in. Whenever possible, metrics should follow the [SI base units](https://www.bipm.org/en/measurement-units/) or be [ISO 4217 currency codes](https://www.iso.org/iso-4217-currency-codes.html). For measures that are counts, the `xdm:unit` must be `null`.",
-          "examples": ["m", "kg", "s", "USD"]
+          "description": "The unit that this metric is measured in. Whenever possible, metrics should follow the [SI base units](https://www.bipm.org/en/measurement-units/) or be [ISO 4217 currency codes](https://www.iso.org/iso-4217-currency-codes.html). For measures that are counts, the `xdm:unit` must be `null`.",
+          "examples": [
+            "m",
+            "kg",
+            "s",
+            "USD"
+          ]
         }
       }
     }
@@ -43,5 +51,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/metric.schema.json
+++ b/schemas/data/metric.schema.json
@@ -21,27 +21,19 @@
         },
         "schema:name": {
           "type": "string",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
           "description": "How to take measures of this metric.",
-          "examples": [
-            "distance",
-            "time",
-            "price",
-            "count"
-          ]
+          "examples": ["distance", "time", "price", "count"]
         },
         "xdm:unit": {
           "type": "string",
-          "description": "The unit that this metric is measured in. Whenever possible, metrics should follow the [SI base units](https://www.bipm.org/en/measurement-units/) or be [ISO 4217 currency codes](https://www.iso.org/iso-4217-currency-codes.html). For measures that are counts, the `xdm:unit` must be `null`.",
-          "examples": [
-            "m",
-            "kg",
-            "s",
-            "USD"
-          ]
+          "description":
+            "The unit that this metric is measured in. Whenever possible, metrics should follow the [SI base units](https://www.bipm.org/en/measurement-units/) or be [ISO 4217 currency codes](https://www.iso.org/iso-4217-currency-codes.html). For measures that are counts, the `xdm:unit` must be `null`.",
+          "examples": ["m", "kg", "s", "USD"]
         }
       }
     }
@@ -51,11 +43,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/metrics.schema.json
+++ b/schemas/data/metrics.schema.json
@@ -9,8 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Metrics",
   "type": "object",
-  "description":
-    "This is map of metrics and measues. Each key is the valid URI of a known `Metric`. Each value is a `Measure`, i.e. a concrete data point.",
+  "description": "This is map of metrics and measues. Each key is the valid URI of a known `Metric`. Each value is a `Measure`, i.e. a concrete data point.",
   "definitions": {
     "metrics": {
       "patternProperties": {
@@ -84,5 +83,6 @@
     {
       "$ref": "#/definitions/metrics"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/metrics.schema.json
+++ b/schemas/data/metrics.schema.json
@@ -9,7 +9,8 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Metrics",
   "type": "object",
-  "description": "This is map of metrics and measues. Each key is the valid URI of a known `Metric`. Each value is a `Measure`, i.e. a concrete data point.",
+  "description":
+    "This is map of metrics and measues. Each key is the valid URI of a known `Metric`. Each value is a `Measure`, i.e. a concrete data point.",
   "definitions": {
     "metrics": {
       "patternProperties": {

--- a/schemas/data/mirror-pages.schema.json
+++ b/schemas/data/mirror-pages.schema.json
@@ -10,23 +10,24 @@
   "title": "mirror-pages",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "The direct-marketing metric mirror-pages describes the number of mirror pages for which a link to the online mirror page of a message has been clicked.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "The direct-marketing metric mirror-pages describes the number of mirror pages for which a link to the online mirror page of a message has been clicked.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/mirror-pages",
+          "const":
+            "https://ns.adobe.com/xdm/data/metrics/direct-marketing/mirror-pages",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "direct-marketing metric: mirror-pages",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +45,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/mirror-pages.schema.json
+++ b/schemas/data/mirror-pages.schema.json
@@ -10,24 +10,23 @@
   "title": "mirror-pages",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "The direct-marketing metric mirror-pages describes the number of mirror pages for which a link to the online mirror page of a message has been clicked.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "The direct-marketing metric mirror-pages describes the number of mirror pages for which a link to the online mirror page of a message has been clicked.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const":
-            "https://ns.adobe.com/xdm/data/metrics/direct-marketing/mirror-pages",
+          "const": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/mirror-pages",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "direct-marketing metric: mirror-pages",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -45,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/non-deliverables.schema.json
+++ b/schemas/data/non-deliverables.schema.json
@@ -5,28 +5,30 @@
     "you may not use this file except in compliance with the License. You may obtain a copy",
     "of the License at https://creativecommons.org/licenses/by/4.0/"
   ],
-  "$id": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/non-deliverables",
+  "$id":
+    "https://ns.adobe.com/xdm/data/metrics/direct-marketing/non-deliverables",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "non-deliverables",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "The direct-marketing metric non-deliverables describes the umber of asynchronous messages that failed to deliver in a way that indicates that no future messages will be deliverable either to this address.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "The direct-marketing metric non-deliverables describes the umber of asynchronous messages that failed to deliver in a way that indicates that no future messages will be deliverable either to this address.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/non-deliverables",
+          "const":
+            "https://ns.adobe.com/xdm/data/metrics/direct-marketing/non-deliverables",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "direct-marketing metric: non-deliverables",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +46,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/non-deliverables.schema.json
+++ b/schemas/data/non-deliverables.schema.json
@@ -5,30 +5,28 @@
     "you may not use this file except in compliance with the License. You may obtain a copy",
     "of the License at https://creativecommons.org/licenses/by/4.0/"
   ],
-  "$id":
-    "https://ns.adobe.com/xdm/data/metrics/direct-marketing/non-deliverables",
+  "$id": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/non-deliverables",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "non-deliverables",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "The direct-marketing metric non-deliverables describes the umber of asynchronous messages that failed to deliver in a way that indicates that no future messages will be deliverable either to this address.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "The direct-marketing metric non-deliverables describes the umber of asynchronous messages that failed to deliver in a way that indicates that no future messages will be deliverable either to this address.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const":
-            "https://ns.adobe.com/xdm/data/metrics/direct-marketing/non-deliverables",
+          "const": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/non-deliverables",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "direct-marketing metric: non-deliverables",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -46,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/order.schema.json
+++ b/schemas/data/order.schema.json
@@ -16,14 +16,12 @@
         "xdm:purchaseID": {
           "title": "Purchase ID",
           "type": "string",
-          "description":
-            "Unique identifier assigned by the seller for this purchase or contract. There is no guarantee that the ID is unique."
+          "description": "Unique identifier assigned by the seller for this purchase or contract. There is no guarantee that the ID is unique."
         },
         "xdm:purchaseOrderNumber": {
           "title": "Purchase Order Number",
           "type": "string",
-          "description":
-            "Unique identifier assigned by the purchaser for this purchase or contract."
+          "description": "Unique identifier assigned by the purchaser for this purchase or contract."
         },
         "xdm:payments": {
           "title": "Payment List",
@@ -36,15 +34,17 @@
         "xdm:currencyCode": {
           "title": "Currency",
           "type": "string",
-          "examples": ["USD", "EUR"],
+          "examples": [
+            "USD",
+            "EUR"
+          ],
           "pattern": "^[A-Z]{3}$",
           "description": "The ISO 4217 currency code used for the order totals."
         },
         "xdm:priceTotal": {
           "title": "Price Total",
           "type": "number",
-          "description":
-            "The total price of this order after all discounts and taxes have been applied."
+          "description": "The total price of this order after all discounts and taxes have been applied."
         }
       }
     }
@@ -53,5 +53,6 @@
     {
       "$ref": "#/definitions/order"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/order.schema.json
+++ b/schemas/data/order.schema.json
@@ -16,12 +16,14 @@
         "xdm:purchaseID": {
           "title": "Purchase ID",
           "type": "string",
-          "description": "Unique identifier assigned by the seller for this purchase or contract. There is no guarantee that the ID is unique."
+          "description":
+            "Unique identifier assigned by the seller for this purchase or contract. There is no guarantee that the ID is unique."
         },
         "xdm:purchaseOrderNumber": {
           "title": "Purchase Order Number",
           "type": "string",
-          "description": "Unique identifier assigned by the purchaser for this purchase or contract."
+          "description":
+            "Unique identifier assigned by the purchaser for this purchase or contract."
         },
         "xdm:payments": {
           "title": "Payment List",
@@ -34,17 +36,15 @@
         "xdm:currencyCode": {
           "title": "Currency",
           "type": "string",
-          "examples": [
-            "USD",
-            "EUR"
-          ],
+          "examples": ["USD", "EUR"],
           "pattern": "^[A-Z]{3}$",
           "description": "The ISO 4217 currency code used for the order totals."
         },
         "xdm:priceTotal": {
           "title": "Price Total",
           "type": "number",
-          "description": "The total price of this order after all discounts and taxes have been applied."
+          "description":
+            "The total price of this order after all discounts and taxes have been applied."
         }
       }
     }

--- a/schemas/data/page-views.schema.json
+++ b/schemas/data/page-views.schema.json
@@ -10,10 +10,9 @@
   "title": "page-views",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "The web metric page-views describes the number of impressions of a web page.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "The web metric page-views describes the number of impressions of a web page.",
   "definitions": {
     "metric": {
       "properties": {
@@ -26,7 +25,8 @@
         "schema:name": {
           "type": "string",
           "const": "web metric: page-views",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +44,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/page-views.schema.json
+++ b/schemas/data/page-views.schema.json
@@ -10,9 +10,10 @@
   "title": "page-views",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "The web metric page-views describes the number of impressions of a web page.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "The web metric page-views describes the number of impressions of a web page.",
   "definitions": {
     "metric": {
       "properties": {
@@ -25,8 +26,7 @@
         "schema:name": {
           "type": "string",
           "const": "web metric: page-views",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/paymentitem.schema.json
+++ b/schemas/data/paymentitem.schema.json
@@ -9,14 +9,16 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Payment Item",
   "type": "object",
-  "description": "A payment associated with an order that defines the type of payment, the amount and the associated currency.",
+  "description":
+    "A payment associated with an order that defines the type of payment, the amount and the associated currency.",
   "definitions": {
     "paymentitem": {
       "properties": {
         "xdm:transactionID": {
           "title": "Transaction ID",
           "type": "string",
-          "description": "The unique transaction identifier for this payment item."
+          "description":
+            "The unique transaction identifier for this payment item."
         },
         "xdm:paymentAmount": {
           "title": "Payment Amount",
@@ -26,7 +28,8 @@
         "xdm:paymentType": {
           "title": "Payment Type",
           "type": "string",
-          "description": "The method of payment for this order. Enumerated, custom values allowed.",
+          "description":
+            "The method of payment for this order. Enumerated, custom values allowed.",
           "default": "other",
           "meta:enum": {
             "cash": "Cash",
@@ -43,12 +46,10 @@
         "xdm:currencyCode": {
           "title": "Currency Code",
           "type": "string",
-          "examples": [
-            "USD",
-            "EUR"
-          ],
+          "examples": ["USD", "EUR"],
           "pattern": "^[A-Z]{3}$",
-          "description": "The ISO 4217 currency code used for this payment item."
+          "description":
+            "The ISO 4217 currency code used for this payment item."
         }
       }
     }

--- a/schemas/data/paymentitem.schema.json
+++ b/schemas/data/paymentitem.schema.json
@@ -9,16 +9,14 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Payment Item",
   "type": "object",
-  "description":
-    "A payment associated with an order that defines the type of payment, the amount and the associated currency.",
+  "description": "A payment associated with an order that defines the type of payment, the amount and the associated currency.",
   "definitions": {
     "paymentitem": {
       "properties": {
         "xdm:transactionID": {
           "title": "Transaction ID",
           "type": "string",
-          "description":
-            "The unique transaction identifier for this payment item."
+          "description": "The unique transaction identifier for this payment item."
         },
         "xdm:paymentAmount": {
           "title": "Payment Amount",
@@ -28,8 +26,7 @@
         "xdm:paymentType": {
           "title": "Payment Type",
           "type": "string",
-          "description":
-            "The method of payment for this order. Enumerated, custom values allowed.",
+          "description": "The method of payment for this order. Enumerated, custom values allowed.",
           "default": "other",
           "meta:enum": {
             "cash": "Cash",
@@ -46,10 +43,12 @@
         "xdm:currencyCode": {
           "title": "Currency Code",
           "type": "string",
-          "examples": ["USD", "EUR"],
+          "examples": [
+            "USD",
+            "EUR"
+          ],
           "pattern": "^[A-Z]{3}$",
-          "description":
-            "The ISO 4217 currency code used for this payment item."
+          "description": "The ISO 4217 currency code used for this payment item."
         }
       }
     }
@@ -58,5 +57,6 @@
     {
       "$ref": "#/definitions/paymentitem"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/product-list-adds.schema.json
+++ b/schemas/data/product-list-adds.schema.json
@@ -10,23 +10,24 @@
   "title": "product-list-adds",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "The commerce metric product-list-adds describes the number of times a product has been added to a product list. The most common case is adding an item to the shopping cart.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "The commerce metric product-list-adds describes the number of times a product has been added to a product list. The most common case is adding an item to the shopping cart.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-adds",
+          "const":
+            "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-adds",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: product-list-adds",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +45,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/product-list-adds.schema.json
+++ b/schemas/data/product-list-adds.schema.json
@@ -10,24 +10,23 @@
   "title": "product-list-adds",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "The commerce metric product-list-adds describes the number of times a product has been added to a product list. The most common case is adding an item to the shopping cart.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "The commerce metric product-list-adds describes the number of times a product has been added to a product list. The most common case is adding an item to the shopping cart.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const":
-            "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-adds",
+          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-adds",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: product-list-adds",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -45,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/product-list-opens.schema.json
+++ b/schemas/data/product-list-opens.schema.json
@@ -10,23 +10,24 @@
   "title": "product-list-opens",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "The commerce metric product-list-opens describes how many new product lists have been created. The most common case is the creation of a new shopping cart by putting the first item into the shopping cart.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "The commerce metric product-list-opens describes how many new product lists have been created. The most common case is the creation of a new shopping cart by putting the first item into the shopping cart.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-opens",
+          "const":
+            "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-opens",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: product-list-opens",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +45,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/product-list-opens.schema.json
+++ b/schemas/data/product-list-opens.schema.json
@@ -10,24 +10,23 @@
   "title": "product-list-opens",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "The commerce metric product-list-opens describes how many new product lists have been created. The most common case is the creation of a new shopping cart by putting the first item into the shopping cart.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "The commerce metric product-list-opens describes how many new product lists have been created. The most common case is the creation of a new shopping cart by putting the first item into the shopping cart.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const":
-            "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-opens",
+          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-opens",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: product-list-opens",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -45,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/product-list-removals.schema.json
+++ b/schemas/data/product-list-removals.schema.json
@@ -10,24 +10,23 @@
   "title": "product-list-removals",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "The commerce metric product-list-removals describes the number of times a product has been removed from a product list. The most common use case is the removal of a product from the shopping cart.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "The commerce metric product-list-removals describes the number of times a product has been removed from a product list. The most common use case is the removal of a product from the shopping cart.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const":
-            "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-removals",
+          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-removals",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: product-list-removals",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -45,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/product-list-removals.schema.json
+++ b/schemas/data/product-list-removals.schema.json
@@ -10,23 +10,24 @@
   "title": "product-list-removals",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "The commerce metric product-list-removals describes the number of times a product has been removed from a product list. The most common use case is the removal of a product from the shopping cart.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "The commerce metric product-list-removals describes the number of times a product has been removed from a product list. The most common use case is the removal of a product from the shopping cart.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-removals",
+          "const":
+            "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-removals",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: product-list-removals",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +45,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/product-list-reopens.schema.json
+++ b/schemas/data/product-list-reopens.schema.json
@@ -10,23 +10,24 @@
   "title": "product-list-reopens",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "Number of reopens for which a product list that was no longer accessible has been re-activated by the user, for example via a re-marketing activity.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "Number of reopens for which a product list that was no longer accessible has been re-activated by the user, for example via a re-marketing activity.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-reopens",
+          "const":
+            "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-reopens",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: product-list-reopens",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +45,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/product-list-reopens.schema.json
+++ b/schemas/data/product-list-reopens.schema.json
@@ -10,24 +10,23 @@
   "title": "product-list-reopens",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "Number of reopens for which a product list that was no longer accessible has been re-activated by the user, for example via a re-marketing activity.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "Number of reopens for which a product list that was no longer accessible has been re-activated by the user, for example via a re-marketing activity.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const":
-            "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-reopens",
+          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-reopens",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: product-list-reopens",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -45,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/product-list-views.schema.json
+++ b/schemas/data/product-list-views.schema.json
@@ -10,24 +10,23 @@
   "title": "product-list-views",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "The commerce metric product-list-views describes how often a product list has been seen by a shopper. The most common use case is to open the shopping cart to inspect its contents.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "The commerce metric product-list-views describes how often a product list has been seen by a shopper. The most common use case is to open the shopping cart to inspect its contents.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const":
-            "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-views",
+          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-views",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: product-list-views",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -45,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/product-list-views.schema.json
+++ b/schemas/data/product-list-views.schema.json
@@ -10,23 +10,24 @@
   "title": "product-list-views",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "The commerce metric product-list-views describes how often a product list has been seen by a shopper. The most common use case is to open the shopping cart to inspect its contents.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "The commerce metric product-list-views describes how often a product list has been seen by a shopper. The most common use case is to open the shopping cart to inspect its contents.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-views",
+          "const":
+            "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-views",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: product-list-views",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +45,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/product-views.schema.json
+++ b/schemas/data/product-views.schema.json
@@ -10,23 +10,24 @@
   "title": "product-views",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "The commerce metric product-views describes the number of product views that have occurred. Because the number of products on a page might be greater than one, this number may differ from the page view count of product pages.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "The commerce metric product-views describes the number of product views that have occurred. Because the number of products on a page might be greater than one, this number may differ from the page view count of product pages.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/product-views",
+          "const":
+            "https://ns.adobe.com/xdm/data/metrics/commerce/product-views",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: product-views",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +45,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/product-views.schema.json
+++ b/schemas/data/product-views.schema.json
@@ -10,24 +10,23 @@
   "title": "product-views",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "The commerce metric product-views describes the number of product views that have occurred. Because the number of products on a page might be greater than one, this number may differ from the page view count of product pages.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "The commerce metric product-views describes the number of product views that have occurred. Because the number of products on a page might be greater than one, this number may differ from the page view count of product pages.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const":
-            "https://ns.adobe.com/xdm/data/metrics/commerce/product-views",
+          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/product-views",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: product-views",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -45,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/purchases.schema.json
+++ b/schemas/data/purchases.schema.json
@@ -10,10 +10,9 @@
   "title": "purchases",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "Number of orders has occurred. Purchase is the only required action in a commerce conversion. Purchase must have a product list referenced.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "Number of orders has occurred. Purchase is the only required action in a commerce conversion. Purchase must have a product list referenced.",
   "definitions": {
     "metric": {
       "properties": {
@@ -26,7 +25,8 @@
         "schema:name": {
           "type": "string",
           "const": "commerce metric: purchases",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +44,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/purchases.schema.json
+++ b/schemas/data/purchases.schema.json
@@ -10,9 +10,10 @@
   "title": "purchases",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "Number of orders has occurred. Purchase is the only required action in a commerce conversion. Purchase must have a product list referenced.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "Number of orders has occurred. Purchase is the only required action in a commerce conversion. Purchase must have a product list referenced.",
   "definitions": {
     "metric": {
       "properties": {
@@ -25,8 +26,7 @@
         "schema:name": {
           "type": "string",
           "const": "commerce metric: purchases",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/save-for-laters.schema.json
+++ b/schemas/data/save-for-laters.schema.json
@@ -10,24 +10,23 @@
   "title": "save-for-laters",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "The commerce metric save-for-laters describes how often a product has been saved for a later day purchase.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "The commerce metric save-for-laters describes how often a product has been saved for a later day purchase.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const":
-            "https://ns.adobe.com/xdm/data/metrics/commerce/save-for-laters",
+          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/save-for-laters",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: save-for-laters",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -45,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/save-for-laters.schema.json
+++ b/schemas/data/save-for-laters.schema.json
@@ -10,23 +10,24 @@
   "title": "save-for-laters",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "The commerce metric save-for-laters describes how often a product has been saved for a later day purchase.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "The commerce metric save-for-laters describes how often a product has been saved for a later day purchase.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/data/metrics/commerce/save-for-laters",
+          "const":
+            "https://ns.adobe.com/xdm/data/metrics/commerce/save-for-laters",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "commerce metric: save-for-laters",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +45,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/sends.schema.json
+++ b/schemas/data/sends.schema.json
@@ -10,23 +10,24 @@
   "title": "sends",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "The direct-marketing metric sends describes the number of asynchronous messages (email, SMS, MMS etc) that have been dispatched to an recipient's account/address/device",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "The direct-marketing metric sends describes the number of asynchronous messages (email, SMS, MMS etc) that have been dispatched to an recipient's account/address/device",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/sends",
+          "const":
+            "https://ns.adobe.com/xdm/data/metrics/direct-marketing/sends",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "direct-marketing metric: sends",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +45,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/data/sends.schema.json
+++ b/schemas/data/sends.schema.json
@@ -10,24 +10,23 @@
   "title": "sends",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "The direct-marketing metric sends describes the number of asynchronous messages (email, SMS, MMS etc) that have been dispatched to an recipient's account/address/device",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "The direct-marketing metric sends describes the number of asynchronous messages (email, SMS, MMS etc) that have been dispatched to an recipient's account/address/device",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const":
-            "https://ns.adobe.com/xdm/data/metrics/direct-marketing/sends",
+          "const": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/sends",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "direct-marketing metric: sends",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -45,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/user-complaints.schema.json
+++ b/schemas/data/user-complaints.schema.json
@@ -5,30 +5,28 @@
     "you may not use this file except in compliance with the License. You may obtain a copy",
     "of the License at https://creativecommons.org/licenses/by/4.0/"
   ],
-  "$id":
-    "https://ns.adobe.com/xdm/data/metrics/direct-marketing/user-complaints",
+  "$id": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/user-complaints",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "user-complaints",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
-  "description":
-    "The direct-marketing metric user-complaints describes the number of user complaints that have been received. This generally occurs when a recipient of a message reported it as spam.",
+  "meta:extends": [
+    "https://ns.adobe.com/xdm/data/metric"
+  ],
+  "description": "The direct-marketing metric user-complaints describes the number of user complaints that have been received. This generally occurs when a recipient of a message reported it as spam.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const":
-            "https://ns.adobe.com/xdm/data/metrics/direct-marketing/user-complaints",
+          "const": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/user-complaints",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "direct-marketing metric: user-complaints",
-          "description":
-            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -46,5 +44,11 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"]
+  "required": [
+    "@id",
+    "schema:name",
+    "xdm:measurement",
+    "xdm:unit"
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/data/user-complaints.schema.json
+++ b/schemas/data/user-complaints.schema.json
@@ -5,28 +5,30 @@
     "you may not use this file except in compliance with the License. You may obtain a copy",
     "of the License at https://creativecommons.org/licenses/by/4.0/"
   ],
-  "$id": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/user-complaints",
+  "$id":
+    "https://ns.adobe.com/xdm/data/metrics/direct-marketing/user-complaints",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "user-complaints",
   "type": "object",
   "meta:extensible": true,
-  "meta:extends": [
-    "https://ns.adobe.com/xdm/data/metric"
-  ],
-  "description": "The direct-marketing metric user-complaints describes the number of user complaints that have been received. This generally occurs when a recipient of a message reported it as spam.",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/metric"],
+  "description":
+    "The direct-marketing metric user-complaints describes the number of user complaints that have been received. This generally occurs when a recipient of a message reported it as spam.",
   "definitions": {
     "metric": {
       "properties": {
         "@id": {
           "type": "string",
           "format": "uri",
-          "const": "https://ns.adobe.com/xdm/data/metrics/direct-marketing/user-complaints",
+          "const":
+            "https://ns.adobe.com/xdm/data/metrics/direct-marketing/user-complaints",
           "description": "The unique identifier of this metric."
         },
         "schema:name": {
           "type": "string",
           "const": "direct-marketing metric: user-complaints",
-          "description": "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
+          "description":
+            "The human-readable name of the metric. The name can be used in user interfaces and does not have to be unique."
         },
         "xdm:measurement": {
           "type": "string",
@@ -44,11 +46,6 @@
       "$ref": "#/definitions/metric"
     }
   ],
-  "required": [
-    "@id",
-    "schema:name",
-    "xdm:measurement",
-    "xdm:unit"
-  ],
+  "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
   "meta:status": "experimental"
 }

--- a/schemas/external/activity-streams-2/activity.schema.json
+++ b/schemas/external/activity-streams-2/activity.schema.json
@@ -78,5 +78,6 @@
       "$ref": "#/definitions/extra-properties"
     }
   ],
-  "title": "Activity"
+  "title": "Activity",
+  "meta:status": "experimental"
 }

--- a/schemas/external/activity-streams-2/collection-page.schema.json
+++ b/schemas/external/activity-streams-2/collection-page.schema.json
@@ -59,5 +59,6 @@
       "$ref": "#/definitions/extra-properties"
     }
   ],
-  "title": "Collection Page"
+  "title": "Collection Page",
+  "meta:status": "experimental"
 }

--- a/schemas/external/activity-streams-2/collection.schema.json
+++ b/schemas/external/activity-streams-2/collection.schema.json
@@ -84,5 +84,6 @@
       "$ref": "#/definitions/extra-properties"
     }
   ],
-  "title": "Collection"
+  "title": "Collection",
+  "meta:status": "experimental"
 }

--- a/schemas/external/activity-streams-2/context.schema.json
+++ b/schemas/external/activity-streams-2/context.schema.json
@@ -237,5 +237,6 @@
     }
   },
   "type": "object",
-  "title": "JSON-LD `@context`"
+  "title": "JSON-LD `@context`",
+  "meta:status": "experimental"
 }

--- a/schemas/external/activity-streams-2/document.schema.json
+++ b/schemas/external/activity-streams-2/document.schema.json
@@ -10,5 +10,6 @@
   "description": "Represents a document of any kind. Refer to the [Activity Streams 2.0 Core](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-document) specification for a complete description of the `document` type.",
   "$ref": "https://ns.adobe.com/xdm/external/activity-streams-2/object",
   "title": "Document",
-  "type": "object"
+  "type": "object",
+  "meta:status": "experimental"
 }

--- a/schemas/external/activity-streams-2/id.schema.json
+++ b/schemas/external/activity-streams-2/id.schema.json
@@ -15,5 +15,6 @@
     }
   },
   "title": "JSON-LD `@id`",
-  "type": "object"
+  "type": "object",
+  "meta:status": "experimental"
 }

--- a/schemas/external/activity-streams-2/image.schema.json
+++ b/schemas/external/activity-streams-2/image.schema.json
@@ -10,5 +10,6 @@
   "description": "An image document of any kind. Refer to the [Activity Streams 2.0 Core](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-image) specification for a complete description of the `image` type.",
   "$ref": "https://ns.adobe.com/xdm/external/activity-streams-2/document",
   "title": "Image Document",
-  "type": "object"
+  "type": "object",
+  "meta:status": "experimental"
 }

--- a/schemas/external/activity-streams-2/link.schema.json
+++ b/schemas/external/activity-streams-2/link.schema.json
@@ -98,5 +98,6 @@
       "description": "Identifies an entity that provides a preview of this object. Refer to the [Activity Streams 2.0 Core](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-preview) document for a complete description.",
       "$ref": "#/definitions/object-or-link-or-array-of-object-or-link"
     }
-  }
+  },
+  "meta:status": "experimental"
 }

--- a/schemas/external/activity-streams-2/object.schema.json
+++ b/schemas/external/activity-streams-2/object.schema.json
@@ -242,5 +242,6 @@
     {
       "$ref": "#/definitions/object-properties"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/external/activity-streams-2/rdf-langstring.schema.json
+++ b/schemas/external/activity-streams-2/rdf-langstring.schema.json
@@ -23,5 +23,6 @@
   },
   "additionalProperties": false,
   "title": "RDF Language Tagged String",
-  "description": "The class `rdf:langString` is the class of [language-tagged string values](http://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string)."
+  "description": "The class `rdf:langString` is the class of [language-tagged string values](http://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string).",
+  "meta:status": "experimental"
 }

--- a/schemas/external/activity-streams-2/type.schema.json
+++ b/schemas/external/activity-streams-2/type.schema.json
@@ -31,5 +31,6 @@
     "@type": {
       "$ref": "#/definitions/type"
     }
-  }
+  },
+  "meta:status": "experimental"
 }

--- a/schemas/external/hal/hal-link.schema.json
+++ b/schemas/external/hal/hal-link.schema.json
@@ -104,5 +104,6 @@
     {
       "$ref": "#/definitions/hal-link-common"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/external/hal/hal.schema.json
+++ b/schemas/external/hal/hal.schema.json
@@ -277,5 +277,6 @@
     {
       "$ref": "#/definitions/hal"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/external/repo/accesscontrolentry.schema.json
+++ b/schemas/external/repo/accesscontrolentry.schema.json
@@ -97,5 +97,6 @@
     {
       "$ref": "#/definitions/ace"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/external/repo/accesscontrolpolicy.schema.json
+++ b/schemas/external/repo/accesscontrolpolicy.schema.json
@@ -24,5 +24,6 @@
     {
       "$ref": "#/definitions/accesscontrolpolicy"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/external/repo/asset.schema.json
+++ b/schemas/external/repo/asset.schema.json
@@ -90,5 +90,6 @@
     "repo:etag",
     "repo:version",
     "repo:size"
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/external/repo/common.schema.json
+++ b/schemas/external/repo/common.schema.json
@@ -54,5 +54,6 @@
         }
       }
     }
-  }
+  },
+  "meta:status": "experimental"
 }

--- a/schemas/external/repo/directory.schema.json
+++ b/schemas/external/repo/directory.schema.json
@@ -63,5 +63,6 @@
     "dc:format",
     "repo:createdDate",
     "repo:lastModifiedDate"
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/external/repo/effectiveprivileges.schema.json
+++ b/schemas/external/repo/effectiveprivileges.schema.json
@@ -41,5 +41,6 @@
     {
       "$ref": "#/definitions/effectiveprivileges"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/external/repo/sub-directory.schema.json
+++ b/schemas/external/repo/sub-directory.schema.json
@@ -41,5 +41,6 @@
     "repo:name",
     "repo:path",
     "dc:format"
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/external/schema/geocircle.schema.json
+++ b/schemas/external/schema/geocircle.schema.json
@@ -43,5 +43,6 @@
     {
       "$ref": "#/definitions/geocircle"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/external/schema/geocoordinates.schema.json
+++ b/schemas/external/schema/geocoordinates.schema.json
@@ -54,5 +54,6 @@
     {
       "$ref": "#/definitions/geocoordinates"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/external/schema/geoshape.schema.json
+++ b/schemas/external/schema/geoshape.schema.json
@@ -67,5 +67,6 @@
     {
       "$ref": "#/definitions/geoshape"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }


### PR DESCRIPTION
This PR links to the issue #161 : This change is to add a new metadata type `meta:status` used to indicate the stability of the schema