### PR TITLE
Correct and Improve titles and descriptions in channels

### DIFF
--- a/schemas/channels/adm.schema.json
+++ b/schemas/channels/adm.schema.json
@@ -7,8 +7,8 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/adm",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "ADM",
-  "description": "Amazon Device Messaging",
+  "title": "ADM Channel",
+  "description": "Amazon Device Messaging channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/agency.schema.json
+++ b/schemas/channels/agency.schema.json
@@ -7,8 +7,8 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/agency",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "External Agency",
-  "description": "The marketing experience is handed-off to an external agency. This channel has no specific mechanism and is designed for descriptive purposes only. Such as, to define experiences for which you want to keep a trace of the population targeted in an external tool",
+  "title": "External Agency Channel",
+  "description": "The marketing experience is handed-off to an external agency channel. This channel has no specific mechanism and is designed for descriptive purposes only. Such as, to define experiences for which you want to keep a trace of the population targeted in an external tool",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/agency.schema.json
+++ b/schemas/channels/agency.schema.json
@@ -7,7 +7,7 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/agency",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "E-Mail",
+  "title": "External Agency",
   "description": "The marketing experience is handed-off to an external agency. This channel has no specific mechanism and is designed for descriptive purposes only. Such as, to define experiences for which you want to keep a trace of the population targeted in an external tool",
   "meta:extensible": true,
   "meta:extends": [

--- a/schemas/channels/apns.schema.json
+++ b/schemas/channels/apns.schema.json
@@ -7,8 +7,8 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/apns",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "APNS",
-  "description": "Apple Push Notification Service",
+  "title": "APNS Channel",
+  "description": "Apple Push Notification Service channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/application.schema.json
+++ b/schemas/channels/application.schema.json
@@ -10,7 +10,7 @@
   "title": "Application Channel",
   "type": "object",
   "description":
-    "An application that accepts messages or emit events (Facebook page, Mobile App, ...).",
+    "An application that accepts messages or emit events (Facebook page, Mobile App, ...) channel.",
   "definitions": {
     "application": {
       "properties": {

--- a/schemas/channels/application.schema.json
+++ b/schemas/channels/application.schema.json
@@ -7,10 +7,10 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/application",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Application",
+  "title": "Application Channel",
   "type": "object",
   "description":
-    "An application that accepts messages or emit events (Facebook page, Mobile App, ...).\n",
+    "An application that accepts messages or emit events (Facebook page, Mobile App, ...).",
   "definitions": {
     "application": {
       "properties": {

--- a/schemas/channels/baidu.schema.json
+++ b/schemas/channels/baidu.schema.json
@@ -7,8 +7,8 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/baidu",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Baidu",
-  "description": "Baidu Cloud Push Service",
+  "title": "Baidu Channel",
+  "description": "Baidu Cloud Push Service channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/channel.schema.json
+++ b/schemas/channels/channel.schema.json
@@ -11,7 +11,7 @@
   "meta:extensible": true,
   "meta:abstract": true,
   "type": "object",
-  "description": "",
+  "description": "Experience Channel.",
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/direct-mail.schema.json
+++ b/schemas/channels/direct-mail.schema.json
@@ -7,8 +7,8 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/direct-mail",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Direct Mail",
-  "description": "Mail delivered by a postal service.",
+  "title": "Direct Mail Channel",
+  "description": "Mail delivered by a postal service channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/email.schema.json
+++ b/schemas/channels/email.schema.json
@@ -7,7 +7,7 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/email",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "E-Mail",
+  "title": "E-Mail Channel",
   "description": "E-Mail messages, delivered via SMTP to list subscribers.",
   "meta:extensible": true,
   "meta:extends": [

--- a/schemas/channels/email.schema.json
+++ b/schemas/channels/email.schema.json
@@ -8,7 +8,7 @@
   "$id": "https://ns.adobe.com/xdm/channels/email",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "E-Mail Channel",
-  "description": "E-Mail messages, delivered via SMTP to list subscribers.",
+  "description": "E-Mail messages, delivered via SMTP to list subscribers channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/facebook-feed.schema.json
+++ b/schemas/channels/facebook-feed.schema.json
@@ -7,8 +7,8 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/facebook-feed",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Facebook News Feed",
-  "description": "The Facebook News Feed. This does not include Facebook Messenger, or Facebook App pages.",
+  "title": "Facebook News Feed Channel",
+  "description": "The Facebook News Feed. This does not include Facebook Messenger, or Facebook App pages channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/fax.schema.json
+++ b/schemas/channels/fax.schema.json
@@ -8,7 +8,7 @@
   "$id": "https://ns.adobe.com/xdm/channels/fax",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Fax Channel",
-  "description": "Telefacsimile",
+  "description": "Telefacsimile channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/fax.schema.json
+++ b/schemas/channels/fax.schema.json
@@ -7,7 +7,7 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/fax",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Fax",
+  "title": "Fax Channel",
   "description": "Telefacsimile",
   "meta:extensible": true,
   "meta:extends": [

--- a/schemas/channels/gcm.schema.json
+++ b/schemas/channels/gcm.schema.json
@@ -7,8 +7,8 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/gcm",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "GCM",
-  "description": "Google Cloud Messaging",
+  "title": "GCM Channel",
+  "description": "Google Cloud Messaging channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/line.schema.json
+++ b/schemas/channels/line.schema.json
@@ -7,8 +7,8 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/line",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "LINE",
-  "description": "Line Platform Notification",
+  "title": "LINE Channel",
+  "description": "Line Platform Notification channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/mobile-app.schema.json
+++ b/schemas/channels/mobile-app.schema.json
@@ -7,7 +7,7 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/mobile-app",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Web",
+  "title": "Native Mobile Application Channel",
   "description": "Native mobile applications that are installed through an app store.",
   "meta:extensible": true,
   "meta:extends": [

--- a/schemas/channels/mobile-app.schema.json
+++ b/schemas/channels/mobile-app.schema.json
@@ -8,7 +8,7 @@
   "$id": "https://ns.adobe.com/xdm/channels/mobile-app",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Native Mobile Application Channel",
-  "description": "Native mobile applications that are installed through an app store.",
+  "description": "Native mobile applications that are installed through an app store channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/mpns.schema.json
+++ b/schemas/channels/mpns.schema.json
@@ -7,8 +7,8 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/mpns",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "MPNS",
-  "description": "Microsoft Push Notification Service",
+  "title": "MPNS Channel",
+  "description": "Microsoft Push Notification Service channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/phone.schema.json
+++ b/schemas/channels/phone.schema.json
@@ -8,7 +8,7 @@
   "$id": "https://ns.adobe.com/xdm/channels/phone",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Phone Channel",
-  "description": "The telephone. Includes both inbound and outbound.",
+  "description": "The telephone channel. Includes both inbound and outbound.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/phone.schema.json
+++ b/schemas/channels/phone.schema.json
@@ -7,7 +7,7 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/phone",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Phone",
+  "title": "Phone Channel",
   "description": "The telephone. Includes both inbound and outbound.",
   "meta:extensible": true,
   "meta:extends": [

--- a/schemas/channels/sms.schema.json
+++ b/schemas/channels/sms.schema.json
@@ -7,7 +7,7 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/sms",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "SMS",
+  "title": "SMS Channel",
   "description": "Short Message Service delivered to a mobile phone.",
   "meta:extensible": true,
   "meta:extends": [

--- a/schemas/channels/sms.schema.json
+++ b/schemas/channels/sms.schema.json
@@ -8,7 +8,7 @@
   "$id": "https://ns.adobe.com/xdm/channels/sms",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "SMS Channel",
-  "description": "Short Message Service delivered to a mobile phone.",
+  "description": "Short Message Service delivered to a mobile phone channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/twitter-feed.schema.json
+++ b/schemas/channels/twitter-feed.schema.json
@@ -7,7 +7,7 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/twitter-feed",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Twitter Feed",
+  "title": "Twitter Feed Channel",
   "description": "The Twitter Feed, i.e. the stream of user-generated tweets. This does not include Twitter direct messages.",
   "meta:extensible": true,
   "meta:extends": [

--- a/schemas/channels/web.schema.json
+++ b/schemas/channels/web.schema.json
@@ -8,7 +8,7 @@
   "$id": "https://ns.adobe.com/xdm/channels/web",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Web Channel",
-  "description": "The world wide web and mobile web. Pages delivered via HTTP to a web browser or in-app browser.",
+  "description": "The world wide web and mobile web channel. Pages delivered via HTTP to a web browser or in-app browser.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/web.schema.json
+++ b/schemas/channels/web.schema.json
@@ -7,7 +7,7 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/web",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "Web",
+  "title": "Web Channel",
   "description": "The world wide web and mobile web. Pages delivered via HTTP to a web browser or in-app browser.",
   "meta:extensible": true,
   "meta:extends": [

--- a/schemas/channels/wechat.schema.json
+++ b/schemas/channels/wechat.schema.json
@@ -7,8 +7,8 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/wechat",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "WeChat",
-  "description": "WeChat Platform Notification",
+  "title": "WeChat Channel",
+  "description": "WeChat Platform Notification Channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"

--- a/schemas/channels/wns.schema.json
+++ b/schemas/channels/wns.schema.json
@@ -7,8 +7,8 @@
   ],
   "$id": "https://ns.adobe.com/xdm/channels/wns",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "title": "WNS",
-  "description": "Windows Push Notification Service.",
+  "title": "WNS Channel",
+  "description": "Windows Push Notification Service Channel.",
   "meta:extensible": true,
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"


### PR DESCRIPTION
With the Channels schemas turning up in User Experiences we have found that the names and descriptions are too generic and cause confusion.

Titles and Descriptions have been improved and one error in a title has been corrected.