### PR TITLE
Added meta:xdmType to hyper schema

### DIFF
--- a/meta.schema.json
+++ b/meta.schema.json
@@ -71,6 +71,33 @@
         }
       ]
     },
+    "meta:xdmType": {
+      "string": {
+        "sqlType": "varchar(255)",
+        "protoType": "string"
+      },
+      "boolean": {
+        "protoType": "bool"
+      },
+      "byte": {
+        "protoType": "int32"
+      },
+      "short": {
+        "protoType": "int32"
+      },
+      "int": {
+        "protoType": "int32"
+      },
+      "long": {
+        "protoType": "int64"
+      },
+      "float": {
+        "protoType": "float"
+      },
+      "double": {
+        "protoType": "double"
+      }
+    },
     "type": {
       "type": "string",
       "const": "object"


### PR DESCRIPTION
This PR links to the issue #157 

@trieloff @kstreeter @cmathis

This is the first draft of the meta:xdmType added to hyper schema, please review and make recommendation as needed. 

It is very simple at this moment as it can be quite complicated if want to cover all the dbs and programming languages, also we do not have use cases for those yet.
