### PR TITLE
Removed Circular Reference in Org and Geo Units

### DIFF
--- a/schemas/common/geounit.example.1.json
+++ b/schemas/common/geounit.example.1.json
@@ -1,7 +1,4 @@
 {
   "@id": "https://data.adobe.io/geo-san-jose",
-  "xdm:label": "San Jose",
-  "xdm:parentGeoUnit": {
-    "@id": "https://data.adobe.io/geo-sf-bay-area"
-  } 
+  "xdm:label": "San Jose"
 }

--- a/schemas/common/geounit.schema.json
+++ b/schemas/common/geounit.schema.json
@@ -25,11 +25,6 @@
           "title": "Label of the geographical unit.",
           "type": "string",
           "description": "The user-friendly name for the geographical unit."
-        },
-        "xdm:parentGeoUnit": {
-          "title": "Parent Geographical Unit.",
-          "$ref": "https://ns.adobe.com/xdm/common/geounit",
-          "description": "Parent geographical unit of the current geographical unit in the geographical hierarchy. For e.g. `geounit` for `France` might have `xdm:parentGeoUnit` as `geounit` `Europe`."
         }
       },
       "required": ["@id"]

--- a/schemas/common/orgunit.example.1.json
+++ b/schemas/common/orgunit.example.1.json
@@ -1,7 +1,4 @@
 {
   "@id": "https://data.adobe.io/org-apparals-men",
-  "xdm:label": "Men Apparals",
-  "xdm:parentOrgUnit": {
-    "@id": "https://data.adobe.io/org-apparals"
-  }
+  "xdm:label": "Men Apparals"
 }

--- a/schemas/common/orgunit.schema.json
+++ b/schemas/common/orgunit.schema.json
@@ -25,11 +25,6 @@
           "title": "Label of the organizational unit.",
           "type": "string",
           "description": "The user-friendly name for the organizational unit."
-        },
-        "xdm:parentOrgUnit": {
-          "title": "Parent Organizational Unit.",
-          "$ref": "https://ns.adobe.com/xdm/common/orgunit",
-          "description": "The parent organizational unit of the current organizational unit in the org hierarchy. For e.g. `orgunit` for `Shirts` might have `xdm:parentOrgUnit` as `orgunit` `Apparals`."
         }
       },
       "required": ["@id"]


### PR DESCRIPTION
Remove the concept of a Parent to Geo and Org for now as we workout the correct longer term structures for this. Keeping the original breaking change.
