### PR TITLE
Change repo:assetID to repo:id

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ Avoid non-semantic limits – don’t put current resource limits in the data mo
 * don't restrict values of `string` properties beyond the constraints of the domain, e.g. don't set a `maxLength` of 255, just because your current database uses a `VARCHAR(255)` default
 * run `npm test` before you make a pull request
 * convention is that property names are in camelCase, when they appear in JSON
-* Acronyms and abbreviations in camelCase like ID, API, JSON are also capitalized in camelCase, such as `assetID`
+* Acronyms and abbreviations in camelCase like ID, API, JSON are also capitalized in camelCase, such as `documentID`
 * When combining two acronyms, use lowercase for the first and uppercase for the second, such as `dmaID`
 * don't invent your own `ID` attributes, use the `@id` convention
 * don't invent your own `type` attributes, use the `@type` convention

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -22,7 +22,7 @@ Some XDM schemas might be declared non-extensible, which means that any property
 
 XDM generally separates two kinds of properties:
 
-1.  Standard properties are part of the XDM specification, and follow a pattern of `prefix:name`. For instance, `repo:id` is the unique identifier of assets in the content repository.
+1.  Standard properties are part of the XDM specification, and follow a pattern of `prefix:name`. For instance, `repo:id` is the unique identifier of assets in a repository.
 2.  Extension properties are not part of the XDM specification and have been defined by a customer, a partner, or by Adobe for things that are specific to one implementation. Extension property names are always URIs like `http://example.com/ns/xdm/my_property`
 
 XDM comes with a small list of allowed prefixes that correspond to the namespace URIs of the standards that XDM is incorporating.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -22,7 +22,7 @@ Some XDM schemas might be declared non-extensible, which means that any property
 
 XDM generally separates two kinds of properties:
 
-1.  Standard properties are part of the XDM specification, and follow a pattern of `prefix:name`. For instance, `repo:assetID` is the unique identifier of assets in XDM.
+1.  Standard properties are part of the XDM specification, and follow a pattern of `prefix:name`. For instance, `repo:id` is the unique identifier of assets in the content repository.
 2.  Extension properties are not part of the XDM specification and have been defined by a customer, a partner, or by Adobe for things that are specific to one implementation. Extension property names are always URIs like `http://example.com/ns/xdm/my_property`
 
 XDM comes with a small list of allowed prefixes that correspond to the namespace URIs of the standards that XDM is incorporating.
@@ -48,7 +48,7 @@ This ensures that no matter who is generating an XDM document, or how the XDM do
 ```json
 {
   "https://ns.example.com/asset_name": "custom_asset_1",
-  "repo:assetID": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
+  "repo:id": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
   "xmp:createDate": "2017-09-26T15:52:25+00:00",
   "repo:createdDate": "2017-09-26T15:52:25+00:00",
   "xdm:repositoryCreatedBy": "lars",

--- a/extensions/adobe/experience/offer-management/offer-representation.schema.json
+++ b/extensions/adobe/experience/offer-management/offer-representation.schema.json
@@ -96,7 +96,7 @@
             "repo:name": {
               "type": "string",
               "description":
-                "Some hint about where to locate the repository that stores the external asset by the \"repo:assetID\".",
+                "Some hint about where to locate the repository that stores the external asset by the \"repo:id\".",
             },
             "repo:id": {
               "type": "string",

--- a/schemas/assets/aggregated-asset.example.1.json
+++ b/schemas/assets/aggregated-asset.example.1.json
@@ -1,5 +1,5 @@
 {
-  "repo:assetID": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
+  "repo:id": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
   "xmp:createDate": "2017-09-26T15:52:25+00:00",
   "repo:createdDate": "2017-09-26T15:52:25+00:00",
   "xdm:repositoryCreatedBy": "lars",

--- a/schemas/assets/asset.example.1.json
+++ b/schemas/assets/asset.example.1.json
@@ -1,5 +1,5 @@
 {
-  "repo:assetID": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
+  "repo:id": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
   "xmp:createDate": "2017-09-26T15:52:25+00:00",
   "repo:createdDate": "2017-09-26T15:52:25+00:00",
   "xdm:repositoryCreatedBy": "lars",

--- a/schemas/assets/asset.schema.json
+++ b/schemas/assets/asset.schema.json
@@ -438,7 +438,7 @@
     "dc:format",
     "repo:createdDate",
     "repo:lastModifiedDate",
-    "repo:assetID",
+    "repo:id",
     "repo:etag",
     "repo:version",
     "repo:size"

--- a/schemas/assets/image.example.1.json
+++ b/schemas/assets/image.example.1.json
@@ -1,5 +1,5 @@
 {
-  "repo:assetID": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
+  "repo:id": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
   "xmp:createDate": "2017-09-26T15:52:25+00:00",
   "repo:createdDate": "2017-09-26T15:52:25+00:00",
   "xdm:repositoryCreatedBy": "lars",

--- a/schemas/assets/image.schema.json
+++ b/schemas/assets/image.schema.json
@@ -162,7 +162,7 @@
     }
   ],
   "required": [
-    "repo:assetID",
+    "repo:id",
     "repo:createdDate",
     "xdm:repositoryCreatedBy",
     "repo:lastModifiedDate",

--- a/schemas/assets/video.example.1.json
+++ b/schemas/assets/video.example.1.json
@@ -1,5 +1,5 @@
 {
-  "repo:assetID": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ac",
+  "repo:id": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ac",
   "xmp:createDate": "2017-09-26T15:52:25+00:00",
   "repo:createdDate": "2017-09-26T15:52:25+00:00",
   "xdm:repositoryCreatedBy": "lars",

--- a/schemas/assets/video.example.2.json
+++ b/schemas/assets/video.example.2.json
@@ -1,5 +1,5 @@
 {
-  "repo:assetID": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ad",
+  "repo:id": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ad",
   "xmp:createDate": "2017-09-26T15:52:25+00:00",
   "repo:createdDate": "2017-09-26T15:52:25+00:00",
   "xdm:repositoryCreatedBy": "lars",

--- a/schemas/assets/video.schema.json
+++ b/schemas/assets/video.schema.json
@@ -56,7 +56,7 @@
     }
   ],
   "required": [
-    "repo:assetID",
+    "repo:id",
     "repo:createdDate",
     "xdm:repositoryCreatedBy",
     "repo:lastModifiedDate",

--- a/schemas/common/event/created.example.1.json
+++ b/schemas/common/event/created.example.1.json
@@ -13,7 +13,7 @@
   },
   "activitystreams:object": {
     "@type": "https://ns.adobe.com/xdm/assets/asset",
-    "repo:assetID": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+    "repo:id": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
     "xdm:name": "example.jpg",
     "repo:etag": "6fc55d0389d856ae7deccebba54f110e",
     "xdm:path": "/MyFolder/example.jpg",

--- a/schemas/common/event/deleted.example.1.json
+++ b/schemas/common/event/deleted.example.1.json
@@ -13,7 +13,7 @@
   },
   "activitystreams:object": {
     "@type": "https://ns.adobe.com/xdm/assets/asset",
-    "repo:assetID": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+    "repo:id": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
     "xdm:name": "example.jpg",
     "repo:etag": "6fc55d0389d856ae7deccebba54f110e",
     "xdm:path": "/MyFolder/example.jpg",

--- a/schemas/common/event/published.example.1.json
+++ b/schemas/common/event/published.example.1.json
@@ -13,7 +13,7 @@
   },
   "activitystreams:object": {
     "@type": "https://ns.adobe.com/xdm/assets/asset",
-    "repo:assetID": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+    "repo:id": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
     "xdm:name": "example.jpg",
     "repo:etag": "6fc55d0389d856ae7deccebba54f110e",
     "xdm:path": "/MyFolder/example.jpg",

--- a/schemas/common/event/unpublished.example.1.json
+++ b/schemas/common/event/unpublished.example.1.json
@@ -13,7 +13,7 @@
   },
   "activitystreams:object": {
     "@type": "https://ns.adobe.com/xdm/assets/asset",
-    "repo:assetID": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+    "repo:id": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
     "xdm:name": "example.jpg",
     "repo:etag": "6fc55d0389d856ae7deccebba54f110e",
     "xdm:path": "/MyFolder/example.jpg",

--- a/schemas/common/event/updated.example.1.json
+++ b/schemas/common/event/updated.example.1.json
@@ -13,7 +13,7 @@
   },
   "activitystreams:object": {
     "@type": "https://ns.adobe.com/xdm/assets/asset",
-    "repo:assetID": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+    "repo:id": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
     "xdm:name": "example.jpg",
     "repo:etag": "6fc55d0389d856ae7deccebba54f110e",
     "xdm:path": "/MyFolder/example.jpg",

--- a/schemas/common/eventenvelope.example.1.json
+++ b/schemas/common/eventenvelope.example.1.json
@@ -18,7 +18,7 @@
   },
   "activitystreams:object": {
     "@type": "https://ns.adobe.com/xdm/assets/asset",
-    "repo:assetID": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+    "repo:id": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
     "@id":
       "https://cc-api-storage-stage.adobe.io/id/urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
     "xdm:name": "example.jpg",

--- a/schemas/common/eventenvelope.example.2.json
+++ b/schemas/common/eventenvelope.example.2.json
@@ -18,7 +18,7 @@
   },
   "activitystreams:object": {
     "@type": "https://ns.adobe.com/xdm/assets/asset",
-    "repo:assetID": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+    "repo:id": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
     "@id":
       "https://cc-api-storage-stage.adobe.io/id/urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185"
   }

--- a/schemas/common/eventenvelope.example.3.json
+++ b/schemas/common/eventenvelope.example.3.json
@@ -18,7 +18,7 @@
   },
   "activitystreams:object": {
     "@type": "https://ns.adobe.com/xdm/assets/asset",
-    "repo:assetID": "urn:aaid:aem:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+    "repo:id": "urn:aaid:aem:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
     "@id": "https://francois.corp.adobe.com:4502/content/dam/Fx_DUKE-small.jpg",
     "xdm:name": "Fx_DUKE-small.png",
     "xdm:path": "/content/dam/Fx_DUKE-small.png",

--- a/schemas/common/extensible.example.1.json
+++ b/schemas/common/extensible.example.1.json
@@ -1,5 +1,5 @@
 {
-  "repo:assetID": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
+  "repo:id": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
   "xdm:createDate": "2017-09-26T15:52:25+00:00",
   "repo:createdDate": "2017-09-26T15:52:25+00:00",
   "xdm:repositoryCreatedBy": "lars",

--- a/schemas/common/extensible.example.2.json
+++ b/schemas/common/extensible.example.2.json
@@ -1,6 +1,6 @@
 {
   "https://ns.example.com/asset_name": "custom_asset_1",
-  "repo:assetID": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
+  "repo:id": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
   "xdm:createDate": "2017-09-26T15:52:25+00:00",
   "repo:createdDate": "2017-09-26T15:52:25+00:00",
   "xdm:repositoryCreatedBy": "lars",

--- a/schemas/common/extensible.example.3.json
+++ b/schemas/common/extensible.example.3.json
@@ -31,7 +31,7 @@
   },
   "https://ns.example.com/path": "/custom/path/1",
   "https://ns.example.com/asset_name": "custom_asset_1",
-  "repo:assetID": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
+  "repo:id": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
   "xdm:createDate": "2017-09-26T15:52:25+00:00",
   "repo:createdDate": "2017-09-26T15:52:25+00:00",
   "xdm:repositoryCreatedBy": "lars",

--- a/schemas/content/component-container.example.1.json
+++ b/schemas/content/component-container.example.1.json
@@ -11,7 +11,7 @@
       "type": "https://francois.corp.adobe.com:4502/apps/foundation/image",
       "image": {
         "@type": "https://ns.adobe.com/xdm/assets/asset",
-        "repo:assetID": "urn:aaid:aem:4123ba4c-93a8-4c5d-b979-1234e4318185",
+        "repo:id": "urn:aaid:aem:4123ba4c-93a8-4c5d-b979-1234e4318185",
         "id":
           "https://francois.corp.adobe.com:4502/content/dam/Glasses-small.jpg"
       }

--- a/schemas/content/componentized-page.example.1.json
+++ b/schemas/content/componentized-page.example.1.json
@@ -16,7 +16,7 @@
     "title": "Sunglasses",
     "image": {
       "@type": "https://ns.adobe.com/xdm/assets/asset",
-      "repo:assetID": "urn:aaid:aem:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+      "repo:id": "urn:aaid:aem:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
       "@id":
         "https://francois.corp.adobe.com:4502/content/dam/Fx_DUKE-small.jpg"
     }

--- a/schemas/content/page-component.example.2.json
+++ b/schemas/content/page-component.example.2.json
@@ -2,7 +2,7 @@
   "@type": "https://francois.corp.adobe.com:4502/apps/foundation/image",
   "image": {
     "@type": "https://ns.adobe.com/xdm/assets/asset",
-    "repo:assetID": "urn:aaid:aem:4123ba4c-93a8-4c5d-b979-1234e4318185",
+    "repo:id": "urn:aaid:aem:4123ba4c-93a8-4c5d-b979-1234e4318185",
     "@id": "https://francois.corp.adobe.com:4502/content/dam/Glasses-small.jpg"
   }
 }

--- a/schemas/external/repo/asset.example.1.json
+++ b/schemas/external/repo/asset.example.1.json
@@ -1,5 +1,5 @@
 {
-  "repo:assetID": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
+  "repo:id": "urn:aaid:a:b:01234578-0123-ABCD-abcd-0123456789ab",
   "repo:createdDate": "2017-09-26T15:52:25+00:00",
   "repo:lastModifiedDate": "2017-09-26T15:52:25+00:00",
   "repo:version": "15",

--- a/schemas/external/repo/asset.schema.json
+++ b/schemas/external/repo/asset.schema.json
@@ -20,7 +20,7 @@
   "definitions": {
     "asset": {
       "properties": {
-        "repo:assetID": {
+        "repo:id": {
           "type": "string",
           "meta:immutable": true,
           "meta:usereditable": false,
@@ -90,7 +90,7 @@
     "dc:format",
     "repo:createdDate",
     "repo:lastModifiedDate",
-    "repo:assetID",
+    "repo:id",
     "repo:etag",
     "repo:version",
     "repo:size"


### PR DESCRIPTION
Every content type (file, composite, entity, directory) in the Platform API has an identifier that uniquely identifies the content item. The property name of this identifier is currently "repo:assetID". The term asset does not particularly fit many content item types such as directories, datasets, and other entities. Furthermore, since this identifier is specific to the repository, it seems more appropriate to use the property name "repo:id" for the repository identifier. A few of the data XDM use the term assetID to mean a different identifier.

This change set updates the repository XDM to use "repo:id" for the repository identifier property name.

Issue: https://jira.corp.adobe.com/browse/ACP-217
