### PR TITLE
Fix value of "examples" to be array in advertisement of adcloud extension.

### DIFF
--- a/extensions/adobe/experience/adcloud/advertisement.schema.json
+++ b/extensions/adobe/experience/adcloud/advertisement.schema.json
@@ -36,7 +36,6 @@
             "display": "Display",
             "video": "Video",
             "social": "Social"
-
             }
         },
         "xdm:adUnitType": {

--- a/extensions/adobe/experience/adcloud/advertisement.schema.json
+++ b/extensions/adobe/experience/adcloud/advertisement.schema.json
@@ -23,19 +23,41 @@
           "title": "Runtime Type",
           "type": "string",
           "description": "The runtime of the ad unit itself, not the runtime of the browser or the operating system.",
-          "examples": ["unknown", "HTML5"]
+          "meta:enum": {
+            "unknown": "Unknown",
+            "HTML5": "HTML5"
+            }
         },
         "xdm:adClass": {
           "title": "Ad Class",
           "type": "string",
           "description": "Ad class of driving event.",
-          "examples": ["display", "video", "social"]
+          "meta:enum": {
+            "display": "Display",
+            "video": "Video",
+            "social": "Social"
+
+            }
         },
         "xdm:adUnitType": {
           "title": "Ad Unit Type",
           "type": "string",
           "description": "Unique identifier for the literal piece of code driving display of the ad in a browser/device.",
-          "examples": ["linearVideo", "interactiveVideo", "banner", "richMediaBanner", "newsFeedVideo", "newsFeedDisplay", "HTML5", "inPageVideo", "inPageDisplay", "facebook", "twitter", "linearTv", "vod"]
+          "meta:enum": {
+            "linearVideo": "Linear video",
+            "interactiveVideo": "Interactive video",
+            "banner": "Banner",
+            "richMediaBanner": "Rich media banner",
+            "newsFeedVideo": "News feed video",
+            "newsFeedDisplay": "News feed display",
+            "HTML5": "HTML5",
+            "inPageVideo": "In page video",
+            "inPageDisplay": "In page display",
+            "facebook":"Facebook",
+            "twitter": "Twitter",
+            "linearTv": "linear TV",
+            "vod": "VOD"
+            }
         },
         "xdm:promotedAssetId": {
           "title": "Promoted Asset ID",

--- a/extensions/adobe/experience/adcloud/advertisement.schema.json
+++ b/extensions/adobe/experience/adcloud/advertisement.schema.json
@@ -23,19 +23,19 @@
           "title": "Runtime Type",
           "type": "string",
           "description": "The runtime of the ad unit itself, not the runtime of the browser or the operating system.",
-          "examples": "unknown, HTML5"
+          "examples": ["unknown", "HTML5"]
         },
         "xdm:adClass": {
           "title": "Ad Class",
           "type": "string",
           "description": "Ad class of driving event.",
-          "examples": "display, video, social"
+          "examples": ["display", "video", "social"]
         },
         "xdm:adUnitType": {
           "title": "Ad Unit Type",
           "type": "string",
           "description": "Unique identifier for the literal piece of code driving display of the ad in a browser/device.",
-          "examples": "linearVideo, interactiveVideo, banner, richMediaBanner, newsFeedVideo, newsFeedDisplay, HTML5, inPageVideo, inPageDisplay, facebook, twitter, linearTv, vod"
+          "examples": ["linearVideo", "interactiveVideo", "banner", "richMediaBanner", "newsFeedVideo", "newsFeedDisplay", "HTML5", "inPageVideo", "inPageDisplay", "facebook", "twitter", "linearTv", "vod"]
         },
         "xdm:promotedAssetId": {
           "title": "Promoted Asset ID",

--- a/extensions/adobe/experience/adcloud/advertisement.schema.json
+++ b/extensions/adobe/experience/adcloud/advertisement.schema.json
@@ -54,8 +54,8 @@
             "inPageDisplay": "In page display",
             "facebook":"Facebook",
             "twitter": "Twitter",
-            "linearTv": "linear TV",
-            "vod": "VOD"
+            "linearTv": "Linear TV",
+            "vod": "Video on Demand"
             }
         },
         "xdm:promotedAssetId": {


### PR DESCRIPTION
This PR links to the issue #355 

@kstreeter @trieloff @cdegroot-adobe @gabebarcelos-adobe.

This PR fixes the "examples" value to be array.