### PR TITLE
Fix wrong $id in meta:extends of campaign's address extension schema

### DIFF
--- a/extensions/adobe/experience/campaign/address.schema.json
+++ b/extensions/adobe/experience/campaign/address.schema.json
@@ -10,7 +10,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Address Extensions for Adobe Campaign",
   "type": "object",
-  "meta:extends": ["https://ns.adobe.com/xdm/context/address"],
+  "meta:extends": ["https://ns.adobe.com/xdm/common/address"],
   "description": "Address extension properties specific to Adobe Campaign.",
   "definitions": {
     "address": {


### PR DESCRIPTION
This PR links to the issue #343 

@kstreeter @trieloff @aarjain

This PR fixes wrong $id in meta:extends of campaign's address extension schema.