### PR TITLE
Remove audit fields from the person data type.

### DIFF
--- a/schemas/context/person.schema.json
+++ b/schemas/context/person.schema.json
@@ -66,9 +66,6 @@
         },
         {
             "$ref": "#/definitions/person"
-        },
-        {
-            "$ref": "https://ns.adobe.com/xdm/common/auditable"
         }
     ],
     "meta:status": "experimental"


### PR DESCRIPTION
The context/person schema is today used by the context/profile-person-details mixin which is intended for the context/profile class. 

This context/profile class already include the audit fields so it doesn't make sense to have them included under the person mixin (which adds a person field) as well. 

Note, this will create a breaking change to anyone using this context/profile-person-details mixin, but that is only by the few people testing the AEP platform today and have confirmed they are not populating these fields.

cc @chrisdegroot @prabhum2 