### PR TITLE
Correct common/auditable schema

### DIFF
--- a/schemas/common/auditable.schema.json
+++ b/schemas/common/auditable.schema.json
@@ -48,7 +48,7 @@
       "$ref": "#/definitions/auditlog"
     },
     {
-      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#definitions/date-properties"
+      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
     }
   ],
   "meta:status": "experimental"

--- a/schemas/common/auditable.schema.json
+++ b/schemas/common/auditable.schema.json
@@ -9,7 +9,6 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Audit Trail",
   "type": "object",
-  "meta:extends": ["http://ns.adobe.com/adobecloud/core/1.0"],
   "meta:abstract": true,
   "description":
     "Inheriting this schema using `allOf` indicates that the data record is auditable, i.e. it can be determined when the record has last been modified and by whom.",
@@ -19,27 +18,27 @@
         "xdm:repositoryCreatedBy": {
           "title": "Created by User Identifier",
           "type": "string",
-          "description": "User id who has created the entity.\n"
+          "description": "User id who has created the entity."
         },
         "xdm:repositoryLastModifiedBy": {
           "title": "Modified by User Identifier",
           "type": "string",
           "description":
-            "User id who last modified the entity.\nAt creation time, `modifiedByUser` is set as `createdByUser`.\n"
+            "User id who last modified the entity. At creation time, `modifiedByUser` is set as `createdByUser`."
         },
         "xdm:createdByBatchID": {
           "title": "Created by Batch Identifier",
           "type": "string",
           "format": "uri",
           "description":
-            "The Data Set Files in Catalog Services which has been originating the creation of the entity.\n"
+            "The Data Set Files in Catalog Services which has been originating the creation of the entity."
         },
         "xdm:modifiedByBatchID": {
           "title": "Modified by Batch Identifier",
           "type": "string",
           "format": "uri",
           "description":
-            "The last Data Set Files in Catalog Services which has modified the entity.\nAt creation time, `modifiedByBatchID` is set as `createdByBatchID`.\n"
+            "The last Data Set Files in Catalog Services which has modified the entity. At creation time, `modifiedByBatchID` is set as `createdByBatchID`."
         }
       }
     }
@@ -47,10 +46,6 @@
   "allOf": [
     {
       "$ref": "#/definitions/auditlog"
-    },
-    {
-      "$ref":
-        "http://ns.adobe.com/adobecloud/core/1.0#/definitions/date-properties"
     }
   ],
   "meta:status": "experimental"

--- a/schemas/common/auditable.schema.json
+++ b/schemas/common/auditable.schema.json
@@ -46,6 +46,9 @@
   "allOf": [
     {
       "$ref": "#/definitions/auditlog"
+    },
+    {
+      "$ref": "http://ns.adobe.com/adobecloud/core/1.0#definitions/date-properties"
     }
   ],
   "meta:status": "experimental"

--- a/schemas/common/auditable.schema.json
+++ b/schemas/common/auditable.schema.json
@@ -11,7 +11,7 @@
   "type": "object",
   "meta:abstract": true,
   "description":
-    "Inheriting this schema using `allOf` indicates that the data record is auditable, i.e. it can be determined when the record has last been modified and by whom.",
+    "Inclusion of this schema indicates that the data record is auditable, i.e. it can be determined when the record has last been modified and by whom.",
   "definitions": {
     "auditlog": {
       "properties": {

--- a/schemas/common/auditable.schema.json
+++ b/schemas/common/auditable.schema.json
@@ -29,14 +29,14 @@
         "xdm:createdByBatchID": {
           "title": "Created by Batch Identifier",
           "type": "string",
-          "format": "uri",
+          "format": "uri-reference",
           "description":
             "The Data Set Files in Catalog Services which has been originating the creation of the entity."
         },
         "xdm:modifiedByBatchID": {
           "title": "Modified by Batch Identifier",
           "type": "string",
-          "format": "uri",
+          "format": "uri-reference",
           "description":
             "The last Data Set Files in Catalog Services which has modified the entity. At creation time, `modifiedByBatchID` is set as `createdByBatchID`."
         }

--- a/schemas/context/profile.schema.json
+++ b/schemas/context/profile.schema.json
@@ -14,7 +14,6 @@
   "meta:abstract": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/data/record",
-    "https://ns.adobe.com/xdm/common/auditable",
     "https://ns.adobe.com/xdm/context/identitymap"
   ],
   "description":


### PR DESCRIPTION
The `common/auditable.schema.json` has the following problems:
1. It meta:extends and allOfs a schema that does not exist.
2. The descriptions contain newlines.
3. The Description talks about the use of `allOf` which it too low level semantics.
4. The IDs are of format=uri, they need to be updated to format=uri-reference.

Correct common/auditable schema
