### PR TITLE
Align external schema namespaces

### DIFF
--- a/schemas/common/organization.example.1.json
+++ b/schemas/common/organization.example.1.json
@@ -27,12 +27,12 @@
     },
     "schema:telephone": "1-408-800-0000",
     "xdm:identifier": {
-      "https://ns.adobe.com/external/dnb": "1234",
-      "https://ns.adobe.com/external/angellist": "https://angel.co/adobe"
+      "https://ns.adobe.com/xdm/external/dnb": "1234",
+      "https://ns.adobe.com/xdm/external/angellist": "https://angel.co/adobe"
     },
     "xdm:classifier": {
-      "https://ns.adobe.com/external/sic": "1234",
-      "https://ns.adobe.com/external/naics": "1234"
+      "https://ns.adobe.com/xdm/external/sic": "1234",
+      "https://ns.adobe.com/xdm/external/naics": "1234"
     }
   }
 }

--- a/schemas/common/organization.schema.json
+++ b/schemas/common/organization.schema.json
@@ -69,8 +69,8 @@
           "title": "Organization Identifier",
           "type": "object",
           "meta:keys": {
-            "https://ns.adobe.com/external/dnb": "Dun & Bradstreet",
-            "https://ns.adobe.com/external/angellist": "Angellist"
+            "https://ns.adobe.com/xdm/external/dnb": "Dun & Bradstreet",
+            "https://ns.adobe.com/xdm/external/angellist": "Angellist"
           },
           "patternProperties": {
             ".+://.+": {
@@ -80,8 +80,8 @@
           },
           "examples": [
             {
-              "https://ns.adobe.com/external/dnb": "1234",
-              "https://ns.adobe.com/external/angellist":
+              "https://ns.adobe.com/xdm/external/dnb": "1234",
+              "https://ns.adobe.com/xdm/external/angellist":
                 "https://angel.co/adobe"
             }
           ],
@@ -92,11 +92,11 @@
           "title": "Market/Industry Classifier",
           "type": "object",
           "meta:keys": {
-            "https://ns.adobe.com/external/isic4":
+            "https://ns.adobe.com/xdm/external/isic4":
               "International Standard of Industrial Classification of All Economic Activities (ISIC)",
-            "https://ns.adobe.com/external/sic":
+            "https://ns.adobe.com/xdm/external/sic":
               "Standard Industrial Classification",
-            "https://ns.adobe.com/external/naics":
+            "https://ns.adobe.com/xdm/external/naics":
               "North American Industry Classification System"
           },
           "patternProperties": {
@@ -108,8 +108,8 @@
           },
           "examples": [
             {
-              "https://ns.adobe.com/external/sic": "1234",
-              "https://ns.adobe.com/external/naics": "1234"
+              "https://ns.adobe.com/xdm/external/sic": "1234",
+              "https://ns.adobe.com/xdm/external/naics": "1234"
             }
           ],
           "description":

--- a/schemas/context/device.example.1.json
+++ b/schemas/context/device.example.1.json
@@ -1,6 +1,6 @@
 {
   "xdm:typeID": "TypeIdentifier-111",
-  "xdm:typeIDService": "https://ns.adobe.com/external/deviceatlas",
+  "xdm:typeIDService": "https://ns.adobe.com/xdm/external/deviceatlas",
   "xdm:type": "mobile",
   "xdm:manufacturer": "Apple",
   "xdm:model": "iPhone 6",

--- a/schemas/context/device.schema.json
+++ b/schemas/context/device.schema.json
@@ -27,7 +27,7 @@
           "description":
             "The namespace of the service that is used to identify the device type.",
           "meta:enum": {
-            "https://ns.adobe.com/external/deviceatlas": "Device Atlas"
+            "https://ns.adobe.com/xdm/external/deviceatlas": "Device Atlas"
           }
         },
         "xdm:type": {


### PR DESCRIPTION
Addresses #191

Rename `ns.adobe.com/external/ => ns.adobe.com/xdm/external/` to align with other `external` schema references
