### PR TITLE
Fix decisionevent-all schema ID

### DIFF
--- a/extensions/adobe/experience/campaign/experienceevent.example.click.json
+++ b/extensions/adobe/experience/campaign/experienceevent.example.click.json
@@ -85,6 +85,7 @@
     "xdm:eventID": "store-entry-beacon-triggered"
   },
   "https://ns.adobe.com/experience/campaign/eventSource": "pipelined-trackinglogd",
+  "https://ns.adobe.com/experience/decisioning/propositionID": "3cc33a7e-13ca-4b19-b25d-c816eff9a701",  
   "https://ns.adobe.com/experience/campaign/offerOpened": {
     "xdm:activity": {
       "@id": "xcore:offer-activity:ebc48132c26ccfc"

--- a/extensions/adobe/experience/campaign/experienceevent.example.click.json
+++ b/extensions/adobe/experience/campaign/experienceevent.example.click.json
@@ -85,7 +85,7 @@
     "xdm:eventID": "store-entry-beacon-triggered"
   },
   "https://ns.adobe.com/experience/campaign/eventSource": "pipelined-trackinglogd",
-  "https://ns.adobe.com/experience/decisioning/propositionID": "3cc33a7e-13ca-4b19-b25d-c816eff9a701",  
+  "https://ns.adobe.com/experience/decisioning/propositionID": "3cc33a7e-13ca-4b19-b25d-c816eff9a701",
   "https://ns.adobe.com/experience/campaign/offerOpened": {
     "xdm:activity": {
       "@id": "xcore:offer-activity:ebc48132c26ccfc"

--- a/extensions/adobe/experience/decisioning/activity-detail.schema.json
+++ b/extensions/adobe/experience/decisioning/activity-detail.schema.json
@@ -11,7 +11,7 @@
   "type": "object",
   "meta:extensible": true,
   "meta:abstract": true,
-  "description": "Detail about the Entity controlling the decisioning process. The decision activity specifies a fallback option should the combined constraints disqualify all narrowed-down options.",
+  "description": "Detail about the Entity defining and controlling the decisioning process. Decisions are made in the context of an Activity. At any given time, the best Option is re-evaluated, or ranked, based on the most current set of context variables, rules and constraints. The decision activity specifies a fallback option should the combined constraints disqualify all narrowed-down options.",
   "definitions": {
     "activity-detail-datatype": {
       "properties": {

--- a/extensions/adobe/experience/decisioning/decisionevent-all.schema.json
+++ b/extensions/adobe/experience/decisioning/decisionevent-all.schema.json
@@ -5,7 +5,7 @@
     "you may not use this file except in compliance with the License. You may obtain a copy",
     "of the License at https://creativecommons.org/licenses/by/4.0/"
   ],
-  "$id": "https://ns.adobe.com/experience/decisioning/decisionevent",
+  "$id": "https://ns.adobe.com/experience/decisioning/decisionevent-all",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Decision Event Decisioning Extension",
   "type": "object",

--- a/extensions/adobe/experience/decisioning/decisionevent.example.1.json
+++ b/extensions/adobe/experience/decisioning/decisionevent.example.1.json
@@ -24,6 +24,15 @@
       "schema:longitude": 139.73237
     }
   },
+  "xdm:web": {
+    "xdm:webPageView": {
+      "xdm:URL": "https://www.example.com"
+    },
+    "xdm:webReferrer": {
+      "xdm:URL": "https://www.examplereferrer.com/",
+      "xdm:domain": "examplereferrer.com"
+    }
+  },
   "https://ns.adobe.com/experience/decisioning/propositionID": "3cc33a7e-13ca-4b19-b25d-c816eff9a70a",
   "https://ns.adobe.com/experience/decisioning/propositionDetails": [
     {
@@ -53,15 +62,5 @@
     }
   ],
   "https://ns.adobe.com/adobecloudplatform/ims/organizationID": "0D8E32C65A8A91520A494008@AdobeOrg",
-  "https://ns.adobe.com/experience/decisioning/containerID": "c75afa32-371f-4895-8f43-b853dd9fe740",
-  "https://ns.adobe.com/experience/campaign/offerOpened": {
-    "xdm:activity": {
-      "xdm:id": "xcore:offer-activity:f3f13bfccb4da6e"
-    },
-    "xdm:selections": [
-      {
-        "xdm:id": "xcore:personalized-offer:f3e4b72eb3808e9"
-      }
-    ]
-  }
+  "https://ns.adobe.com/experience/decisioning/containerID": "c75afa32-371f-4895-8f43-b853dd9fe740"
 }

--- a/extensions/adobe/experience/decisioning/experienceevent-with-proposition.example.1.json
+++ b/extensions/adobe/experience/decisioning/experienceevent-with-proposition.example.1.json
@@ -83,7 +83,7 @@
     {
       "xdm:activity": {
         "xdm:id": "xcore:offer-activity:ebc48132c26ccfc",
-        "xdm:name": "Video Totorial"
+        "xdm:name": "Video Tutorial"
       },
       "xdm:selections": [
         {

--- a/extensions/adobe/experience/decisioning/experienceevent-with-proposition.example.1.json
+++ b/extensions/adobe/experience/decisioning/experienceevent-with-proposition.example.1.json
@@ -83,22 +83,18 @@
     {
       "xdm:activity": {
         "xdm:id": "xcore:offer-activity:ebc48132c26ccfc",
-        "xdm:name": "Kiosk"
+        "xdm:name": "Video Totorial"
       },
       "xdm:selections": [
         {
-          "xdm:id": "xcore:personalized-offer:e91ee850a0bb7d9",
-
-          "https://ns.adobe.com/experience/decisioning/propositionsTotal": {
-            "xdm:value": 948
-          }
+          "xdm:id": "xcore:personalized-offer:e91ee850a0bb7d9"
         }
       ]
     },
     {
       "xdm:activity": {
         "xdm:id": "xcore:offer-activity:f203512e02542b5",
-        "xdm:name": "Sessions"
+        "xdm:name": "Conferences"
       },
       "xdm:fallback": {
         "xdm:id": "xcore:fallback-offer:e91ce7243fd8c2a"


### PR DESCRIPTION
Fix decisionevent-all schema ID
Add to description of activity-detail schema
Improve three examples
- Example Campaign click event references the propositionID to track the decision
- Decision Event shows another context data example, a web page visited just prior to the decision
- remove the decision metric from the example experience event because it would typically not be carried through to the end user and echoed back