### PR TITLE
Updating schemas for 0.91 to 'stabilizing' status

### DIFF
--- a/schemas/context/advertising.schema.json
+++ b/schemas/context/advertising.schema.json
@@ -60,5 +60,5 @@
       "$ref": "#/definitions/advertising"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/context/adviewability.schema.json
+++ b/schemas/context/adviewability.schema.json
@@ -152,5 +152,5 @@
       "$ref": "#/definitions/adviewability"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/context/application.schema.json
+++ b/schemas/context/application.schema.json
@@ -74,5 +74,5 @@
       "$ref": "#/definitions/application"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/context/identity.schema.json
+++ b/schemas/context/identity.schema.json
@@ -47,5 +47,5 @@
       "$ref": "#/definitions/identity"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/context/implementationdetails.schema.json
+++ b/schemas/context/implementationdetails.schema.json
@@ -10,7 +10,7 @@
   "title": "Implementation Details",
   "type": "object",
   "meta:extensible": true,
-  "meta:status": "experimental",
+  "meta:status": "stabilizing",
   "description":
     "Details about the SDK, library or service used in an application's or web page's implementation of a service.",
   "definitions": {

--- a/schemas/context/namespace.schema.json
+++ b/schemas/context/namespace.schema.json
@@ -28,5 +28,5 @@
       "$ref": "#/definitions/namespace"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/context/search.schema.json
+++ b/schemas/context/search.schema.json
@@ -41,5 +41,5 @@
       "$ref": "#/definitions/search"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/context/webinfo.schema.json
+++ b/schemas/context/webinfo.schema.json
@@ -9,7 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Web Information",
   "type": "object",
-  "meta:status": "experimental",
+  "meta:status": "stabilizing",
   "description": "",
   "definitions": {
     "webinfo": {

--- a/schemas/context/webinteraction.schema.json
+++ b/schemas/context/webinteraction.schema.json
@@ -48,5 +48,5 @@
       "$ref": "#/definitions/webinteraction"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/context/webpagedetails.schema.json
+++ b/schemas/context/webpagedetails.schema.json
@@ -64,5 +64,5 @@
       "$ref": "#/definitions/webpagedetails"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/context/webreferrer.schema.json
+++ b/schemas/context/webreferrer.schema.json
@@ -57,5 +57,5 @@
       "$ref": "#/definitions/webreferrer"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/application-closes.schema.json
+++ b/schemas/data/application-closes.schema.json
@@ -45,5 +45,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/completes.schema.json
+++ b/schemas/data/completes.schema.json
@@ -43,5 +43,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/conversions.schema.json
+++ b/schemas/data/conversions.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/datasource.schema.json
+++ b/schemas/data/datasource.schema.json
@@ -46,5 +46,5 @@
       "$ref": "#/definitions/datasource"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/feature-usages.schema.json
+++ b/schemas/data/feature-usages.schema.json
@@ -45,5 +45,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/first-launches.schema.json
+++ b/schemas/data/first-launches.schema.json
@@ -45,5 +45,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/firstquartiles.schema.json
+++ b/schemas/data/firstquartiles.schema.json
@@ -43,5 +43,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/impressions.schema.json
+++ b/schemas/data/impressions.schema.json
@@ -43,5 +43,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/installs.schema.json
+++ b/schemas/data/installs.schema.json
@@ -45,5 +45,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/launches.schema.json
+++ b/schemas/data/launches.schema.json
@@ -45,5 +45,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/linkclicks.schema.json
+++ b/schemas/data/linkclicks.schema.json
@@ -45,5 +45,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/measuredmuted.schema.json
+++ b/schemas/data/measuredmuted.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/measuredwindowinactive.schema.json
+++ b/schemas/data/measuredwindowinactive.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/metricdefinition.schema.json
+++ b/schemas/data/metricdefinition.schema.json
@@ -47,5 +47,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/midpoints.schema.json
+++ b/schemas/data/midpoints.schema.json
@@ -43,5 +43,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/mirror-pages.schema.json
+++ b/schemas/data/mirror-pages.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/non-deliverables.schema.json
+++ b/schemas/data/non-deliverables.schema.json
@@ -45,5 +45,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/not-sent.schema.json
+++ b/schemas/data/not-sent.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/opens.schema.json
+++ b/schemas/data/opens.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/pageviews.schema.json
+++ b/schemas/data/pageviews.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/purchases.schema.json
+++ b/schemas/data/purchases.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/save-for-laters.schema.json
+++ b/schemas/data/save-for-laters.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/sends.schema.json
+++ b/schemas/data/sends.schema.json
@@ -45,5 +45,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/starts.schema.json
+++ b/schemas/data/starts.schema.json
@@ -43,5 +43,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/thirdquartiles.schema.json
+++ b/schemas/data/thirdquartiles.schema.json
@@ -43,5 +43,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/unmeasurableiframe.schema.json
+++ b/schemas/data/unmeasurableiframe.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/unmeasurableother.schema.json
+++ b/schemas/data/unmeasurableother.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/unsubscriptions.schema.json
+++ b/schemas/data/unsubscriptions.schema.json
@@ -45,5 +45,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/upgrades.schema.json
+++ b/schemas/data/upgrades.schema.json
@@ -45,5 +45,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/user-complaints.schema.json
+++ b/schemas/data/user-complaints.schema.json
@@ -45,5 +45,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/viewabilityeligibleimpressions.schema.json
+++ b/schemas/data/viewabilityeligibleimpressions.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/viewablecompletes.schema.json
+++ b/schemas/data/viewablecompletes.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/viewablefirstquartiles.schema.json
+++ b/schemas/data/viewablefirstquartiles.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/viewableimpressions.schema.json
+++ b/schemas/data/viewableimpressions.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/viewablemidpoints.schema.json
+++ b/schemas/data/viewablemidpoints.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }

--- a/schemas/data/viewablethirdquartiles.schema.json
+++ b/schemas/data/viewablethirdquartiles.schema.json
@@ -44,5 +44,5 @@
     }
   ],
   "required": ["@id", "schema:name", "xdm:measurement", "xdm:unit"],
-  "meta:status": "experimental"
+  "meta:status": "stabilizing"
 }


### PR DESCRIPTION
A number of the schemas we have added or updated in preparation for the 0.91 milestone have not been moved to stabilizing, this PR addresses.
