### PR TITLE
Added new experienceevent schema which includes all solution extensions

### DIFF
--- a/extensions/adobe/experience/experienceevent.schema.json
+++ b/extensions/adobe/experience/experienceevent.schema.json
@@ -1,0 +1,32 @@
+{
+  "meta:license": [
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/experience/experienceevent",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "ExperienceEvent",
+  "type": "object",
+  "description":
+    "This ExperienceEvent XDM includes the core/standard ExperienceEvent as well as the Adobe solution ExperienceEvents.",
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent"
+    },
+    {
+      "$ref": "https://ns.adobe.com/experience/analytics/experienceevent"
+    },
+    {
+      "$ref": "https://ns.adobe.com/experience/target/experienceevent"
+    },
+    {
+      "$ref": "https://ns.adobe.com/experience/campaign/experienceevent"
+    }
+  ],
+  "meta:status": "experimental"
+}


### PR DESCRIPTION
This PR links to the issue #328 

@trieloff @kstreeter @cmathis @cdegroot-adobe 

This PR create a uber experienceevent schema which contains core/standard fields as well as the solution extension experienceevent fields.  