### PR TITLE
Utilize the created/modified dates from auditable for profile, address and person schemas

### DIFF
--- a/schemas/common/address.schema.json
+++ b/schemas/common/address.schema.json
@@ -99,7 +99,7 @@
       "$ref": "https://ns.adobe.com/xdm/common/geo"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/common/auditable#/definitions/auditlog"
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
     },
     {
       "$ref": "#/definitions/address"

--- a/schemas/context/person.schema.json
+++ b/schemas/context/person.schema.json
@@ -64,7 +64,7 @@
       "$ref": "#/definitions/person"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/common/auditable#/definitions/auditlog"
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
     }
   ],
   "meta:status": "experimental"

--- a/schemas/context/profile.schema.json
+++ b/schemas/context/profile.schema.json
@@ -96,7 +96,7 @@
           "$ref": "https://ns.adobe.com/xdm/common/geounit",
           "description":
             "The geographical unit within the organization owning the profile. This can be used to reference the geographical information maintained in another dataset."
-        },        
+        },
         "xdm:preferredLanguage": {
           "title": "Preferred Language",
           "type": "string",
@@ -159,7 +159,7 @@
       "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/common/auditable#/definitions/auditlog"
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
     },
     {
       "$ref": "#/definitions/profile"


### PR DESCRIPTION
This PR links to the issue #392 

@kstreeter @trieloff @cmathis @cdegroot-adobe @saurabhere 

Currently, the platform xdm schemas below do not utilize the created/modified dates from "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties" in the auditable schema.

-common/address
-context/person
-context/profile

We need to include those per Campaign's request.