### PR TITLE
Add Delivery, Campaign name and label to experience event

### DIFF
--- a/extensions/adobe/experience/campaign/experienceevent.example.email-send.json
+++ b/extensions/adobe/experience/campaign/experienceevent.example.email-send.json
@@ -56,13 +56,17 @@
   },
   "https://ns.adobe.com/experience/campaign/delivery": {
     "xdm:id": 1001,
+    ""
     "xdm:from": "no-reply@adobe.com",
     "xdm:testEnabled": true,
     "xdm:messageClass": "continuous",
-    "xdm:templateID": 1000
+    "xdm:templateID": 1000,
+    "xdm:name": "DM200",
+    "xdm:label": "Birthday Wishes"
   },
   "https://ns.adobe.com/experience/campaign/marketingCampaign": {
-    "xdm:id": 100
+    "xdm:id": 100,
+    "xdm:name": "CAMP2010"
   },
   "https://ns.adobe.com/experience/campaign/orchestration": {
     "xdm:businessReason": "onJourneyEnter"

--- a/extensions/adobe/experience/campaign/experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign/experienceevent.schema.json
@@ -191,6 +191,16 @@
               "type": "integer",
               "description":
                 "The delivery template's ID used to initialize this delivery.\n\nThe type the template used in Adobe Campaign can be identified using the `messageClass`.\n\n* `messageClass` = `oneTime`: the template is standard delivery template.\n* `messageClass` = `continuous`: the template is a recurring delivery.\n* `messageClass` = `transactional`: the template is a transactionnal message template.\n"
+            },
+            "xdm:label": {
+              "title": "Delivery Label",
+              "type": "string",
+              "description" : "Human friendly name of the campaign activity which is originating this message."
+            },
+            "xdm:name": {
+              "title": "Delivery Internal name",
+              "type": "string",
+              "description" : "Friendly identifier of the campaign activity which is originating this message."
             }
           }
         },
@@ -202,6 +212,11 @@
               "title": "Campaign ID",
               "type": "integer",
               "description": "Identifier of the marketing campaign to which activity originating this message belongs to."
+            },
+            "xdm:name": {
+              "title": "Campaign Internal name",
+              "type": "string",
+              "description" : "Friendly identifier of the marketing campaign which is originating this message."
             }
           }
         },


### PR DESCRIPTION
Requirement is to add "Delivery name" and "Campaign Name" which is kind of friendly identifier for the user to remember instead of simple integer id. Similarly "Delivery Label" is a kind of descriptive name given to the marketing activity for easy searchable queries. 
