### PR TITLE
Corrected the meta:abstract settings for channels schemas.

### DIFF
--- a/schemas/channels/adm.schema.json
+++ b/schemas/channels/adm.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/agency.schema.json
+++ b/schemas/channels/agency.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/apns.schema.json
+++ b/schemas/channels/apns.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/application.schema.json
+++ b/schemas/channels/application.schema.json
@@ -9,6 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Application Channel",
   "type": "object",
+  "meta:abstract": true,
   "description":
     "An application that accepts messages or emit events (Facebook page, Mobile App, ...) channel.",
   "definitions": {

--- a/schemas/channels/baidu.schema.json
+++ b/schemas/channels/baidu.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/direct-mail.schema.json
+++ b/schemas/channels/direct-mail.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/email.schema.json
+++ b/schemas/channels/email.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/facebook-feed.schema.json
+++ b/schemas/channels/facebook-feed.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/fax.schema.json
+++ b/schemas/channels/fax.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/gcm.schema.json
+++ b/schemas/channels/gcm.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/line.schema.json
+++ b/schemas/channels/line.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/mobile-app.schema.json
+++ b/schemas/channels/mobile-app.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/mpns.schema.json
+++ b/schemas/channels/mpns.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/phone.schema.json
+++ b/schemas/channels/phone.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/sms.schema.json
+++ b/schemas/channels/sms.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/twitter-feed.schema.json
+++ b/schemas/channels/twitter-feed.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/web.schema.json
+++ b/schemas/channels/web.schema.json
@@ -13,7 +13,7 @@
   "meta:extends": [
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
-  "meta:abstract": false,
+  "meta:abstract": true,
   "type": "object",
   "definitions": {
     "channel": {

--- a/schemas/channels/wechat.schema.json
+++ b/schemas/channels/wechat.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {

--- a/schemas/channels/wns.schema.json
+++ b/schemas/channels/wns.schema.json
@@ -14,7 +14,7 @@
     "https://ns.adobe.com/xdm/channels/channel#/definitions/channel"
   ],
   "type": "object",
-  "meta:abstract": false,
+  "meta:abstract": true,
   "definitions": {
     "channel": {
       "properties": {


### PR DESCRIPTION
Resolves issue #698

Non breaking change that fixes the /schemas/channels utility schemas that were set as if they would have represent data ("meta:abstract": false) when they are purely metadata/semantic representative schemas.

This was causing issues with the XDM Registry getting confused about the meaning of these schemas.   
