### PR TITLE
0.9.9 remove deprecated fields, continue support for deprecated Identity related fields.

### DIFF
--- a/extensions/adobe/experience/adcloud-experienceevent.schema.json
+++ b/extensions/adobe/experience/adcloud-experienceevent.schema.json
@@ -14,7 +14,7 @@
   "meta:abstract": true,
   "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
   "meta:extends": [
-    "https://ns.adobe.com/experience/experienceevent",
+    "https://ns.adobe.com/xdm/context/experienceevent",
     "https://ns.adobe.com/xdm/context/experienceevent-advertising",
     "https://ns.adobe.com/xdm/context/experienceevent-application",
     "https://ns.adobe.com/xdm/context/experienceevent-channel",
@@ -31,7 +31,8 @@
     "https://ns.adobe.com/experience/adcloud/experienceevent-all",
     "https://ns.adobe.com/experience/target/experienceevent-shared",
     "https://ns.adobe.com/experience/profile/experienceevent-shared",
-    "https://ns.adobe.com/experience/implementations-ext"
+    "https://ns.adobe.com/experience/implementations-ext",
+    "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
   ],
   "definitions": {
     "adcloud-experienceevent": {
@@ -43,7 +44,7 @@
       "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
     },
     {
-      "$ref": "https://ns.adobe.com/experience/experienceevent"
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/experienceevent-advertising"
@@ -95,6 +96,9 @@
     },
     {
       "$ref": "https://ns.adobe.com/experience/implementations-ext"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
     },
     {
       "$ref": "#/definitions/adcloud-experienceevent"

--- a/extensions/adobe/experience/analytics-experienceevent.schema.json
+++ b/extensions/adobe/experience/analytics-experienceevent.schema.json
@@ -14,7 +14,7 @@
   "meta:abstract": true,
   "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
   "meta:extends": [
-    "https://ns.adobe.com/experience/experienceevent",
+    "https://ns.adobe.com/xdm/context/experienceevent",
     "https://ns.adobe.com/xdm/context/experienceevent-advertising",
     "https://ns.adobe.com/xdm/context/experienceevent-application",
     "https://ns.adobe.com/xdm/context/experienceevent-channel",
@@ -31,7 +31,8 @@
     "https://ns.adobe.com/experience/analytics/experienceevent-all",
     "https://ns.adobe.com/experience/target/experienceevent-shared",
     "https://ns.adobe.com/experience/profile/experienceevent-shared",
-    "https://ns.adobe.com/experience/implementations-ext"
+    "https://ns.adobe.com/experience/implementations-ext",
+    "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
   ],
   "definitions": {
     "analytics-experienceevent": {
@@ -43,7 +44,7 @@
       "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
     },
     {
-      "$ref": "https://ns.adobe.com/experience/experienceevent"
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/experienceevent-advertising"
@@ -95,6 +96,9 @@
     },
     {
       "$ref": "https://ns.adobe.com/experience/implementations-ext"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
     },
     {
       "$ref": "#/definitions/analytics-experienceevent"

--- a/extensions/adobe/experience/campaign-experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign-experienceevent.schema.json
@@ -14,7 +14,7 @@
   "meta:abstract": true,
   "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
   "meta:extends": [
-    "https://ns.adobe.com/experience/experienceevent",
+    "https://ns.adobe.com/xdm/context/experienceevent",
     "https://ns.adobe.com/xdm/context/experienceevent-advertising",
     "https://ns.adobe.com/xdm/context/experienceevent-application",
     "https://ns.adobe.com/xdm/context/experienceevent-channel",
@@ -31,7 +31,8 @@
     "https://ns.adobe.com/experience/campaign/experienceevent-all",
     "https://ns.adobe.com/experience/target/experienceevent-shared",
     "https://ns.adobe.com/experience/profile/experienceevent-shared",
-    "https://ns.adobe.com/experience/implementations-ext"
+    "https://ns.adobe.com/experience/implementations-ext",
+    "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
   ],
   "definitions": {
     "campaign-experienceevent": {
@@ -43,7 +44,7 @@
       "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
     },
     {
-      "$ref": "https://ns.adobe.com/experience/experienceevent"
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/experienceevent-advertising"
@@ -95,6 +96,9 @@
     },
     {
       "$ref": "https://ns.adobe.com/experience/implementations-ext"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
     },
     {
       "$ref": "#/definitions/campaign-experienceevent"

--- a/extensions/adobe/experience/campaign/experienceevent-all.schema.json
+++ b/extensions/adobe/experience/campaign/experienceevent-all.schema.json
@@ -242,12 +242,6 @@
           "title": "Campaign Orchestration for creating user journey.",
           "type": "object",
           "properties": {
-            "xdm:businessReason": {
-              "meta:status": "deprecated",
-              "title": "Business Reason",
-              "type": "string",
-              "description": "Business qualifier that identifies the event sent by the data source. It informs on the business reason for sending the event. It is unique per organization. This is used by Campaign orchestration to identify the event without inspecting its payload to determine which action should be triggered when the event is received. The value of this field is a contract between Campaign orchestration and the data source."
-            },
             "xdm:eventID": {
               "title": "Event ID",
               "type": "string",

--- a/extensions/adobe/experience/campaign/orchestration/experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign/orchestration/experienceevent.schema.json
@@ -71,21 +71,6 @@
             "messageService_request":
               "The message service action performs REST calls to campaign instance to send messages with messaging service"
           }
-        },
-        "xdm:type": { 
-          "title": "Action Type (Deprecated)", 
-          "type": "string", 
-          "description": "The type of action to be performed.  This field has been deprecated, use `xdm:actionType` instead", 
-          "meta:enum": {  
-            "scheduled_notification": "This action type allows to specify scheduled notifications and wait for the notifications as incoming events for steps", 
-            "http_call": "This action type is for a HTTP call on an external system", 
-            "action_with_personalization": "This action type describes an action with personalization that will be resolved at runtime for each voyager instance",  
-            "parameterized_action": "This action type describes an action with parameterization", 
-            "send_journey_notification": "This action type is to send notification for another journey",  
-            "acs_writer": "The ACS writer action performs REST calls to an Adobe campaign standard instance to write data", 
-            "acs_message_center": "The ACS message center action performs REST calls to an Adobe campaign standard instance to send messages with Message Center" 
-          },
-          "meta:status": "deprecated"
         }
       }
     }

--- a/extensions/adobe/experience/experienceevent.schema.json
+++ b/extensions/adobe/experience/experienceevent.schema.json
@@ -13,6 +13,7 @@
   "meta:abstract": true,
   "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
   "meta:extends": [
+    "https://ns.adobe.com/xdm/context/experienceevent",
     "https://ns.adobe.com/xdm/context/experienceevent-advertising",
     "https://ns.adobe.com/xdm/context/experienceevent-application",
     "https://ns.adobe.com/xdm/context/experienceevent-channel",
@@ -29,7 +30,8 @@
     "https://ns.adobe.com/experience/analytics/experienceevent-all",
     "https://ns.adobe.com/experience/adcloud/experienceevent-all",
     "https://ns.adobe.com/experience/campaign/experienceevent-all",
-    "https://ns.adobe.com/experience/target/experienceevent-all"
+    "https://ns.adobe.com/experience/target/experienceevent-all",
+    "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
   ],
   "description": "Adobe Experience Event Mixin with all Standard and Solution Mixins included.",
   "definitions": {
@@ -40,6 +42,9 @@
   "allOf": [
     {
       "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/experienceevent-advertising"
@@ -91,6 +96,9 @@
     },
     {
       "$ref": "https://ns.adobe.com/experience/target/experienceevent-all"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
     },
     {
       "$ref": "#/definitions/experienceevent"

--- a/extensions/adobe/experience/profile.schema.json
+++ b/extensions/adobe/experience/profile.schema.json
@@ -26,7 +26,8 @@
     "https://ns.adobe.com/xdm/context/profile-push-details",
     "https://ns.adobe.com/xdm/context/profile-segmentation",
     "https://ns.adobe.com/xdm/context/profile-subscriptions",
-    "https://ns.adobe.com/xdm/context/profile-test-profile"
+    "https://ns.adobe.com/xdm/context/profile-test-profile",
+    "https://ns.adobe.com/xdm/context/profile-identities-deprecated"
   ],
   "description": "Adobe Experience Profile schema.",
   "definitions": {
@@ -67,6 +68,9 @@
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/profile-test-profile"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/context/profile-identities-deprecated"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/common/auditable"

--- a/extensions/adobe/experience/target-experienceevent.schema.json
+++ b/extensions/adobe/experience/target-experienceevent.schema.json
@@ -14,7 +14,7 @@
   "meta:abstract": true,
   "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
   "meta:extends": [
-    "https://ns.adobe.com/experience/experienceevent",
+    "https://ns.adobe.com/xdm/context/experienceevent",
     "https://ns.adobe.com/xdm/context/experienceevent-advertising",
     "https://ns.adobe.com/xdm/context/experienceevent-application",
     "https://ns.adobe.com/xdm/context/experienceevent-channel",
@@ -30,7 +30,8 @@
     "https://ns.adobe.com/xdm/context/experienceevent-web",
     "https://ns.adobe.com/experience/target/experienceevent-all",
     "https://ns.adobe.com/experience/profile/experienceevent-shared",
-    "https://ns.adobe.com/experience/implementations-ext"
+    "https://ns.adobe.com/experience/implementations-ext",
+    "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
   ],
   "definitions": {
     "target-experienceevent": {
@@ -42,7 +43,7 @@
       "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
     },
     {
-      "$ref": "https://ns.adobe.com/experience/experienceevent"
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/experienceevent-advertising"
@@ -91,6 +92,9 @@
     },
     {
       "$ref": "https://ns.adobe.com/experience/implementations-ext"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
     },
     {
       "$ref": "#/definitions/target-experienceevent"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "aem_user": "packageUser",
     "aem_password": "override me securely",
     "markdown-importer-version": "0.0.4",
-    "schemas": 240
+    "schemas": 242
   },
   "scripts": {
     "clean": "rm -rf docs/reference",

--- a/schemas/context/experienceevent-enduserids-deprecated.example.1.json
+++ b/schemas/context/experienceevent-enduserids-deprecated.example.1.json
@@ -1,0 +1,23 @@
+{
+  "xdm:endUserIDs": {
+    "https://ns.adobe.com/experience/mcid": {
+      "@id": "https://data.adobe.io/entities/identity/92312748749128",
+      "xdm:namespace": {
+        "xdm:code": "ECID"
+      }
+    },
+    "https://ns.adobe.com/experience/aaid": {
+      "@id": "https://data.adobe.io/entities/identity/2394509340-30453470347",
+      "xdm:namespace": {
+        "xdm:code": "AVID"
+      }
+    },
+    "https://ns.adobe.com/experience/tntid": {
+      "@id":
+        "https://data.adobe.io/entities/identity/1233ce17-20e0-4a2c-8198-2a77fd60cf4d",
+      "xdm:namespace": {
+        "xdm:code": "tnt0051"
+      }
+    }
+  }
+}

--- a/schemas/context/experienceevent-enduserids-deprecated.schema.json
+++ b/schemas/context/experienceevent-enduserids-deprecated.schema.json
@@ -1,0 +1,37 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "ExperienceEvent endUserIDs (deprecated)",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
+  "description": "ExperienceEvent endUserIDs (deprecated).",
+  "definitions": {
+    "experienceevent-enduserids-deprecated": {
+      "properties": {
+        "xdm:endUserIDs": {
+          "meta:status": "deprecated",
+          "title": "End User IDs",
+          "$ref": "https://ns.adobe.com/xdm/context/enduserids",
+          "description": "Condensed, normalized encapsulation of all end user identifiers. Deprecated, use `xdm:identityMap` instead."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "#/definitions/experienceevent-enduserids-deprecated"
+    }
+  ],
+  "meta:status": "deprecated"
+}

--- a/schemas/context/experienceevent-profile-stitch.schema.json
+++ b/schemas/context/experienceevent-profile-stitch.schema.json
@@ -23,12 +23,6 @@
           "items" : {
             "$ref": "https://ns.adobe.com/xdm/context/profileStitch"
           }
-        },
-        "xdm:profileStitching" : {
-          "meta:status": "deprecated",
-          "title": "Profile Stitching",
-          "description": "Details about the ids that were joined by profile stitching. Deprecated, use `xdm:profileStitch`",
-          "$ref": "https://ns.adobe.com/xdm/context/profileStitch"
         }
       }
     }

--- a/schemas/context/person.schema.json
+++ b/schemas/context/person.schema.json
@@ -20,22 +20,6 @@
                     "$ref": "https://ns.adobe.com/xdm/context/person-name",
                     "description": "The person's full name"
                 },
-                "xdm:birthDay": {
-                    "title": "Birth day",
-                    "type": "integer",
-                    "description": "The day of the month a person was born (1-31).",
-                    "minimum": 1,
-                    "maximum": 31,
-                    "meta:status": "deprecated"
-                },
-                "xdm:birthMonth": {
-                    "title": "Birth month",
-                    "type": "integer",
-                    "description": "The month of the year a person was born (1-12).",
-                    "minimum": 1,
-                    "maximum": 12,
-                    "meta:status": "deprecated"
-                },
                 "xdm:birthDate": {
                     "title": "Birth Date",
                     "type": "string",

--- a/schemas/context/profile-identities-deprecated.example.1.json
+++ b/schemas/context/profile-identities-deprecated.example.1.json
@@ -1,0 +1,8 @@
+{
+  "xdm:identities": [{
+    "xdm:id": "someone@example.com",
+    "xdm:namespace": {
+      "xdm:code": "Email"
+    }
+  } ]
+}

--- a/schemas/context/profile-identities-deprecated.schema.json
+++ b/schemas/context/profile-identities-deprecated.schema.json
@@ -1,0 +1,42 @@
+{
+  "meta:license": [
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/context/profile-identities-deprecated",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Identities Array for Profile (deprecated)",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/profile"],
+  "description": "Identities Array for Profile (deprecated).",
+  "definitions": {
+    "profile-identities-deprecated": {
+      "properties": {
+        "xdm:identities": {
+          "meta:status": "deprecated",
+          "title": "All User Identities (deprecated)",
+          "type": "array",
+          "items": {
+            "$ref": "https://ns.adobe.com/xdm/context/identity"
+          },
+          "minItems": 1,
+          "description":
+            "Array of Identities. Condensed, normalized encapsulation of all end user identifiers.  Deprecated, use `xdm:identityMap` instead."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "#/definitions/profile-identities-deprecated"
+    }
+  ],
+  "meta:status": "deprecated"
+}

--- a/schemas/context/profilestitch.schema.json
+++ b/schemas/context/profilestitch.schema.json
@@ -22,22 +22,6 @@
           "title": "Version",
           "type": "string",
           "description": "The version of the profile stitch definition used. Useful for debugging."
-        },
-        "xdm:identities": {
-          "meta:status": "deprecated",
-          "title": "All User Identities",
-          "type": "array",
-          "items": {
-            "$ref": "https://ns.adobe.com/xdm/context/identity"
-          },
-          "minItems": 1,
-          "description": "Array of Identities. Condensed, normalized encapsulation of all end user identifiers. Deprecated."
-        },
-        "xdm:endUserIDs": {
-          "meta:status": "deprecated",
-          "title": "End User IDs",
-          "$ref": "https://ns.adobe.com/xdm/context/enduserids",
-          "description": "Condensed, normalized encapsulation of all end user identifiers. Deprecated"
         }
       }
     }

--- a/schemas/context/segmentmembershipitem.schema.json
+++ b/schemas/context/segmentmembershipitem.schema.json
@@ -15,17 +15,6 @@
       "properties": {
         "xdm:profileStitchID": {
           "$ref": "https://ns.adobe.com/xdm/context/profileStitchIdentity"
-        },
-        "xdm:identities": {
-          "meta:status": "deprecated",
-          "title": "All User Identities",
-          "type": "array",
-          "items": {
-            "$ref": "https://ns.adobe.com/xdm/context/identity"
-          },
-          "minItems": 1,
-          "description":
-            "Array of Identities. Condensed, normalized encapsulation of all end user identifiers.  Deprecated"
         }
       }
     }
@@ -40,4 +29,3 @@
   ],
   "meta:status": "experimental"
 }
-


### PR DESCRIPTION
Remove Deprecated fields in the experience data related schemas.
Provide continued (depercated) support for endUserIDs and Identities[]
