### PR TITLE
Added custom mutationevent schema

### DIFF
--- a/extensions/adobe/experience/campaign/experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign/experienceevent.schema.json
@@ -264,15 +264,8 @@
       "properties": {
         "https://ns.adobe.com/experience/campaign/mutation": {
           "title": "Mutated fields from the previous experienceEvent.",
-          "allOf": [
-            {
-              "$ref": "https://ns.adobe.com/xdm/context/experienceevent#/definitions/experienceevent"
-            },
-            {
-              "$ref": "#/definitions/experienceevent"
-            }
-          ],
-          "description": "Information of the fields that have changed since the previous experienceevent to keep track of the state changes across events. For e.g. if when an email gets sent, an experienceEvent with metric `sends` will be sent. This may get bounced and an experienceEvent with metric `bounces` will be sent then. It may be important for a downstream application to know that the previous experienceEvent with metric `sends` is now to be invalidated. This field will contain the values from the previous experienceEvent that have a different value in the current experienceEvent."
+          "description": "Information of the fields that have changed since the previous experienceevent to keep track of the state changes across events. For e.g. if when an email gets sent, an experienceEvent with metric `sends` will be sent. This may get bounced and an experienceEvent with metric `bounces` will be sent then. It may be important for a downstream application to know that the previous experienceEvent with metric `sends` is now to be invalidated. This field will contain the values from the previous experienceEvent that have a different value in the current experienceEvent.",
+		  "$ref":"https://ns.adobe.com/experience/campaign/mutationevent"
         }
       }
     }

--- a/extensions/adobe/experience/campaign/mutationevent.schema.json
+++ b/extensions/adobe/experience/campaign/mutationevent.schema.json
@@ -1,0 +1,19 @@
+{
+  "meta:license": [
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id":"https://ns.adobe.com/experience/campaign/mutationevent",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Adobe Campaign Mutation Event",
+  "type": "object",
+  "meta:extends": ["https://ns.adobe.com/xdm/context/experienceevent"],
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/experience/campaign/experienceevent#/definitions/experienceevent"
+    }
+  ],
+  "meta:status": "experimental"
+}


### PR DESCRIPTION
Issue #361 

Doing it this way allows us to have this mutation event reference an external schema which in turn references an outside Protobuf message class. The current implementation with allOf get's expanded inline into a nested structure with repeated field names that Protobuf does not support. 
