### PR TITLE
Add Profile Directmarketing Addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "aem_user": "packageUser",
     "aem_password": "override me securely",
     "markdown-importer-version": "0.0.4",
-    "schemas": 242
+    "schemas": 246
   },
   "scripts": {
     "clean": "rm -rf docs/reference",

--- a/schemas/context/directmarketing-address.example.1.json
+++ b/schemas/context/directmarketing-address.example.1.json
@@ -1,0 +1,16 @@
+{
+    "@id": "https://data.adobe.io/entities/address/123",
+    "xdm:primary": false,
+    "xdm:street1": "345 Park Ave",
+    "xdm:city": "San Jose",
+    "xdm:stateProvince": "US-CA",
+    "xdm:postalCode": "95110",
+    "xdm:country": "United States",
+    "xdm:countryCode": "US",
+    "schema:latitude": 37.3382,
+    "schema:longitude": 121.8863,
+    "xdm:status": "active",
+    "xdm:lastVerifiedDate": "2018-01-02",
+    "xdm:errorCount": 0,
+    "xdm:quality": "Fully-recognized street"
+}

--- a/schemas/context/directmarketing-address.schema.json
+++ b/schemas/context/directmarketing-address.schema.json
@@ -1,0 +1,45 @@
+{
+  "meta:license": [
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/context/directmarketing-address",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Direct Marketing Address",
+  "type": "object",
+  "description": "Direct Marketing Address.",
+  "definitions": {
+    "directmarketing-address": {
+      "properties": {
+        "xdm:errorCount": {
+          "title": "Address Error Count",
+          "type": "integer",
+          "description": "Number of consecutive errors when sending to this address."
+        },
+        "xdm:quality": {
+          "title": "Address Quality",
+          "type": "string",
+          "description": "Address quality rating.",
+          "meta:enum": {
+            "incomplete_address": "Incomplete address",
+            "unknown_town_postal_code": "Unknown Town-Postal Code",
+            "empty_street": "Empty street",
+            "unknown_street": "Unknown street",
+            "partially_recognized_street": "Partially-recognized street",
+            "fully_recognized_street": "Fully-recognized street"
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/directmarketing-address"
+    },
+    {
+      "ref": "https://ns.adobe.com/xdm/common/address"
+    }
+  ]
+}

--- a/schemas/context/directmarketing-address.schema.json
+++ b/schemas/context/directmarketing-address.schema.json
@@ -41,5 +41,6 @@
     {
       "ref": "https://ns.adobe.com/xdm/common/address"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/directmarketing-emailaddress.example.1.json
+++ b/schemas/context/directmarketing-emailaddress.example.1.json
@@ -1,0 +1,8 @@
+{
+    "xdm:primary": false,
+    "xdm:address": "jsmith@xyzinc.com",
+    "xdm:label": "John Smith",
+    "xdm:type": "work",
+    "xdm:status": "active",
+    "xdm:errorCount": 0
+}

--- a/schemas/context/directmarketing-emailaddress.schema.json
+++ b/schemas/context/directmarketing-emailaddress.schema.json
@@ -1,0 +1,37 @@
+{
+  "meta:license": [
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/context/directmarketing-emailaddress",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Direct Marketing Email Address",
+  "type": "object",
+  "description": "Direct Marketing Email Address.",
+  "definitions": {
+    "directmarketing-emailaddress": {
+      "properties": {
+        "xdm:errorCount": {
+          "title": "Error Count",
+          "type": "integer",
+          "description": "Number of consecutive errors when sending to this email address."
+        },
+        "xdm:quality": {
+          "title": "Quality",
+          "type": "string",
+          "description": "Quality rating."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/directmarketing-emailaddress"
+    },
+    {
+      "ref": "https://ns.adobe.com/xdm/context/phonenumber"
+    }
+  ]
+}

--- a/schemas/context/directmarketing-emailaddress.schema.json
+++ b/schemas/context/directmarketing-emailaddress.schema.json
@@ -33,5 +33,6 @@
     {
       "ref": "https://ns.adobe.com/xdm/context/phonenumber"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/directmarketing-phonenumber.example.1.json
+++ b/schemas/context/directmarketing-phonenumber.example.1.json
@@ -1,0 +1,6 @@
+{
+    "xdm:primary": true,
+    "xdm:number": "1-408-888-8888",
+    "xdm:status": "active",
+    "xdm:errorCount": 0
+}

--- a/schemas/context/directmarketing-phonenumber.schema.json
+++ b/schemas/context/directmarketing-phonenumber.schema.json
@@ -33,5 +33,6 @@
     {
       "ref": "https://ns.adobe.com/xdm/context/phonenumber"
     }
-  ]
+  ],
+  "meta:status": "experimental"
 }

--- a/schemas/context/directmarketing-phonenumber.schema.json
+++ b/schemas/context/directmarketing-phonenumber.schema.json
@@ -11,7 +11,7 @@
   "type": "object",
   "description": "Direct Marketing Phone Number.",
   "definitions": {
-    "directmarketing-phone": {
+    "directmarketing-phonenumber": {
       "properties": {
         "xdm:errorCount": {
           "title": "Error Count",

--- a/schemas/context/directmarketing-phonenumber.schema.json
+++ b/schemas/context/directmarketing-phonenumber.schema.json
@@ -1,0 +1,37 @@
+{
+  "meta:license": [
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/context/directmarketing-phonenumber",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Direct Marketing Phone Number",
+  "type": "object",
+  "description": "Direct Marketing Phone Number.",
+  "definitions": {
+    "directmarketing-phone": {
+      "properties": {
+        "xdm:errorCount": {
+          "title": "Error Count",
+          "type": "integer",
+          "description": "Number of consecutive errors when calling this phone number."
+        },
+        "xdm:quality": {
+          "title": "Quality",
+          "type": "string",
+          "description": "Quality rating."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/directmarketing-phonenumber"
+    },
+    {
+      "ref": "https://ns.adobe.com/xdm/context/phonenumber"
+    }
+  ]
+}

--- a/schemas/context/profile-directmarketing.example.1.json
+++ b/schemas/context/profile-directmarketing.example.1.json
@@ -1,11 +1,11 @@
 {
-  "xdm:phone": {
+  "xdm:directMarketingPhone": {
     "xdm:primary": true,
     "xdm:number": "1-408-888-8888",
     "xdm:status": "active",
     "xdm:errorCount": 0
   },
-  "xdm:address": {
+  "xdm:directMarketingAddress": {
     "@id": "https://data.adobe.io/entities/address/123",
     "xdm:primary": false,
     "xdm:street1": "345 Park Ave",
@@ -21,7 +21,7 @@
     "xdm:errorCount": 0,
     "xdm:quality": "Fully-recognized street"
   },
-  "xdm:email": {
+  "xdm:directMarketingEmail": {
     "xdm:primary": false,
     "xdm:address": "jsmith@xyzinc.com",
     "xdm:label": "John Smith",

--- a/schemas/context/profile-directmarketing.example.1.json
+++ b/schemas/context/profile-directmarketing.example.1.json
@@ -1,0 +1,32 @@
+{
+  "xdm:phone": {
+    "xdm:primary": true,
+    "xdm:number": "1-408-888-8888",
+    "xdm:status": "active",
+    "xdm:errorCount": 0
+  },
+  "xdm:address": {
+    "@id": "https://data.adobe.io/entities/address/123",
+    "xdm:primary": false,
+    "xdm:street1": "345 Park Ave",
+    "xdm:city": "San Jose",
+    "xdm:stateProvince": "US-CA",
+    "xdm:postalCode": "95110",
+    "xdm:country": "United States",
+    "xdm:countryCode": "US",
+    "schema:latitude": 37.3382,
+    "schema:longitude": 121.8863,
+    "xdm:status": "active",
+    "xdm:lastVerifiedDate": "2018-01-02",
+    "xdm:errorCount": 0,
+    "xdm:quality": "Fully-recognized street"
+  },
+  "xdm:email": {
+    "xdm:primary": false,
+    "xdm:address": "jsmith@xyzinc.com",
+    "xdm:label": "John Smith",
+    "xdm:type": "work",
+    "xdm:status": "active",
+    "xdm:errorCount": 0
+  }
+}

--- a/schemas/context/profile-directmarketing.schema.json
+++ b/schemas/context/profile-directmarketing.schema.json
@@ -16,17 +16,17 @@
   "definitions": {
     "profile-directmarketing": {
       "properties": {
-        "xdm:address": {
+        "xdm:directMarketingAddress": {
           "title": "Direct Marketing Address",
           "$ref": "https://ns.adobe.com/xdm/context/directmarketing-address",
           "description": "Direct Marketing postal address."
         },
-        "xdm:email": {
+        "xdm:directMarketingEmail": {
           "title": "Direct Marketing Email",
           "$ref": "https://ns.adobe.com/xdm/context/directmarketing-emailaddress",
           "description": "Direct Marketing email address."
         },
-        "xdm:phone": {
+        "xdm:directMarketingPhone": {
           "title": "Direct Marketing Phone",
           "$ref": "https://ns.adobe.com/xdm/context/directmarketing-phonenumber",
           "description": "Direct Marketing phone number."

--- a/schemas/context/profile-directmarketing.schema.json
+++ b/schemas/context/profile-directmarketing.schema.json
@@ -1,0 +1,46 @@
+{
+  "meta:license": [
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/context/profile-directmarketing",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Profile Direct Marketing",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/profile"],
+  "description": "Direct Marketing addressing for profiles.",
+  "definitions": {
+    "profile-directmarketing": {
+      "properties": {
+        "xdm:address": {
+          "title": "Direct Marketing Address",
+          "$ref": "https://ns.adobe.com/xdm/context/directmarketing-address",
+          "description": "Direct Marketing postal address."
+        },
+        "xdm:email": {
+          "title": "Direct Marketing Email",
+          "$ref": "https://ns.adobe.com/xdm/context/directmarketing-emailaddress",
+          "description": "Direct Marketing email address."
+        },
+        "xdm:phone": {
+          "title": "Direct Marketing Phone",
+          "$ref": "https://ns.adobe.com/xdm/context/directmarketing-phonenumber",
+          "description": "Direct Marketing phone number."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "#/definitions/profile-directmarketing"
+    }
+  ],
+  "meta:status": "experimental"
+}


### PR DESCRIPTION
The context/profile has standardized fields for personal(home) and work addressing (postal addresses, email addresses, phone numbers etc) and these work well for their intended purposes.

The issue arises where a set of addresses are to be used for direct marketing to a profile. In the B2B case work addresses make sense, and in the consumer b2c case the home* addressing makes sense. But there has further been issues with joint b2b and b2c cases in the same implementation as well as where a system needs to maintain both but use a mix for direct communication. 

Standard customer implementations use a dedicated direct marketing set of addresses that are distinct from the work* and home* addresses.

The recommendation from implementors of Direct Marketing solutions implementors is what has been executed here and uses the enhanced directmarketing-* data types which include quality measures for the address interactions.
