### PR TITLE
issue400-Use $ref for array of items.

### DIFF
--- a/extensions/adobe/experience/analytics/keyvalue.schema.json
+++ b/extensions/adobe/experience/analytics/keyvalue.schema.json
@@ -5,28 +5,28 @@
     "you may not use this file except in compliance with the License. You may obtain a copy",
     "of the License at https://creativecommons.org/licenses/by/4.0/"
   ],
-  "$id": "https://ns.adobe.com/experience/analytics/keyedlist",
+  "$id": "https://ns.adobe.com/experience/analytics/keyvalue",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Keyed List",
+  "title": "Key value pair",
   "type": "object",
-  "description": "List of keyed values.",
+  "description": "Key value pair.",
   "definitions": {
-    "keyedlist": {
+    "keyvalue": {
       "properties": {
-        "xdm:list": {
-          "title": "Keyed List",
-          "type": "array",
-          "items": {
-            "$ref": "https://ns.adobe.com/experience/analytics/keyvalue"
-          },
-          "description": "List of keyed values."
+        "xdm:key": {
+          "title": "Key",
+          "description": "Key",
+          "type": "string"
+        },
+        "xdm:value": {
+          "title": "Value",
+          "description": "Value",
+          "type": "string"
         }
       }
     }
   },
-  "allOf":[
-    {
-       "$ref":"#/definitions/keyedlist"
-    }
-  ]
+  "allOf": [{
+    "$ref": "#/definitions/keyvalue"
+  }]
 }


### PR DESCRIPTION
This PR links to the issue #400 

Please review for 0.9.2 release.
@kstreeter @trieloff @cmathis @cdegroot-adobe 

Currently the platform protobuf converter does not translate nested objects inside array of items, we support $ref instead. This PR replaced the obj definition with $ref to make the schema in consistent with other platform xdm schemas and also make proto file cleaner. 
