### PR TITLE
Campaign ExperienceEvent extension tweaks.

### DIFF
--- a/extensions/adobe/experience/campaign/experienceevent.example.click.json
+++ b/extensions/adobe/experience/campaign/experienceevent.example.click.json
@@ -5,6 +5,23 @@
       "xdm:value": 1
     }
   },
+  "xdm:channel": "https://ns.adobe.com/xdm/channels/email",
+  "xdm:endUserIDs": {
+    "https://ns.adobe.com/experience/mcid": {
+      "@id": "https://data.adobe.io/entities/identity/92312748749128",
+      "xdm:namespace": {
+        "@id": "https://data.adobe.io/entities/namespace/4",
+        "xdm:code": "ECID"
+      }
+    },
+    "https://ns.adobe.com/experience/campaign": {
+      "@id": "https://data.adobe.io/entities/identity/1234567",
+      "xdm:namespace": {
+        "@id": "https://data.adobe.io/entities/namespace/2756",
+        "xdm:code": "CPGN"
+      }
+    }
+  },
   "xdm:environment": {
     "xdm:type": "browser",
     "xdm:browserDetails": {
@@ -16,59 +33,56 @@
     "xdm:typeID": "IMac",
     "xdm:typeIDService": "https://ns.adobe.com/xdm/external/adobecampaign"
   },
-  "https://ns.adobe.com/experience/campaign/message": {
-    "id": 10000,
-    "profile": {
-      "xdm:person": {
-        "xdm:birthMonth": 1,
-        "xdm:birthDay": 3,
-        "xdm:birthYear": 1996,
-        "xdm:gender": "female"
+  "https://ns.adobe.com/experience/campaign": {
+    "message": {
+      "id": 10000,
+      "profile": {
+        "xdm:person": {
+          "xdm:birthMonth": 1,
+          "xdm:birthDay": 3,
+          "xdm:birthYear": 1996,
+          "xdm:gender": "female"
+        },
+        "xdm:workAddress": {
+          "@id": "https://ns.adobe.com/entities/address/123",
+          "xdm:primary": true,
+          "xdm:city": "San Jose",
+          "xdm:stateProvinceISO": "CA",
+          "xdm:postalCode": "95110",
+          "xdm:countryCode": "US"
+        },
+        "xdm:workEmail": {
+          "xdm:primary": true,
+          "xdm:address": "jsmith@xyzinc.com"
+        }
       },
-      "xdm:workAddress": {
-        "@id": "https://ns.adobe.com/entities/address/123",
-        "xdm:primary": true,
-        "xdm:city": "San Jose",
-        "xdm:stateProvinceISO": "CA",
-        "xdm:postalCode": "95110",
-        "xdm:countryCode": "US"
-      },
-      "xdm:workEmail": {
-        "xdm:primary": true,
-        "xdm:address": "jsmith@xyzinc.com"
+      "variant": "English",
+      "seedMember": false,
+      "quarantine": false,
+      "proofMember": false,
+      "controlGroupMember": false,
+      "testMember": true,
+      "outboundIP": "10.20.30.40",
+      "external": {
+        "id": "uuid:00112233-4455-6677-8899-AABBCCDDEEFF"
       }
     },
-    "variant": "English",
-    "seedMember": false,
-    "quarantine": false,
-    "proofMember": false,
-    "controlGroupMember": false,
-    "testMember": true,
-    "outboundIP": "10.20.30.40"
-  },
-  "https://ns.adobe.com/experience/campaign/delivery": {
-    "id": 1001,
-    "channel": "https://ns.adobe.com/xdm/channels/email",
-    "from": "no-reply@adobe.com",
-    "testEnabled": true,
-    "messageClass": "messageCenter",
-    "templateID": 1100
-  },
-  "https://ns.adobe.com/experience/campaign/link": {
-    "id": "98765",
-    "url": "https://newsletters.adobe.com/newsletter/101/mastering-xdm.html",
-    "occurrence": 2,
-    "tags": [
-      {
-        "name": "category",
-        "value": "Promotional Links"
-      },
-      {
-        "name": "label",
-        "value": "XDM information"
-      }
-    ]
-  },
-  "https://ns.adobe.com/experience/campaign/message/external/id": "uuid:00112233-4455-6677-8899-AABBCCDDEEFF",
-  "https://ns.adobe.com/experience/campaign/orchestration/businessReason": "store-entry-beacon-triggered"
+    "delivery": {
+      "id": 1001,
+      "from": "no-reply@adobe.com",
+      "testEnabled": true,
+      "messageClass": "messageCenter",
+      "templateID": 1100
+    },
+    "link": {
+      "id": "98765",
+      "url": "https://newsletters.adobe.com/newsletter/101/mastering-xdm.html",
+      "occurrence": 2,
+      "category": "Promotional Links",
+      "label" : "XDM information"
+    },
+    "orchestration": {
+      "businessReason": "store-entry-beacon-triggered"
+    }
+  }
 }

--- a/extensions/adobe/experience/campaign/experienceevent.example.email-send.json
+++ b/extensions/adobe/experience/campaign/experienceevent.example.email-send.json
@@ -5,46 +5,70 @@
       "xdm:value": 1
     }
   },
-  "https://ns.adobe.com/experience/campaign/message": {
-    "id": 10000,
-    "profile": {
-      "xdm:person": {
-        "xdm:birthMonth": 1,
-        "xdm:birthDay": 3,
-        "xdm:birthYear": 1996,
-        "xdm:gender": "female"
-      },
-      "xdm:workAddress": {
-        "@id": "https://ns.adobe.com/entities/address/123",
-        "xdm:primary": true,
-        "xdm:city": "San Jose",
-        "xdm:stateProvinceISO": "CA",
-        "xdm:postalCode": "95110",
-        "xdm:countryCode": "US"
-      },
-      "xdm:workEmail": {
-        "xdm:primary": true,
-        "xdm:address": "jsmith@xyzinc.com"
+  "xdm:channel": "https://ns.adobe.com/xdm/channels/email",
+  "xdm:endUserIDs": {
+    "https://ns.adobe.com/experience/mcid": {
+      "@id": "https://data.adobe.io/entities/identity/92312748749128",
+      "xdm:namespace": {
+        "@id": "https://data.adobe.io/entities/namespace/4",
+        "xdm:code": "ECID"
       }
     },
-    "variant": "English",
-    "seedMember": false,
-    "quarantine": false,
-    "proofMember": false,
-    "controlGroupMember": false,
-    "testMember": true,
-    "size": 421,
-    "outboundIP": "10.20.30.40"
+    "https://ns.adobe.com/experience/campaign": {
+      "@id": "https://data.adobe.io/entities/identity/1234567",
+      "xdm:namespace": {
+        "@id": "https://data.adobe.io/entities/namespace/2756",
+        "xdm:code": "CPGN"
+      }
+    }
   },
-  "https://ns.adobe.com/experience/campaign/delivery": {
-    "id": 1001,
-    "channel": "https://ns.adobe.com/xdm/channels/email",
-    "from": "no-reply@adobe.com",
-    "testEnabled": true,
-    "messageClass": "continuous",
-    "templateID": 1000
+  "https://ns.adobe.com/experience/campaign": {
+    "message": {
+      "id": 10000,
+      "profile": {
+        "xdm:person": {
+          "xdm:birthMonth": 1,
+          "xdm:birthDay": 3,
+          "xdm:birthYear": 1996,
+          "xdm:gender": "female"
+        },
+        "xdm:workAddress": {
+          "@id": "https://ns.adobe.com/entities/address/123",
+          "xdm:primary": true,
+          "xdm:city": "San Jose",
+          "xdm:stateProvinceISO": "CA",
+          "xdm:postalCode": "95110",
+          "xdm:countryCode": "US"
+        },
+        "xdm:workEmail": {
+          "xdm:primary": true,
+          "xdm:address": "jsmith@xyzinc.com"
+        }
+      },
+      "variant": "English",
+      "seedMember": false,
+      "quarantine": false,
+      "proofMember": false,
+      "controlGroupMember": false,
+      "testMember": true,
+      "size": 421,
+      "outboundIP": "10.20.30.40",
+      "external": {
+        "id": "uuid:00112233-4455-6677-8899-AABBCCDDEEFF"
+      }
+    },
+    "delivery": {
+      "id": 1001,
+      "from": "no-reply@adobe.com",
+      "testEnabled": true,
+      "messageClass": "continuous",
+      "templateID": 1000
+    },
+    "marketingCampaign": {
+      "id": 100
+    }
   },
-  "https://ns.adobe.com/experience/campaign/id": 100,
-  "https://ns.adobe.com/experience/campaign/message/external/id": "uuid:00112233-4455-6677-8899-AABBCCDDEEFF",
-  "https://ns.adobe.com/experience/campaign/orchestration/businessReason": "onJourneyEnter"
+  "orchestration": {
+    "businessReason": "onJourneyEnter"
+  }
 }

--- a/extensions/adobe/experience/campaign/experienceevent.example.open-push.json
+++ b/extensions/adobe/experience/campaign/experienceevent.example.open-push.json
@@ -5,6 +5,23 @@
       "xdm:value": 1
     }
   },
+  "xdm:channel": "https://ns.adobe.com/xdm/channels/apns",
+  "xdm:endUserIDs": {
+    "https://ns.adobe.com/experience/mcid": {
+      "@id": "https://data.adobe.io/entities/identity/92312748749128",
+      "xdm:namespace": {
+        "@id": "https://data.adobe.io/entities/namespace/4",
+        "xdm:code": "ECID"
+      }
+    },
+    "https://ns.adobe.com/experience/campaign": {
+      "@id": "https://data.adobe.io/entities/identity/1234567",
+      "xdm:namespace": {
+        "@id": "https://data.adobe.io/entities/namespace/2756",
+        "xdm:code": "CPGN"
+      }
+    }
+  },
   "xdm:environment": {
     "xdm:type": "browser",
     "xdm:browserDetails": {
@@ -19,42 +36,47 @@
     "xdm:typeID": "IPad",
     "xdm:typeIDService": "https://ns.adobe.com/xdm/external/adobecampaign"
   },
-  "https://ns.adobe.com/experience/campaign/message": {
-    "id": 10000,
-    "profile": {
-      "xdm:person": {
-        "xdm:birthMonth": 1,
-        "xdm:birthDay": 3,
-        "xdm:birthYear": 1996,
-        "xdm:gender": "female"
+  "https://ns.adobe.com/experience/campaign": {
+    "message": {
+      "id": 10000,
+      "profile": {
+        "xdm:person": {
+          "xdm:birthMonth": 1,
+          "xdm:birthDay": 3,
+          "xdm:birthYear": 1996,
+          "xdm:gender": "female"
+        },
+        "xdm:workAddress": {
+          "@id": "https://ns.adobe.com/entities/address/123",
+          "xdm:primary": true,
+          "xdm:city": "San Jose",
+          "xdm:stateProvinceISO": "CA",
+          "xdm:postalCode": "95110",
+          "xdm:countryCode": "US"
+        },
+        "xdm:workEmail": {
+          "xdm:primary": true,
+          "xdm:address": "jsmith@xyzinc.com"
+        }
       },
-      "xdm:workAddress": {
-        "@id": "https://ns.adobe.com/entities/address/123",
-        "xdm:primary": true,
-        "xdm:city": "San Jose",
-        "xdm:stateProvinceISO": "CA",
-        "xdm:postalCode": "95110",
-        "xdm:countryCode": "US"
-      },
-      "xdm:workEmail": {
-        "xdm:primary": true,
-        "xdm:address": "jsmith@xyzinc.com"
+      "variant": "English",
+      "seedMember": false,
+      "quarantine": false,
+      "proofMember": false,
+      "controlGroupMember": false,
+      "testMember": false,
+      "external": {
+        "id": "uuid:00112233-4455-6677-8899-AABBCCDDEEFF"
       }
     },
-    "variant": "English",
-    "seedMember": false,
-    "quarantine": false,
-    "proofMember": false,
-    "controlGroupMember": false,
-    "testMember": false
-  },
-  "https://ns.adobe.com/experience/campaign/delivery": {
-    "id": 1001,
-    "channel": "https://ns.adobe.com/xdm/channels/apns",
-    "testEnabled": false,
-    "messageClass": "messageCenter",
-    "templateID": 1100
-  },
-  "https://ns.adobe.com/experience/campaign/message/external/id": "uuid:00112233-4455-6677-8899-AABBCCDDEEFF",
-  "https://ns.adobe.com/experience/campaign/orchestration/businessReason": "store-entry-beacon-triggered"
+    "delivery": {
+      "id": 1001,
+      "testEnabled": false,
+      "messageClass": "messageCenter",
+      "templateID": 1100
+    },
+    "orchestration": {
+      "businessReason": "store-entry-beacon-triggered"
+    }
+  }
 }

--- a/extensions/adobe/experience/campaign/experienceevent.example.sms-bounce.json
+++ b/extensions/adobe/experience/campaign/experienceevent.example.sms-bounce.json
@@ -5,44 +5,66 @@
       "xdm:value": 1
     }
   },
-  "https://ns.adobe.com/experience/campaign/message": {
-    "id": 10000,
-    "profile": {
-      "xdm:person": {
-        "xdm:birthMonth": 1,
-        "xdm:birthDay": 3,
-        "xdm:birthYear": 1996,
-        "xdm:gender": "female"
-      },
-      "xdm:workAddress": {
-        "@id": "https://ns.adobe.com/entities/address/123",
-        "xdm:primary": true,
-        "xdm:city": "San Jose",
-        "xdm:stateProvinceISO": "CA",
-        "xdm:postalCode": "95110",
-        "xdm:countryCode": "US"
-      },
-      "xdm:mobilePhone": {
-        "xdm:primary": true,
-        "xdm:number": "1-408-888-8888"
+  "xdm:channel": "https://ns.adobe.com/xdm/channels/sms",
+  "xdm:endUserIDs": {
+    "https://ns.adobe.com/experience/mcid": {
+      "@id": "https://data.adobe.io/entities/identity/92312748749128",
+      "xdm:namespace": {
+        "@id": "https://data.adobe.io/entities/namespace/4",
+        "xdm:code": "ECID"
       }
     },
-    "seedMember": false,
-    "quarantine": true,
-    "proofMember": false,
-    "controlGroupMember": false,
-    "testMember": false,
-    "size": 2,
-    "reason": "unknown_user",
-    "reasonMessage": "554: Unknown Recipient."
+    "https://ns.adobe.com/experience/campaign": {
+      "@id": "https://data.adobe.io/entities/identity/1234567",
+      "xdm:namespace": {
+        "@id": "https://data.adobe.io/entities/namespace/2756",
+        "xdm:code": "CPGN"
+      }
+    }
   },
-  "https://ns.adobe.com/experience/campaign/delivery": {
-    "id": 1001,
-    "channel": "https://ns.adobe.com/xdm/channels/sms",
-    "from": "CP-ADOBE",
-    "testEnabled": false,
-    "messageClass": "oneTime"
-  },
-  "https://ns.adobe.com/experience/campaign/message/external/id": "uuid:00112233-4455-6677-8899-AABBCCDDEEFF",
-  "https://ns.adobe.com/experience/campaign/orchestration/businessReason": "onJourneyEnter"
+  "https://ns.adobe.com/experience/campaign": {
+    "message": {
+      "id": 10000,
+      "profile": {
+        "xdm:person": {
+          "xdm:birthMonth": 1,
+          "xdm:birthDay": 3,
+          "xdm:birthYear": 1996,
+          "xdm:gender": "female"
+        },
+        "xdm:workAddress": {
+          "@id": "https://ns.adobe.com/entities/address/123",
+          "xdm:primary": true,
+          "xdm:city": "San Jose",
+          "xdm:stateProvinceISO": "CA",
+          "xdm:postalCode": "95110",
+          "xdm:countryCode": "US"
+        },
+        "xdm:mobilePhone": {
+          "xdm:primary": true,
+          "xdm:number": "1-408-888-8888"
+        }
+      },
+      "seedMember": false,
+      "quarantine": true,
+      "proofMember": false,
+      "controlGroupMember": false,
+      "testMember": false,
+      "size": 2,
+      "reason": "unknown_user",
+      "reasonMessage": "554: Unknown Recipient.",
+      "external": {
+        "id": "uuid:00112233-4455-6677-8899-AABBCCDDEEFF"
+      }
+    },
+    "delivery": {
+      "id": 1001,
+      "from": "CP-ADOBE",
+      "testEnabled": false,
+      "messageClass": "oneTime"
+    },
+    "orchestration": {
+      "businessReason": "onJourneyEnter"
+    }
+  }
 }

--- a/extensions/adobe/experience/campaign/experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign/experienceevent.schema.json
@@ -146,7 +146,7 @@
           "type": "integer",
           "description": "The campaign activity originating this message."
         },
-        "https://ns.adobe.com/experience/campaign/campaign/id": {
+        "https://ns.adobe.com/experience/campaign/marketingCampaign/id": {
           "title": "CampaignID",
           "type": "integer",
           "description":
@@ -207,14 +207,15 @@
           "minimum": 1,
           "maximum": 32767
         },
-        "https://ns.adobe.com/experience/campaign/link/tags": {
-          "title": "Tags",
-          "type": "array",
-          "description":
-            "A list of tags qualifying the link. The URL category is one of those tags.",
-          "items": {
-            "type": "string"
-          }
+        "https://ns.adobe.com/experience/campaign/link/label": {
+          "title": "URL Label",
+          "type": "string",
+          "description": "The user-friendly label clicking on which the link opens."
+        },
+        "https://ns.adobe.com/experience/campaign/link/category": {
+          "title": "URL Category",
+          "type": "string",
+          "description": "The category of the link. It may be `subscription`, or a user-defined category."
         },
         "https://ns.adobe.com/experience/campaign/message/external/id": {
           "title": "External ID",


### PR DESCRIPTION
*Make Campaign link Label and Category explicit fields.
*Change Campaign resource name to `marketingcampaign` to handle protobuf parsing.
*Fix examples.

Fixes issue #301 

Out for review: @cmathis @trieloff @cdegroot-adobe 