### PR TITLE
Fix the $id format of implementations extension

### DIFF
--- a/extensions/adobe/experience/implementations.schema.json
+++ b/extensions/adobe/experience/implementations.schema.json
@@ -5,7 +5,7 @@
     "you may not use this file except in compliance with the License. You may obtain a copy",
     "of the License at https://creativecommons.org/licenses/by/4.0/"
   ],
-  "$id": "https://ns.adobe.com/xdm-extensions/experience/implementations",
+  "$id": "https://ns.adobe.com/experience/implementations",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title":
     "The Adobe Experience Cloud technical implementations details for data collection",


### PR DESCRIPTION
This PR links to the issue #260 

@kstreeter @trieloff @cdegroot-adobe 

This PR fixes the $id format of implementations extension to be consistent with others.


