### PR TITLE
Fix:  Typo in schema references in offer-detail and offer-activity-detail

### DIFF
--- a/extensions/adobe/experience/campaign/experienceevent.example.click.json
+++ b/extensions/adobe/experience/campaign/experienceevent.example.click.json
@@ -88,20 +88,15 @@
   "https://ns.adobe.com/experience/decisioning/propositionID": "3cc33a7e-13ca-4b19-b25d-c816eff9a701",
   "https://ns.adobe.com/experience/campaign/offerOpened": {
     "xdm:activity": {
-      "@id": "xcore:offer-activity:f66f792de3c0ba9",
+      "xdm:id": "xcore:offer-activity:f66f792de3c0ba9",
       "xdm:name": "Email - Next Best Offer",
       "xdm:placement": "xcore:offer-placement:f6524d27c2d6edd",
       "xdm:filter": "xcore:offer-filter:f66f792de3c0ba9"
     },
-    "xdm:offer": [
-      {
-        "@id": "xcore:personalized-offer:f67bab756ed6ee4",
-        "xdm:name": "Beach Vacations",
-        "xdm:tags": [
-          "xcore:tag:f68535bc217322e",
-          "xcore:tag:f66f67dbe6d6ee1"
-        ]
-      }
-    ]
+    "xdm:offer": {
+      "xdm:id": "xcore:personalized-offer:f67bab756ed6ee4",
+      "xdm:name": "Beach Vacations",
+      "xdm:tags": ["xcore:tag:f68535bc217322e", "xcore:tag:f66f67dbe6d6ee1"]
+    }
   }
 }

--- a/extensions/adobe/experience/decisioning/activity-detail.schema.json
+++ b/extensions/adobe/experience/decisioning/activity-detail.schema.json
@@ -53,6 +53,9 @@
     },
     {
       "$ref": "#/definitions/activity-detail-datatype"
+    },
+    {
+      "required": ["xdm:id"]
     }
   ],
   "meta:status": "experimental"

--- a/extensions/adobe/experience/decisioning/option-detail.example.1.json
+++ b/extensions/adobe/experience/decisioning/option-detail.example.1.json
@@ -1,4 +1,15 @@
 {
   "xdm:id": "xcore:personalized-offer:e91ee850a0bb7d9",
-  "xdm:name": "Introduction to machine learning"
+  "xdm:name": "Introduction to machine learning",
+  "xdm:characteristics": {
+    "duration": "14",
+    "level": "intermediate",
+    "format": "Syllable"
+  },
+  "https://ns.adobe.com/experience/decisioning/propositionsTotal": {
+    "xdm:value": 4948
+  },
+  "https://ns.adobe.com/experience/decisioning/propositionsProfile": {
+    "xdm:value": 2
+  }
 }

--- a/extensions/adobe/experience/decisioning/option-detail.schema.json
+++ b/extensions/adobe/experience/decisioning/option-detail.schema.json
@@ -23,20 +23,17 @@
         },
         "xdm:name": {
           "type": "string",
-          "title": "Name",
+          "title": "Option Name",
           "description": "Option name. The name is displayed in various user interfaces."
         },
-        "xdm:customMetadata": {
-          "title": "Option Custom Metadata",
-          "description": "Additional properties kept with an Option. The data can be used do compose options into experiences for delivery to a profile. It is also used to analyze optimize the performance of an Option.",
+        "xdm:characteristics": {
+          "title": "Option Characteristics",
+          "description": "Additional properties or attributed belonging to this particular Option. Different instances can have different characteristics. When every instance has a certain attribute or property it should be modeled as an extension to the schema that derives from Option Detail. The characteristics are name value pairs used to distingusih an option from others. Characteristics are used as features to analyze and optimize the performance of an Option.",
           "type": "object",
           "meta:xdmType": "map",
           "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "description": "Value of the metadata property."
-            }
+            "type": "string",
+            "description": "Value of the property."
           }
         },
         "https://ns.adobe.com/experience/decisioning/propositionsTotal": {
@@ -56,6 +53,9 @@
     },
     {
       "$ref": "#/definitions/option-detail-datatype"
+    },
+    {
+      "required": ["xdm:id"]
     }
   ],
   "meta:status": "experimental"

--- a/extensions/adobe/experience/decisioning/proposition-detail.example.1.json
+++ b/extensions/adobe/experience/decisioning/proposition-detail.example.1.json
@@ -1,7 +1,7 @@
 {
   "xdm:activity": {
     "xdm:id": "xcore:offer-activity:ebc48132c26ccfc",
-    "xdm:name": "Tutorial videos to watch",
+    "xdm:name": "Online College Counseler",
     "xdm:startDate": "2018-10-13T05:59:18.914Z",
     "xdm:endDate": "2018-12-27T05:59:18.914Z",
     "xdm:fallback": "xcore:fallback-offer:e91ce7243fd8c2a"
@@ -10,8 +10,31 @@
     {
       "xdm:id": "xcore:personalized-offer:e91ee850a0bb7d9",
       "xdm:name": "Introduction to machine learning",
+      "xdm:characteristics": {
+        "duration": "14",
+        "level": "intermediate",
+        "format": "Syllable"
+      },
       "https://ns.adobe.com/experience/decisioning/propositionsTotal": {
-        "xdm:value": 948
+        "xdm:value": 4948
+      },
+      "https://ns.adobe.com/experience/decisioning/propositionsProfile": {
+        "xdm:value": 2
+      }
+    },
+    {
+      "xdm:id": "xcore:personalized-offer:f67bab756ed6ee4",
+      "xdm:name": "Summer Camp",
+      "xdm:characteristics": {
+        "cost": "$2400",
+        "inventoryId": "BORA04",
+        "country": "French Polynesia"
+      },
+      "https://ns.adobe.com/experience/decisioning/propositionsTotal": {
+        "xdm:value": 3813
+      },
+      "https://ns.adobe.com/experience/decisioning/propositionsProfile": {
+        "xdm:value": 1
       }
     }
   ]

--- a/extensions/adobe/experience/offer-management/offer-activity-detail.example.1.json
+++ b/extensions/adobe/experience/offer-management/offer-activity-detail.example.1.json
@@ -1,0 +1,7 @@
+{
+  "xdm:id": "xcore:offer-activity:f66f792de3c0ba9",
+  "xdm:name": "Email - Next Best Offer",
+  "xdm:placement": "xcore:offer-placement:f6524d27c2d6edd",
+  "xdm:filter": "xcore:offer-filter:f66f792de3c0ba9",
+  "xdm:fallback": "xcore:fallback-offer:f6529b31b3c0ba6"
+}

--- a/extensions/adobe/experience/offer-management/offer-activity-detail.schema.json
+++ b/extensions/adobe/experience/offer-management/offer-activity-detail.schema.json
@@ -44,7 +44,7 @@
       "$ref": "#/definitions/offer-activity-detail"
     },
     {
-      "$ref": "http://ns.adobe.com/experience/decisioning/activity-detail"
+      "$ref": "https://ns.adobe.com/experience/decisioning/activity-detail"
     }
   ]
 }

--- a/extensions/adobe/experience/offer-management/offer-detail.example.1.json
+++ b/extensions/adobe/experience/offer-management/offer-detail.example.1.json
@@ -1,0 +1,10 @@
+{
+  "xdm:id": "xcore:personalized-offer:f67bab756ed6ee4",
+  "xdm:name": "Beach Vacations",
+  "xdm:tags": ["xcore:tag:f68535bc217322e", "xcore:tag:f66f67dbe6d6ee1"],
+  "xdm:characteristics": {
+    "cost": "$2400",
+    "inventoryId": "BORA04",
+    "country": "French Polynesia"
+  }
+}

--- a/extensions/adobe/experience/offer-management/offer-detail.schema.json
+++ b/extensions/adobe/experience/offer-management/offer-detail.schema.json
@@ -34,7 +34,7 @@
       "$ref": "#/definitions/offer-detail"
     },
     {
-      "$ref": "http://ns.adobe.com/experience/decisioning/option-detail"
+      "$ref": "https://ns.adobe.com/experience/decisioning/option-detail"
     }
   ]
 }

--- a/extensions/adobe/experience/offer-management/proposition-response-detail.example.1.json
+++ b/extensions/adobe/experience/offer-management/proposition-response-detail.example.1.json
@@ -1,0 +1,18 @@
+{
+  "xdm:activity": {
+    "xdm:id": "xcore:offer-activity:f66f792de3c0ba9",
+    "xdm:name": "Email - Next Best Offer",
+    "xdm:placement": "xcore:offer-placement:f6524d27c2d6edd",
+    "xdm:filter": "xcore:offer-filter:f66f792de3c0ba9"
+  },
+  "xdm:offer": {
+    "xdm:id": "xcore:personalized-offer:f67bab756ed6ee4",
+    "xdm:name": "Beach Vacations",
+    "xdm:tags": ["xcore:tag:f68535bc217322e", "xcore:tag:f66f67dbe6d6ee1"],
+    "xdm:characteristics": {
+      "cost": "$2400",
+      "inventoryId": "BORA04",
+      "country": "French Polynesia"
+    }
+  }
+}


### PR DESCRIPTION
See PR #629

- Typo in schema references in offer-detail and offer-activity-detail https instead of http

- Making "xdm:id" in activity-detail and option-detail mandatory to avoid future incompatible schema changes, the presence of the "xdm"id" property is required to correlate the snapshot to the full entity.

- The map property "xdm:customMetadata" replaced with xdm:characteristics as a map of strings and instead of a map of arrays of strings.

- Updating, correcting and completing examples