### PR TITLE
Added back endUserIDs for ExperienceEvent, enabled it for solution extensions.

### DIFF
--- a/extensions/adobe/experience/adcloud-experienceevent.schema.json
+++ b/extensions/adobe/experience/adcloud-experienceevent.schema.json
@@ -31,7 +31,7 @@
     "https://ns.adobe.com/experience/target/experienceevent-shared",
     "https://ns.adobe.com/experience/profile/experienceevent-shared",
     "https://ns.adobe.com/experience/implementations-ext",
-    "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
+    "https://ns.adobe.com/xdm/context/experienceevent-enduserids"
   ],
   "definitions": {
     "adcloud-experienceevent": {
@@ -94,7 +94,7 @@
       "$ref": "https://ns.adobe.com/experience/implementations-ext"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids"
     },
     {
       "$ref": "#/definitions/adcloud-experienceevent"

--- a/extensions/adobe/experience/analytics-experienceevent.schema.json
+++ b/extensions/adobe/experience/analytics-experienceevent.schema.json
@@ -31,7 +31,7 @@
     "https://ns.adobe.com/experience/target/experienceevent-shared",
     "https://ns.adobe.com/experience/profile/experienceevent-shared",
     "https://ns.adobe.com/experience/implementations-ext",
-    "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
+    "https://ns.adobe.com/xdm/context/experienceevent-enduserids"
   ],
   "definitions": {
     "analytics-experienceevent": {
@@ -94,7 +94,7 @@
       "$ref": "https://ns.adobe.com/experience/implementations-ext"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids"
     },
     {
       "$ref": "#/definitions/analytics-experienceevent"

--- a/extensions/adobe/experience/campaign-experienceevent.schema.json
+++ b/extensions/adobe/experience/campaign-experienceevent.schema.json
@@ -31,7 +31,7 @@
     "https://ns.adobe.com/experience/target/experienceevent-shared",
     "https://ns.adobe.com/experience/profile/experienceevent-shared",
     "https://ns.adobe.com/experience/implementations-ext",
-    "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
+    "https://ns.adobe.com/xdm/context/experienceevent-enduserids"
   ],
   "definitions": {
     "campaign-experienceevent": {
@@ -94,7 +94,7 @@
       "$ref": "https://ns.adobe.com/experience/implementations-ext"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids"
     },
     {
       "$ref": "#/definitions/campaign-experienceevent"

--- a/extensions/adobe/experience/target-experienceevent.schema.json
+++ b/extensions/adobe/experience/target-experienceevent.schema.json
@@ -30,7 +30,7 @@
     "https://ns.adobe.com/experience/target/experienceevent-all",
     "https://ns.adobe.com/experience/profile/experienceevent-shared",
     "https://ns.adobe.com/experience/implementations-ext",
-    "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
+    "https://ns.adobe.com/xdm/context/experienceevent-enduserids"
   ],
   "definitions": {
     "target-experienceevent": {
@@ -90,7 +90,7 @@
       "$ref": "https://ns.adobe.com/experience/implementations-ext"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids-deprecated"
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids"
     },
     {
       "$ref": "#/definitions/target-experienceevent"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "aem_user": "packageUser",
     "aem_password": "override me securely",
     "markdown-importer-version": "0.0.4",
-    "schemas": 241
+    "schemas": 242
   },
   "scripts": {
     "clean": "rm -rf docs/reference",

--- a/schemas/context/experienceevent-enduserids.example.1.json
+++ b/schemas/context/experienceevent-enduserids.example.1.json
@@ -1,0 +1,23 @@
+{
+  "xdm:endUserIDs": {
+    "https://ns.adobe.com/experience/mcid": {
+      "@id": "https://data.adobe.io/entities/identity/92312748749128",
+      "xdm:namespace": {
+        "xdm:code": "ECID"
+      }
+    },
+    "https://ns.adobe.com/experience/aaid": {
+      "@id": "https://data.adobe.io/entities/identity/2394509340-30453470347",
+      "xdm:namespace": {
+        "xdm:code": "AVID"
+      }
+    },
+    "https://ns.adobe.com/experience/tntid": {
+      "@id":
+        "https://data.adobe.io/entities/identity/1233ce17-20e0-4a2c-8198-2a77fd60cf4d",
+      "xdm:namespace": {
+        "xdm:code": "tnt0051"
+      }
+    }
+  }
+}

--- a/schemas/context/experienceevent-enduserids.schema.json
+++ b/schemas/context/experienceevent-enduserids.schema.json
@@ -1,0 +1,36 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/context/experienceevent-enduserids",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "ExperienceEvent endUserIDs",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
+  "description": "Condensed, normalized encapsulation of end user identifiers asserted for this ExperienceEvent.",
+  "definitions": {
+    "experienceevent-enduserids": {
+      "properties": {
+        "xdm:endUserIDs": {
+          "title": "End User IDs",
+          "$ref": "https://ns.adobe.com/xdm/context/enduserids",
+          "description": "Condensed, normalized encapsulation of end user identifiers asserted for this ExperienceEvent."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "#/definitions/experienceevent-enduserids"
+    }
+  ],
+  "meta:status": "stabilizing"
+}


### PR DESCRIPTION
This PR brings back endUserIDs for Experience Event and clarifies that it contains the user ids asserted during capture of the EE.

LEFT UNTOUCHED:
context/experienceevent-enduserids-deprecated.schema.json, that will 
need to be removed later.

NON BREAKING CHANGE:
to solution template mixins to use new non 
deprecated endUserIDs

