### PR TITLE
Refactored journey attributes in reporting events

### DIFF
--- a/extensions/adobe/experience/campaign/experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign/experienceevent.schema.json
@@ -255,6 +255,11 @@
               "type": "string",
               "description":
                 "Business qualifier that identifies the event sent by the data source. It informs on the business reason for sending the event. It is unique per organization. This is used by Campaign orchestration to identify the event without inspecting its payload to determine which action should be triggered when the event is received. The value of this field is a contract between Campaign orchestration and the data source."
+            },
+            "orchestrationContext": {
+              "title": "Business Reason Details",
+              "$ref": "https://ns.adobe.com/experience/campaign/orchestration/orchestrationcommon#/definitions/journeyContext",
+              "description": "Set of attributes that are associated with every business reason."
             }
           }
         }

--- a/extensions/adobe/experience/campaign/orchestration/orchestrationcommon.json
+++ b/extensions/adobe/experience/campaign/orchestration/orchestrationcommon.json
@@ -1,0 +1,73 @@
+{
+  "meta:license": [
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id":
+    "https://ns.adobe.com/experience/campaign/orchestration/orchestrationcommon",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "User journey experience event",
+  "type": "object",
+  "meta:extensible": false,
+  "description": "",
+  "definitions": {
+    "journeyID": {
+      "title": "A Journey identifier",
+      "type": "string",
+      "format": "uri",
+      "description":"An identifier of the journey created by the marketer."
+    },
+    "journeyVersionID": {
+      "title": "A Journey Version identifier",
+      "type": "string",
+      "format": "uri",
+      "description":"An identifier denoting the version of journey on which the user is active."
+    },
+    "actionID": {
+      "title": "Action identifier",
+      "type": "string",
+      "format": "uri",
+      "description": "An identifier denoting the associated action during the step transition."
+    },
+    "journeyContext": {
+      "title":"A Journey Context",
+      "type": "object",
+      "description": "set of attributes which defines the context associated with any marketing activity.",
+      "properties": {
+        "journeyID": {
+          "title": "A Journey identifier",
+          "$ref": "#/definitions/journeyID",
+          "title": "An identifier which represent journey in the journey context"
+        },
+        "journeyVersionID":{
+          "title": "A Journey Version identifier",
+          "$ref": "#/definitions/journeyVersionID",
+          "title": "An identifier which represent a specific journey version in the journey context."
+        },
+        "actionID":{
+          "title": "Action identifier",
+          "$ref": "#/definitions/actionID",
+          "title": "An identifier which represent an action in the journey context."
+        }
+      },
+      "required": ["journeyID", "journeyVersionID", "actionID"]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/journeyID",
+    },
+    {
+      "$ref": "#/definitions/journeyVersionID",
+    },
+    {
+      "$ref": "#/definitions/actionID",
+    },
+    {
+      "$ref": "#/definitions/journeyContext",
+    }
+  ],
+  "meta:status": "stabilizing"
+}

--- a/extensions/adobe/experience/campaign/orchestration/reportingevent.schema.json
+++ b/extensions/adobe/experience/campaign/orchestration/reportingevent.schema.json
@@ -73,8 +73,7 @@
           "properties": {
             "xdm:actionID": {
               "title": "Action identifier",
-              "type": "string",
-              "format": "uri",
+              "$ref": "https://ns.adobe.com/experience/campaign/orchestration/orchestrationcommon#/definitions/actionID",
               "description": "Unique identifier denoting the associated action."
             },
             "xdm:type": {
@@ -114,8 +113,7 @@
           "properties": {
             "@id": {
               "title": "Journey unique identifier",
-              "type": "string",
-              "format": "uri",
+              "$ref": "https://ns.adobe.com/experience/campaign/orchestration/orchestrationcommon#/definitions/journeyID",
               "description":
                 "The unique identifier of the journey created by the marketer."
             }
@@ -130,8 +128,7 @@
           "properties": {
             "@id": {
               "title": "Journey version identifier",
-              "type": "string",
-              "format": "uri",
+              "$ref": "https://ns.adobe.com/experience/campaign/orchestration/orchestrationcommon#/definitions/journeyVersionID",
               "description":
                 "The unique identifier denoting the version of journey on which the user is active"
             }


### PR DESCRIPTION
#461 
Here schema structure needs to be refactored to pull out the common sub schema. Common schema should be used in both campaign experience event and voyager reporting event.