### PR TITLE
Issue #265 - Part1 - Moved web metrics to the web contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 [Unreleased](https://github.com/adobe/xdm/releases/tag/v0.9.1)
 
 * Renames all `Metric` schemas to `Metric Definition` #254
+* Moved web metrics used in ExperienceEvent \\metrics to the webinteraction and webpageview contexts #316

--- a/schemas/context/experienceevent.example.1.json
+++ b/schemas/context/experienceevent.example.1.json
@@ -51,11 +51,6 @@
     "https://ns.adobe.com/xdm/data/metrics/commerce/purchases": {
       "xdm:value": 1.0,
       "xdm:unit": null
-    },
-    "https://ns.adobe.com/xdm/data/metrics/web/page-views": {
-      "@type": "https://ns.adobe.com/xdm/data/metrics/web/page-views",
-      "xdm:value": 1.0,
-      "xdm:unit": null
     }
   },
   "xdm:productListItems": [
@@ -109,7 +104,11 @@
       "xdm:name": "Purchase Confirmation",
       "xdm:URL": "https://www.example.com/orderConf",
       "xdm:errorPage": false,
-      "xdm:homePage": false
+      "xdm:homePage": false,
+      "https://ns.adobe.com/xdm/metrics/web/page-views": {
+        "xdm:value": 1.0,
+        "xdm:unit": null
+      }
     },
     "xdm:webReferrer": {
       "xdm:URL": "https://www.example.com/checkout",

--- a/schemas/context/webinfo.example.1.json
+++ b/schemas/context/webinfo.example.1.json
@@ -5,7 +5,10 @@
     "xdm:name": "product home",
     "xdm:URL": "https://www.example.com/products",
     "xdm:errorPage": false,
-    "xdm:homePage": true
+    "xdm:homePage": true,
+    "https://ns.adobe.com/xdm/metrics/web/page-views": {
+      "xdm:value": 1.0
+    }
   },
   "xdm:webReferrer": {
     "xdm:URL": "https://www.some-adserver.com",

--- a/schemas/context/webinfo.example.2.json
+++ b/schemas/context/webinfo.example.2.json
@@ -10,7 +10,10 @@
   "xdm:webInteraction": {
     "xdm:type": "other",
     "xdm:URL": "#stores",
-    "xdm:name": "product store"
+    "xdm:name": "product store",
+    "https://ns.adobe.com/xdm/metrics/web/link-clicks": {
+      "xdm:value": 1.0
+    }
   },
   "xdm:webReferrer": {
     "xdm:URL": "https://www.example.com/products",

--- a/schemas/context/webinteraction.example.1.json
+++ b/schemas/context/webinteraction.example.1.json
@@ -1,5 +1,8 @@
 {
   "xdm:type": "other",
   "xdm:URL": "https://www.example.com/products/store/?view=1",
-  "xdm:name": "product store"
+  "xdm:name": "product store",
+  "https://ns.adobe.com/xdm/metrics/web/link-clicks": {
+    "xdm:value": 1.0
+  }
 }

--- a/schemas/context/webinteraction.schema.json
+++ b/schemas/context/webinteraction.schema.json
@@ -34,6 +34,10 @@
           "type": "string",
           "description":
             "The normative name used for this web link, used for classification purposes"
+        },
+        "https://ns.adobe.com/xdm/metrics/web/link-clicks": {
+          "$ref": "https://ns.adobe.com/xdm/data/measure",
+          "description": "Click of a web-link has occurred."
         }
       }
     }

--- a/schemas/context/webpageview.example.1.json
+++ b/schemas/context/webpageview.example.1.json
@@ -4,5 +4,8 @@
   "xdm:name": "product home",
   "xdm:URL": "https://www.example.com",
   "xdm:errorPage": false,
-  "xdm:homePage": true
+  "xdm:homePage": true,
+  "https://ns.adobe.com/xdm/metrics/web/page-views": {
+    "xdm:value": 1.0
+  }
 }

--- a/schemas/context/webpageview.schema.json
+++ b/schemas/context/webpageview.schema.json
@@ -50,6 +50,10 @@
           "type": "boolean",
           "description":
             "Flag that indicate if the page is the site home page or not.  The definition of home page is determined by the application, but is commonly used to designate a top level landing page or common site entry point.  This flag is used to broadly categorize web interactions."
+        },
+        "https://ns.adobe.com/xdm/metrics/web/page-views": {
+          "$ref": "https://ns.adobe.com/xdm/data/measure",
+          "description": "View(s) of a webpage has occurred."
         }
       }
     }

--- a/schemas/data/metrics.schema.json
+++ b/schemas/data/metrics.schema.json
@@ -62,10 +62,6 @@
           "description":
             "Impression(s) of an advertisement to an end user with the potential of being viewed."
         },
-        "https://ns.adobe.com/xdm/data/metrics/web/link-clicks": {
-          "$ref": "https://ns.adobe.com/xdm/data/measure",
-          "description": "Click of a web-link has occurred."
-        },
         "https://ns.adobe.com/xdm/data/metrics/application/launches": {
           "$ref": "https://ns.adobe.com/xdm/data/measure",
           "description":
@@ -80,10 +76,6 @@
           "$ref": "https://ns.adobe.com/xdm/data/measure",
           "description":
             "Asynchronous message(s) failed to deliver in a way that indicates that no future delivery attempts will be successful to the address."
-        },
-        "https://ns.adobe.com/xdm/data/metrics/web/page-views": {
-          "$ref": "https://ns.adobe.com/xdm/data/measure",
-          "description": "View(s) of a webpage has occurred."
         },
         "https://ns.adobe.com/xdm/data/metrics/commerce/product-list-adds": {
           "$ref": "https://ns.adobe.com/xdm/data/measure",


### PR DESCRIPTION
Shortened the URI field name for the web events to
https://ns.adobe.com/xdm/metrics/web/* by dropping the 'data'.
Updates all examples.
Updarted the change log

Please link to the issue #265 
