### PR TITLE
Drop duration requirement for video data

### DIFF
--- a/schemas/context/media-timed-asset-reference.schema.json
+++ b/schemas/context/media-timed-asset-reference.schema.json
@@ -82,8 +82,7 @@
         }
       },
       "required": [
-        "@id",
-        "xmpDM:duration"
+        "@id"
       ]
     }
   },


### PR DESCRIPTION
#573 
We are seeing values within Analytics of Strings that cannot be parsed into an Integer. The plan is to remove this requirement, so that we could drop the duration value without dropping the rest of the video data.
