### PR TITLE
Correcting xdm:eventType in Campaign Extension, it should not appear in the root of EE

### DIFF
--- a/extensions/adobe/experience/campaign/orchestration/reportingexternalevent.schema.json
+++ b/extensions/adobe/experience/campaign/orchestration/reportingexternalevent.schema.json
@@ -9,7 +9,6 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "external event received",
   "type": "object",
-  "meta:extends": ["https://ns.adobe.com/xdm/context/experienceevent"],
   "description": "",
   "definitions": {
     "reportingexternalevent": {
@@ -28,9 +27,6 @@
   "allOf": [
     {
       "$ref": "#/definitions/reportingexternalevent"
-    },
-    {
-      "$ref": "https://ns.adobe.com/xdm/context/experienceevent"
     }
   ],
   "meta:status": "stabilizing"


### PR DESCRIPTION
xdm:eventType included twice, once in the allOf and once as a ref in "https://ns.adobe.com/experience/campaign/orchestration/reportingevent".

I assume the latter is correct. The former is introducing the field 
into the root of context/experienceevent and I am removing that.

