### PR TITLE
[trivial] Update jsonschema2md to v1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "license": "https://creativecommons.org/licenses/by/4.0/",
   "devDependencies": {
-    "@adobe/jsonschema2md": "1.0.2",
+    "@adobe/jsonschema2md": "1.0.3",
     "prettier": "1.11.1",
     "pretty-quick": "^1.4.1",
     "mocha": "^5.0.1",


### PR DESCRIPTION
Update to use `"jsonschema2md": "1.0.3"` which supports `meta:status` during generation
