### PR TITLE
Add Journey context and delivery attributes in experience event

### DIFF
--- a/extensions/adobe/experience/campaign/experienceevent.example.email-send.json
+++ b/extensions/adobe/experience/campaign/experienceevent.example.email-send.json
@@ -60,12 +60,12 @@
     "xdm:testEnabled": true,
     "xdm:messageClass": "continuous",
     "xdm:templateID": 1000,
-    "xdm:name": "DM200",
-    "xdm:label": "Birthday Wishes"
+    "xdm:deliveryName": "DM200",
+    "xdm:deliveryLabel": "Birthday Wishes"
   },
   "https://ns.adobe.com/experience/campaign/marketingCampaign": {
     "xdm:id": 100,
-    "xdm:name": "CAMP2010"
+    "xdm:campaignName": "CAMP2010"
   },
   "https://ns.adobe.com/experience/campaign/orchestration": {
     "xdm:businessReason": "onJourneyEnter"

--- a/extensions/adobe/experience/campaign/experienceevent.example.email-send.json
+++ b/extensions/adobe/experience/campaign/experienceevent.example.email-send.json
@@ -69,5 +69,6 @@
   },
   "https://ns.adobe.com/experience/campaign/orchestration": {
     "xdm:businessReason": "onJourneyEnter"
-  }
+  },
+  "https://ns.adobe.com/experience/campaign/containerID": "customer-stage"
 }

--- a/extensions/adobe/experience/campaign/experienceevent.example.email-send.json
+++ b/extensions/adobe/experience/campaign/experienceevent.example.email-send.json
@@ -59,10 +59,13 @@
     "xdm:from": "no-reply@adobe.com",
     "xdm:testEnabled": true,
     "xdm:messageClass": "continuous",
-    "xdm:templateID": 1000
+    "xdm:templateID": 1000,
+    "xdm:name": "DM200",
+    "xdm:label": "Birthday Wishes"
   },
   "https://ns.adobe.com/experience/campaign/marketingCampaign": {
-    "xdm:id": 100
+    "xdm:id": 100,
+    "xdm:name": "CAMP2010"
   },
   "https://ns.adobe.com/experience/campaign/orchestration": {
     "xdm:businessReason": "onJourneyEnter"

--- a/extensions/adobe/experience/campaign/experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign/experienceevent.schema.json
@@ -276,6 +276,11 @@
               "$ref": "https://ns.adobe.com/experience/campaign/orchestration/experienceevent#/definitions/journeyContext",
               "description": "Set of attributes that are associated with every business reason."
           }
+        },
+        "https://ns.adobe.com/experience/campaign/containerID": {
+          "title": "Container identifier",
+          "type": "string",
+          "description": "The identifier denoting the container with which campaign experience event is associated."
         }
       }
     },

--- a/extensions/adobe/experience/campaign/experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign/experienceevent.schema.json
@@ -191,6 +191,16 @@
               "type": "integer",
               "description":
                 "The delivery template's ID used to initialize this delivery.\n\nThe type the template used in Adobe Campaign can be identified using the `messageClass`.\n\n* `messageClass` = `oneTime`: the template is standard delivery template.\n* `messageClass` = `continuous`: the template is a recurring delivery.\n* `messageClass` = `transactional`: the template is a transactionnal message template.\n"
+            },
+            "xdm:label": {
+              "title": "Delivery Label",
+              "type": "string",
+              "description" : "Human friendly name of the campaign activity which is originating this message."
+            },
+            "xdm:name": {
+              "title": "Delivery Internal name",
+              "type": "string",
+              "description" : "Friendly identifier of the campaign activity which is originating this message."
             }
           }
         },
@@ -202,6 +212,11 @@
               "title": "Campaign ID",
               "type": "integer",
               "description": "Identifier of the marketing campaign to which activity originating this message belongs to."
+            },
+            "xdm:name": {
+              "title": "Campaign Internal name",
+              "type": "string",
+              "description" : "Friendly identifier of the marketing campaign which is originating this message."
             }
           }
         },
@@ -255,7 +270,11 @@
               "type": "string",
               "description":
                 "Business qualifier that identifies the event sent by the data source. It informs on the business reason for sending the event. It is unique per organization. This is used by Campaign orchestration to identify the event without inspecting its payload to determine which action should be triggered when the event is received. The value of this field is a contract between Campaign orchestration and the data source."
-            }
+            },
+            "orchestrationContext": {
+              "title": "Business Reason Details",
+              "$ref": "https://ns.adobe.com/experience/campaign/orchestration/experienceevent#/definitions/journeyContext",
+              "description": "Set of attributes that are associated with every business reason."
           }
         }
       }

--- a/extensions/adobe/experience/campaign/experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign/experienceevent.schema.json
@@ -192,12 +192,12 @@
               "description":
                 "The delivery template's ID used to initialize this delivery.\n\nThe type the template used in Adobe Campaign can be identified using the `messageClass`.\n\n* `messageClass` = `oneTime`: the template is standard delivery template.\n* `messageClass` = `continuous`: the template is a recurring delivery.\n* `messageClass` = `transactional`: the template is a transactionnal message template.\n"
             },
-            "xdm:label": {
+            "xdm:deliveryLabel": {
               "title": "Delivery Label",
               "type": "string",
               "description" : "Human friendly name of the campaign activity which is originating this message."
             },
-            "xdm:name": {
+            "xdm:deliveryName": {
               "title": "Delivery Internal name",
               "type": "string",
               "description" : "Friendly identifier of the campaign activity which is originating this message."
@@ -213,7 +213,7 @@
               "type": "integer",
               "description": "Identifier of the marketing campaign to which activity originating this message belongs to."
             },
-            "xdm:name": {
+            "xdm:campaignName": {
               "title": "Campaign Internal name",
               "type": "string",
               "description" : "Friendly identifier of the marketing campaign which is originating this message."
@@ -271,7 +271,7 @@
               "description":
                 "Business qualifier that identifies the event sent by the data source. It informs on the business reason for sending the event. It is unique per organization. This is used by Campaign orchestration to identify the event without inspecting its payload to determine which action should be triggered when the event is received. The value of this field is a contract between Campaign orchestration and the data source."
             },
-            "orchestrationContext": {
+            "orchestrationDetails": {
               "title": "Business Reason Details",
               "$ref": "https://ns.adobe.com/experience/campaign/orchestration/experienceevent#/definitions/journeyContext",
               "description": "Set of attributes that are associated with every business reason."

--- a/extensions/adobe/experience/campaign/orchestration/experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign/orchestration/experienceevent.schema.json
@@ -51,7 +51,7 @@
           "format": "uri",
           "description": "Unique identifier denoting the associated action."
         },
-        "xdm:type": {
+        "xdm:actionType": {
           "title": "Action Type",
           "type": "string",
           "description": "The type of action to be performed.",

--- a/extensions/adobe/experience/campaign/orchestration/experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign/orchestration/experienceevent.schema.json
@@ -8,14 +8,14 @@
   "$id":
     "https://ns.adobe.com/experience/campaign/orchestration/experienceevent",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "User journey experience event",
+  "title": "Journey experience event",
   "type": "object",
   "description": "Orchestration extension to ExperienceEvent",
   "definitions": {
     "journey": {
-      "title": "Journey for users",
+      "title": "Journey of an entity",
       "type": "object",
-      "description": "Journey created by marketer for its users",
+      "description": "Journey created for an entity by marketer.",
       "properties": {
         "@id": {
           "title": "Journey unique identifier",
@@ -35,7 +35,7 @@
           "title": "Journey version identifier",
           "type": "string",
           "format": "uri",
-          "description": "The unique identifier denoting the version of journey on which the user is active"
+          "description": "The unique identifier denoting the version of journey on which the entity is active."
         }
       },
       "required": ["@id"]
@@ -43,7 +43,7 @@
     "action": {
       "title": "Action on step transition",
       "type": "object",
-      "description": "Action taken during a step transition happening for an user in state machine",
+      "description": "Action taken during a step transition that happened for an entity in state machine",
       "properties": {
         "xdm:actionID": {
           "title": "Action identifier",
@@ -77,15 +77,15 @@
     "journeyContext": {
       "title": "A Journey Context",
       "type": "object",
-      "description": "A journey context with which a user is associated.",
+      "description": "A journey context with which an entity is associated.",
       "properties": {
         "journey": {
-          "title": "Journey for a user",
+          "title": "Journey for an entity",
           "$ref": "#/definitions/journey",
-          "description": "Journey created by marketer for its users."
+          "description": "Journey created by marketer for its entities."
         },
         "journeyVersion": {
-          "title": "Journey Version for a user",
+          "title": "Journey Version for an entity",
           "$ref": "#/definitions/journeyVersion",
           "description": "Schema for describing the version of a journey, where version holds the state machine."
         },
@@ -93,7 +93,7 @@
           "title": "Action associated with a journey",
           "$ref": "#/definitions/journeyVersion",          
           "description":
-            "Action that is executed for an user when reached a step in in the journey state machine.",
+            "Action that is executed for an entity when reached a step in in the journey state machine.",
           "required":["xdm:actionID"]
         }
       },

--- a/extensions/adobe/experience/campaign/orchestration/experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign/orchestration/experienceevent.schema.json
@@ -1,0 +1,118 @@
+{
+  "meta:license": [
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id":
+    "https://ns.adobe.com/experience/campaign/orchestration/experienceevent",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "User journey experience event",
+  "type": "object",
+  "description": "Orchestration extension to ExperienceEvent",
+  "definitions": {
+    "journey": {
+      "title": "Journey for users",
+      "type": "object",
+      "description": "Journey created by marketer for its users",
+      "properties": {
+        "@id": {
+          "title": "Journey unique identifier",
+          "type": "string",
+          "format": "uri",
+          "description": "The unique identifier of the journey created by the marketer."
+        }
+      },
+      "required": ["@id"]
+    },
+    "journeyVersion": {
+      "title": "Journey version",
+      "type": "object",
+      "description": "Schema for describing the version of a journey, where version holds the state machine",
+      "properties": {
+        "@id": {
+          "title": "Journey version identifier",
+          "type": "string",
+          "format": "uri",
+          "description": "The unique identifier denoting the version of journey on which the user is active"
+        }
+      },
+      "required": ["@id"]
+    },
+    "action": {
+      "title": "Action on step transition",
+      "type": "object",
+      "description": "Action taken during a step transition happening for an user in state machine",
+      "properties": {
+        "xdm:actionID": {
+          "title": "Action identifier",
+          "type": "string",
+          "format": "uri",
+          "description": "Unique identifier denoting the associated action."
+        },
+        "xdm:type": {
+          "title": "Action Type",
+          "type": "string",
+          "description": "The type of action to be performed.",
+          "meta:enum": {
+            "scheduled_notification":
+              "This action type allows to specify scheduled notifications and wait for the notifications as incoming events for steps",
+            "http_call":
+              "This action type is for a HTTP call on an external system",
+            "action_with_personalization":
+              "This action type describes an action with personalization that will be resolved at runtime for each voyager instance",
+            "parameterized_action":
+              "This action type describes an action with parameterization",
+            "send_journey_notification":
+              "This action type is to send notification for another journey",
+            "acs_writer":
+              "The ACS writer action performs REST calls to an Adobe campaign standard instance to write data",
+            "acs_message_center":
+              "The ACS message center action performs REST calls to an Adobe campaign standard instance to send messages with Message Center"
+          }
+        }
+      }
+    },
+    "journeyContext": {
+      "title": "A Journey Context",
+      "type": "object",
+      "description": "A journey context with which a user is associated.",
+      "properties": {
+        "journey": {
+          "title": "Journey for a user",
+          "$ref": "#/definitions/journey",
+          "description": "Journey created by marketer for its users."
+        },
+        "journeyVersion": {
+          "title": "Journey Version for a user",
+          "$ref": "#/definitions/journeyVersion",
+          "description": "Schema for describing the version of a journey, where version holds the state machine."
+        },
+        "action": {
+          "title": "Action associated with a journey",
+          "$ref": "#/definitions/journeyVersion",          
+          "description":
+            "Action that is executed for an user when reached a step in in the journey state machine.",
+          "required":["xdm:actionID"]
+        }
+      },
+      "required":["journey", "journeyVersion", "action"]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/journey"
+    },
+    {
+      "$ref": "#/definitions/journeyVersion"
+    },
+    {
+      "$ref": "#/definitions/action"
+    },
+    {
+      "$ref": "#/definitions/journeyContext"
+    }
+  ],
+  "meta:status": "stabilizing"
+}

--- a/extensions/adobe/experience/campaign/orchestration/reportingevent.example.1.json
+++ b/extensions/adobe/experience/campaign/orchestration/reportingevent.example.1.json
@@ -31,7 +31,7 @@
   "https://ns.adobe.com/experience/campaign/orchestrationAction": {
     "xdm:actionID":
       "https://ns.adobe.com/experience/campaign/orchestration/action/123",
-    "xdm:type": "parameterized_action"
+    "xdm:actionType": "parameterized_action"
   },
   "https://ns.adobe.com/experience/campaign/orchestrationExternalEvent": {
     "@id":

--- a/extensions/adobe/experience/campaign/orchestration/reportingevent.schema.json
+++ b/extensions/adobe/experience/campaign/orchestration/reportingevent.schema.json
@@ -67,38 +67,9 @@
         },
         "https://ns.adobe.com/experience/campaign/orchestrationAction": {
           "title": "Action on step transition",
-          "type": "object",
           "description":
             "Action taken during a step transition happening for an user in state machine",
-          "properties": {
-            "xdm:actionID": {
-              "title": "Action identifier",
-              "type": "string",
-              "format": "uri",
-              "description": "Unique identifier denoting the associated action."
-            },
-            "xdm:type": {
-              "title": "Action Type",
-              "type": "string",
-              "description": "The type of action to be performed.",
-              "meta:enum": {
-                "scheduled_notification":
-                  "This action type allows to specify scheduled notifications and wait for the notifications as incoming events for steps",
-                "http_call":
-                  "This action type is for a HTTP call on an external system",
-                "action_with_personalization":
-                  "This action type describes an action with personalization that will be resolved at runtime for each voyager instance",
-                "parameterized_action":
-                  "This action type describes an action with parameterization",
-                "send_journey_notification":
-                  "This action type is to send notification for another journey",
-                "acs_writer":
-                  "The ACS writer action performs REST calls to an Adobe campaign standard instance to write data",
-                "acs_message_center":
-                  "The ACS message center action performs REST calls to an Adobe campaign standard instance to send messages with Message Center"
-              }
-            }
-          }
+          "$ref": "https://ns.adobe.com/experience/campaign/orchestration/experienceevent#/definitions/action"  
         },
         "https://ns.adobe.com/experience/campaign/orchestrationExternalEvent": {
           "title": "external event received",
@@ -109,34 +80,14 @@
         },
         "https://ns.adobe.com/experience/campaign/journey": {
           "title": "Journey for users",
-          "type": "object",
           "description": "Journey created by marketer for its users",
-          "properties": {
-            "@id": {
-              "title": "Journey unique identifier",
-              "type": "string",
-              "format": "uri",
-              "description":
-                "The unique identifier of the journey created by the marketer."
-            }
-          },
-          "required": ["@id"]
+          "$ref": "https://ns.adobe.com/experience/campaign/orchestration/experienceevent#/definitions/journey"
         },
         "https://ns.adobe.com/experience/campaign/journeyVersion": {
           "title": "Journey version",
-          "type": "object",
           "description":
             "Schema for describing the version of a journey, where version holds the state machine",
-          "properties": {
-            "@id": {
-              "title": "Journey version identifier",
-              "type": "string",
-              "format": "uri",
-              "description":
-                "The unique identifier denoting the version of journey on which the user is active"
-            }
-          },
-          "required": ["@id"]
+          "$ref": "https://ns.adobe.com/experience/campaign/orchestration/experienceevent#/definitions/journeyVersion"
         }
       }
     }


### PR DESCRIPTION
## What are the schemas that are affected by the issue
1) extensions/adobe/experience/campaign/experienceevent
2) extensions/adobe/experience/campaign/orchestration/reportingevent

## What are examples of products that are impacted by the issue
Voyager
Campaign

"reportingevent" schema is having all the attributes which constitute a valid reporting event. Here certain attributes can be pulled out from reporting event and make them available to other experience event. (Ex: Here, "Orchestration Context" in Campaign experience event). This will increase the consumability of common orchestration properties. 

Another change is to add "Delivery name" and "Campaign Name" which is kind of friendly identifier for the user to remember instead of simple integer id. Similarly "Delivery Label" is a descriptive name given to the marketing activity for making it easily searchable.