### PR TITLE
Revert analytics template to use the standard EE-commerce mixin

### DIFF
--- a/extensions/adobe/experience/analytics-experienceevent.schema.json
+++ b/extensions/adobe/experience/analytics-experienceevent.schema.json
@@ -17,6 +17,7 @@
     "https://ns.adobe.com/xdm/context/experienceevent-advertising",
     "https://ns.adobe.com/xdm/context/experienceevent-application",
     "https://ns.adobe.com/xdm/context/experienceevent-channel",
+    "https://ns.adobe.com/xdm/context/experienceevent-commerce",
     "https://ns.adobe.com/xdm/context/experienceevent-directmarketing",
     "https://ns.adobe.com/xdm/context/experienceevent-environment-details",
     "https://ns.adobe.com/xdm/context/experienceevent-marketing",
@@ -30,8 +31,7 @@
     "https://ns.adobe.com/experience/target/experienceevent-shared",
     "https://ns.adobe.com/experience/profile/experienceevent-shared",
     "https://ns.adobe.com/experience/implementations-ext",
-    "https://ns.adobe.com/xdm/context/experienceevent-enduserids",
-    "https://ns.adobe.com/experience/analytics/commerce"
+    "https://ns.adobe.com/xdm/context/experienceevent-enduserids"
   ],
   "definitions": {
     "analytics-experienceevent": {
@@ -50,6 +50,9 @@
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/experienceevent-channel"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-commerce"
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/experienceevent-directmarketing"
@@ -92,9 +95,6 @@
     },
     {
       "$ref": "https://ns.adobe.com/xdm/context/experienceevent-enduserids"
-    },
-    {
-      "$ref": "https://ns.adobe.com/experience/analytics/commerce"
     },
     {
       "$ref": "#/definitions/analytics-experienceevent"


### PR DESCRIPTION
Partial revert of https://github.com/adobe/xdm/pull/656 until we can do further testing of the merchandizing being actually populated in the platform.