### PR TITLE
Remove the requirement for offset in advertising break

### DIFF
--- a/schemas/context/advertising-break.schema.json
+++ b/schemas/context/advertising-break.schema.json
@@ -32,8 +32,7 @@
         }
       },
       "required": [
-        "@id",
-        "xdm:offset"
+        "@id"
       ]
     }
   },


### PR DESCRIPTION
Issue: https://github.com/adobe/xdm/issues/538
When Analytics is creating an advertising break object, the only information that it has is the ID. Right now we do not have classification information and therefore cannot get the offset. We would still like to create the advertising break and not put in an inaccurate offset, but instead leave it blank.