### PR TITLE
Corrected $id reference in data/record-timeseriesevents to match folder path.

### DIFF
--- a/extensions/adobe/experience/profile/profile-all.schema.json
+++ b/extensions/adobe/experience/profile/profile-all.schema.json
@@ -14,7 +14,7 @@
   "meta:abstract": true,
   "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/profile"],
   "meta:extends": [
-    "https://ns.adobe.com/xdm/context/record-timeseries-events",
+    "https://ns.adobe.com/xdm/data/record-timeseries-events",
     "https://ns.adobe.com/xdm/context/identitymap",
     "https://ns.adobe.com/xdm/context/profile-segmentation"
   ],

--- a/schemas/data/record-timeseries-events.schema.json
+++ b/schemas/data/record-timeseries-events.schema.json
@@ -5,7 +5,7 @@
     "you may not use this file except in compliance with the License. You may obtain a copy",
     "of the License at https://creativecommons.org/licenses/by/4.0/"
   ],
-  "$id": "https://ns.adobe.com/xdm/context/record-timeseries-events",
+  "$id": "https://ns.adobe.com/xdm/data/record-timeseries-events",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Time-series Extension for Record Data",
   "type": "object",


### PR DESCRIPTION
The $id was incorrect in the previous PR #643 - This corrects that in both the core Mixin and the Unified Profile Mixin
