### PR TITLE
Move breaking change check to the last step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,10 +80,10 @@ jobs:
           path: junit
       - store_artifacts:
           path: junit 
-      # incompatibility-check
-      - run: npm run incompatibility-check
       # xed-validation
       - run: npm run xed-validation
+      # incompatibility-check
+      - run: npm run incompatibility-check
 
   generate-docs:
     docker:


### PR DESCRIPTION
This PR simply moves the breaking change check after the json xed validation as sometimes the xed validation is ignored when the breaking changes are necessary.
