### PR TITLE
Adobe campaign extension to experience event profile snap shot

### DIFF
--- a/extensions/adobe/experience/campaign/experienceevent-all.schema.json
+++ b/extensions/adobe/experience/campaign/experienceevent-all.schema.json
@@ -28,7 +28,7 @@
             "xdm:profileSnapshot": {
               "title": "Profile Snapshot",
               "$ref": "https://ns.adobe.com/experience/campaign/profile-snapshot",
-              "description": 
+              "description": "Profile Snapshot contains the recipient of the message. This property is primarily used to link the message to a Profile using the `IdentityMap` but it can also be used to freeze some properties of the profile at the time the message was sent."
             },
             "xdm:variant": {
               "title": "Content Variant",

--- a/extensions/adobe/experience/campaign/experienceevent-all.schema.json
+++ b/extensions/adobe/experience/campaign/experienceevent-all.schema.json
@@ -25,10 +25,10 @@
               "type": "number",
               "description": "Identifier of the message."
             },
-            "xdm:profile": {
-              "title": "Profile",
-              "$ref": "https://ns.adobe.com/xdm/context/profile",
-              "description": "The recipient of the message. This property is primarily used to link the message to a Profile using the `EndCustomerID` but it can also be used to freeze some properties of the profile at the time the message was sent."
+            "xdm:profileSnapshot": {
+              "title": "Profile Snapshot",
+              "$ref": "https://ns.adobe.com/experience/campaign/profile-snapshot",
+              "description": 
             },
             "xdm:variant": {
               "title": "Content Variant",

--- a/extensions/adobe/experience/campaign/profile-snapshot.example.1.json
+++ b/extensions/adobe/experience/campaign/profile-snapshot.example.1.json
@@ -1,5 +1,5 @@
 {
-  "xdm:person":{
+  "xdm:person": {
     "xdm:name": {
       "xdm:firstName": "Jane",
       "xdm:middleName": "F",

--- a/extensions/adobe/experience/campaign/profile-snapshot.example.1.json
+++ b/extensions/adobe/experience/campaign/profile-snapshot.example.1.json
@@ -1,0 +1,86 @@
+{
+  "xdm:person":{
+    "xdm:name": {
+      "xdm:firstName": "Jane",
+      "xdm:middleName": "F",
+      "xdm:lastName": "Doe",
+      "xdm:fullName": "Jane F. Doe"
+    },
+    "xdm:birthDayAndMonth": "01-03",
+    "xdm:gender": "female"
+  },
+  "xdm:directMarketingPhone": {
+    "xdm:primary": true,
+    "xdm:number": "1-408-888-8888",
+    "xdm:status": "active",
+    "xdm:errorCount": 0
+  },
+  "xdm:directMarketingAddress": {
+    "@id": "https://data.adobe.io/entities/address/123",
+    "xdm:primary": false,
+    "xdm:street1": "345 Park Ave",
+    "xdm:city": "San Jose",
+    "xdm:stateProvince": "US-CA",
+    "xdm:postalCode": "95110",
+    "xdm:country": "United States",
+    "xdm:countryCode": "US",
+    "schema:latitude": 37.3382,
+    "schema:longitude": 121.8863,
+    "xdm:status": "active",
+    "xdm:lastVerifiedDate": "2018-01-02",
+    "xdm:errorCount": 0,
+    "xdm:quality": "Fully-recognized street"
+  },
+  "xdm:directMarketingEmail": {
+    "xdm:primary": false,
+    "xdm:address": "jsmith@xyzinc.com",
+    "xdm:label": "John Smith",
+    "xdm:type": "work",
+    "xdm:status": "active",
+    "xdm:errorCount": 0
+  },
+  "xdm:pushNotificationTokens": [
+    {
+      "xdm:token": "ABC123DEFG",
+      "xdm:registrationDate": "2017-09-26T15:52:25+00:00",
+      "xdm:environment": {
+        "xdm:type": "browser",
+        "xdm:browserDetails": {
+          "xdm:name": "Chrome",
+          "xdm:version": "63.0.3239",
+          "xdm:acceptLanguage": "en",
+          "xdm:cookiesEnabled": true,
+          "xdm:javaScriptEnabled": true,
+          "xdm:javaScriptVersion": "1.8.5",
+          "xdm:javaEnabled": true,
+          "xdm:javaVersion": "Java SE 8",
+          "xdm:viewportHeight": 600,
+          "xdm:viewportWidth": 300
+        },
+        "xdm:operatingSystem": "iOS",
+        "xdm:operatingSystemVersion": "11.2.1",
+        "xdm:connectionType": "mobile"
+      },
+      "xdm:device": {
+        "xdm:typeId": "TypeIdentifier-111",
+        "xdm:typeIdService": "deviceAtlas",
+        "xdm:type": "mobile",
+        "xdm:manufacturer": "Apple",
+        "xdm:model": "iPhone 6",
+        "xdm:modelNumber": "A1586",
+        "xdm:screenHeight": 667,
+        "xdm:screenWidth": 375,
+        "xdm:colorDepth": 16777216
+      },
+      "xdm:application": {
+        "xdm:id": "Abc123",
+        "xdm:name": "facebook",
+        "xdm:version": "153.0"
+      },
+      "xdm:channel": {
+        "@id": "https://ns.adobe.com/xdm/channels/facebook-feed",
+        "@type": "https://ns.adobe.com/xdm/channel-types/social"
+      }
+    }
+  ]
+}

--- a/extensions/adobe/experience/campaign/profile-snapshot.schema.json
+++ b/extensions/adobe/experience/campaign/profile-snapshot.schema.json
@@ -9,8 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Adobe Campaign Profile Snapshot",
   "type": "object",
-  "description":
-    "Adobe Campaign Profile Snapshot contains the recipient of the message. This property is primarily used to link the message to a Profile using the `IdentityMap` but it can also be used to freeze some properties of the profile at the time the message was sent.",
+  "description": "Adobe Campaign Profile Snapshot contains the recipient of the message. This property is primarily used to link the message to a Profile using the `IdentityMap` but it can also be used to freeze some properties of the profile at the time the message was sent.",
   "definitions": {
     "profile-snapshot": {
       "properties": {
@@ -32,8 +31,7 @@
         "xdm:pushNotificationTokens": {
           "title": "Push Notification Tokens",
           "type": "array",
-          "description":
-            "Push notification tokens are used to communicate with applications that are installed on devices or SaaS application accounts.",
+          "description": "Push notification tokens are used to communicate with applications that are installed on devices or SaaS application accounts.",
           "items": {
             "$ref": "https://ns.adobe.com/xdm/context/pushnotificationtoken"
           }

--- a/extensions/adobe/experience/campaign/profile-snapshot.schema.json
+++ b/extensions/adobe/experience/campaign/profile-snapshot.schema.json
@@ -13,20 +13,25 @@
   "definitions": {
     "profile-snapshot": {
       "properties": {
-        "xdm:workEmail": {
-          "title": "Work Email",
-          "$ref": "https://ns.adobe.com/xdm/context/emailaddress",
-          "description": "A work email address."
-        },
         "xdm:person": {
           "title": "Person",
           "$ref": "https://ns.adobe.com/xdm/context/person",
           "description": "An individual actor, contact, or owner."
         },
-        "xdm:homeAddress": {
-          "title": "Home Address",
-          "$ref": "https://ns.adobe.com/xdm/common/address",
-          "description": "A home postal address."
+        "xdm:directMarketingAddress": {
+          "title": "Direct Marketing Address",
+          "$ref": "https://ns.adobe.com/xdm/context/directmarketing-address",
+          "description": "Direct Marketing postal address."
+        },
+        "xdm:directMarketingEmail": {
+          "title": "Direct Marketing Email",
+          "$ref": "https://ns.adobe.com/xdm/context/directmarketing-emailaddress",
+          "description": "Direct Marketing email address."
+        },
+        "xdm:directMarketingPhone": {
+          "title": "Direct Marketing Phone",
+          "$ref": "https://ns.adobe.com/xdm/context/directmarketing-phonenumber",
+          "description": "Direct Marketing phone number."
         },
         "xdm:pushNotificationTokens": {
           "title": "Push Notification Tokens",

--- a/extensions/adobe/experience/campaign/profile-snapshot.schema.json
+++ b/extensions/adobe/experience/campaign/profile-snapshot.schema.json
@@ -1,0 +1,50 @@
+{
+  "meta:license": [
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/experience/campaign/profile-snapshot",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Adobe Campaign Profile Snapshot",
+  "type": "object",
+  "description":
+    "Adobe Campaign Profile Snapshot contains the recipient of the message. This property is primarily used to link the message to a Profile using the `IdentityMap` but it can also be used to freeze some properties of the profile at the time the message was sent.",
+  "definitions": {
+    "profile-snapshot": {
+      "properties": {
+        "xdm:workEmail": {
+          "title": "Work Email",
+          "$ref": "https://ns.adobe.com/xdm/context/emailaddress",
+          "description": "A work email address."
+        },
+        "xdm:person": {
+          "title": "Person",
+          "$ref": "https://ns.adobe.com/xdm/context/person",
+          "description": "An individual actor, contact, or owner."
+        },
+        "xdm:homeAddress": {
+          "title": "Home Address",
+          "$ref": "https://ns.adobe.com/xdm/common/address",
+          "description": "A home postal address."
+        },
+        "xdm:pushNotificationTokens": {
+          "title": "Push Notification Tokens",
+          "type": "array",
+          "description":
+            "Push notification tokens are used to communicate with applications that are installed on devices or SaaS application accounts.",
+          "items": {
+            "$ref": "https://ns.adobe.com/xdm/context/pushnotificationtoken"
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/profile-snapshot"
+    }
+  ],
+  "meta:status": "experimental"
+}


### PR DESCRIPTION
The Campaign extension has a reference to `context/profile`. This needs to be removed and a more effective group of fields needs to me added.

The fields require for now are:
1. profile/workEmail/address
2. profile/person/birthDate
3. profile/person/gender
4. profile/homeAddress/postalCode
5. profile/homeAddress/city
6. profile/homeAddress/stateProvince
7. profile/homeAddress/countryCode
8. profile/pushNotificationTokens/0/token

