### PR TITLE
Correct the direct inclusion of the context/experienceevent class

### DIFF
--- a/extensions/adobe/experience/adcloud-experienceevent.schema.json
+++ b/extensions/adobe/experience/adcloud-experienceevent.schema.json
@@ -14,7 +14,7 @@
   "meta:abstract": true,
   "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
   "meta:extends": [
-    "https://ns.adobe.com/experience/experienceevent",
+    "https://ns.adobe.com/xdm/context/experienceevent",
     "https://ns.adobe.com/xdm/context/experienceevent-advertising",
     "https://ns.adobe.com/xdm/context/experienceevent-application",
     "https://ns.adobe.com/xdm/context/experienceevent-channel",
@@ -43,7 +43,7 @@
       "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
     },
     {
-      "$ref": "https://ns.adobe.com/experience/experienceevent"
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/experienceevent-advertising"

--- a/extensions/adobe/experience/analytics-experienceevent.schema.json
+++ b/extensions/adobe/experience/analytics-experienceevent.schema.json
@@ -14,7 +14,7 @@
   "meta:abstract": true,
   "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
   "meta:extends": [
-    "https://ns.adobe.com/experience/experienceevent",
+    "https://ns.adobe.com/xdm/context/experienceevent",
     "https://ns.adobe.com/xdm/context/experienceevent-advertising",
     "https://ns.adobe.com/xdm/context/experienceevent-application",
     "https://ns.adobe.com/xdm/context/experienceevent-channel",
@@ -43,7 +43,7 @@
       "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
     },
     {
-      "$ref": "https://ns.adobe.com/experience/experienceevent"
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/experienceevent-advertising"

--- a/extensions/adobe/experience/campaign-experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign-experienceevent.schema.json
@@ -14,7 +14,7 @@
   "meta:abstract": true,
   "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
   "meta:extends": [
-    "https://ns.adobe.com/experience/experienceevent",
+    "https://ns.adobe.com/xdm/context/experienceevent",
     "https://ns.adobe.com/xdm/context/experienceevent-advertising",
     "https://ns.adobe.com/xdm/context/experienceevent-application",
     "https://ns.adobe.com/xdm/context/experienceevent-channel",
@@ -43,7 +43,7 @@
       "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
     },
     {
-      "$ref": "https://ns.adobe.com/experience/experienceevent"
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/experienceevent-advertising"

--- a/extensions/adobe/experience/experienceevent.schema.json
+++ b/extensions/adobe/experience/experienceevent.schema.json
@@ -13,6 +13,7 @@
   "meta:abstract": true,
   "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
   "meta:extends": [
+    "https://ns.adobe.com/xdm/context/experienceevent",
     "https://ns.adobe.com/xdm/context/experienceevent-advertising",
     "https://ns.adobe.com/xdm/context/experienceevent-application",
     "https://ns.adobe.com/xdm/context/experienceevent-channel",
@@ -40,6 +41,9 @@
   "allOf": [
     {
       "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/experienceevent-advertising"

--- a/extensions/adobe/experience/target-experienceevent.schema.json
+++ b/extensions/adobe/experience/target-experienceevent.schema.json
@@ -14,7 +14,7 @@
   "meta:abstract": true,
   "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
   "meta:extends": [
-    "https://ns.adobe.com/experience/experienceevent",
+    "https://ns.adobe.com/xdm/context/experienceevent",
     "https://ns.adobe.com/xdm/context/experienceevent-advertising",
     "https://ns.adobe.com/xdm/context/experienceevent-application",
     "https://ns.adobe.com/xdm/context/experienceevent-channel",
@@ -42,7 +42,7 @@
       "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
     },
     {
-      "$ref": "https://ns.adobe.com/experience/experienceevent"
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/experienceevent-advertising"


### PR DESCRIPTION
The solution mixins were not including the context/experienceevent class directly, but by an inclusion of a mixin. This corrects that.

These changes were inadvertently in https://github.com/adobe/xdm/pull/576