### PR TITLE
bugfix: remove duplicate 'meta:extensible' keys

### DIFF
--- a/schemas/context/commerce.schema.json
+++ b/schemas/context/commerce.schema.json
@@ -11,7 +11,6 @@
   "type": "object",
   "meta:extensible": true,
   "description": "The entites related to buying and selling activity.",
-  "meta:extensible": true,
   "definitions": {
     "commerce": {
       "properties": {

--- a/schemas/context/webinteraction.schema.json
+++ b/schemas/context/webinteraction.schema.json
@@ -11,7 +11,6 @@
   "type": "object",
   "meta:extensible": true,
   "description": "Interaction details from inside the context of a loaded webpage.",
-  "meta:extensible": true,
   "definitions": {
     "webinteraction": {
       "properties": {

--- a/schemas/context/webpagedetails.schema.json
+++ b/schemas/context/webpagedetails.schema.json
@@ -11,7 +11,6 @@
   "type": "object",
   "meta:extensible": true,
   "description": "",
-  "meta:extensible": true,
   "definitions": {
     "webpagedetails": {
       "properties": {


### PR DESCRIPTION
I found 3 schemas with a duplicate entry of the `meta:extensible` key in the root. This causes some JSON parsers to throw an exception.