### PR TITLE
add propensity to segment membership

### DIFF
--- a/schemas/context/segmentmembership.example.1.json
+++ b/schemas/context/segmentmembership.example.1.json
@@ -8,6 +8,7 @@
 	"xdm:lastQualificationTime": "2017-09-26T15:52:25+00:00",
   	"xdm:version": "1.0",
   	"xdm:validUntil" : "2017-12-26T15:52:25+00:00",
-  	"xdm:status" : "realized"
+  	"xdm:status" : "realized",
+	"xdm:propensity": 0.5
 }
 

--- a/schemas/context/segmentmembership.schema.json
+++ b/schemas/context/segmentmembership.schema.json
@@ -51,9 +51,9 @@
           "title" : "Propensity",
           "type" : "number",
           "description": "How strongly associated the membership is. When missing, assumed to be 1 (strongest level of association).",
-          "minimum" : 0,
-          "exclusiveMinimum": true,
-          "maximum" : 1
+          "exclusiveMinimum": 0,
+          "maximum" : 1,
+          "default": 1
         }
       }
     }

--- a/schemas/context/segmentmembership.schema.json
+++ b/schemas/context/segmentmembership.schema.json
@@ -52,6 +52,7 @@
           "type" : "number",
           "description": "How strongly associated the membership is. When missing, assumed to be 1 (strongest level of association).",
           "minimum" : 0,
+          "exclusiveMinimum": true,
           "maximum" : 1
         }
       }

--- a/schemas/context/segmentmembership.schema.json
+++ b/schemas/context/segmentmembership.schema.json
@@ -46,6 +46,13 @@
             "realized": "Entity is entering the segment",
             "exited": "Entity is exiting the segment"
           }
+        },
+        "xdm:propensity" : {
+          "title" : "Propensity",
+          "type" : "number",
+          "description": "How strongly associated the membership is. When missing, assumed to be 1 (strongest level of association).",
+          "minimum" : 0,
+          "maximum" : 1
         }
       }
     }


### PR DESCRIPTION
Add a concept of propensity to segment membership. Initially this was being considered for a payload value type, but @chrisdegroot, @cluby-adobe, and others felt that it seems to be an intrinsic property of membership itself. That makes more sense. 