### PR TITLE
Sample standard Campaign class with solution mixin

### DIFF
--- a/extensions/adobe/experience/adcloud/searchadvertising/campaign.example.1.json
+++ b/extensions/adobe/experience/adcloud/searchadvertising/campaign.example.1.json
@@ -1,0 +1,7 @@
+{
+  "https://ns.adobe.com/experience/adcloud/campaignId": "10001234",
+  "https://ns.adobe.com/experience/adcloud/channelType": "Search",
+  "https://ns.adobe.com/experience/adcloud/budget": 123.45,
+  "https://ns.adobe.com/experience/adcloud/budgetType": "Monthly",
+  "https://ns.adobe.com/experience/adcloud/adDeliveryType": "Standard",
+}

--- a/extensions/adobe/experience/adcloud/searchadvertising/campaign.schema.json
+++ b/extensions/adobe/experience/adcloud/searchadvertising/campaign.schema.json
@@ -1,0 +1,81 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/experience/adcloud/searchadvertising/campaign",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Search Advertising Campaign Mixin",
+  "type": "object",
+  "meta:abstract": true,
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/common/campaign"],
+  "description": "Adds a set of Search Advertising Fields to the base Campaign.",
+  "definitions": {
+    "searchadvertising-campaign": {
+      "properties": {
+        "https://ns.adobe.com/experience/adcloud/campaignId": {
+          "title": "Campaign Identifier",
+          "type": "string",
+          "description": "Campaign ID on the search advertising platform."
+        },
+        "https://ns.adobe.com/experience/adcloud/channelType": {
+          "title": "Channel Type",
+          "type": "string",
+          "description": "Channel Type for the Campaign"
+        },
+        "https://ns.adobe.com/experience/adcloud/budget": {
+          "title": "Budget",
+          "type": "number",
+          "description": "Budget Allocated for the Campaign"
+        },
+        "https://ns.adobe.com/experience/adcloud/budgetType": {
+          "title": "Budget Type",
+          "type": "string",
+          "description": "Budget Type indicates how the allocated budget will be spent",
+          "enum": [
+            "Daily",
+            "Monthly",
+            "Lifetime",
+            "Daily Spend Until Depleted",
+            "Day of Week"
+          ],
+          "meta:enum": {
+            "daily": "Daily",
+            "Monthly": "Monthly",
+            "Lifetime": "Lifetime",
+            "Daily Spend Until Depleted": "Daily spend until depleted",
+            "Day of week": "Day of week"
+          }
+        },
+        "https://ns.adobe.com/experience/adcloud/adDeliveryType": {
+          "title": "Ad Delivery Method",
+          "type": "string",
+          "description": "Ad Delivery method can determine how long your budget lasts",
+          "enum": ["Standard", "Accelerated"],
+          "meta:enum": {
+            "standard": "Standard",
+            "accelerated": "Accelerated"
+          }
+        },
+        "https://ns.adobe.com/experience/adcloud/portfolioId": {
+          "title": "Portfolio Identifier",
+          "type": "string",
+          "description": "Identifier indicates if campaign has been assigned and managed via portfolio."
+        },
+        "https://ns.adobe.com/experience/adcloud/searchEngineId": {
+          "title": "Search Engine Identifier",
+          "type": "integer",
+          "description": "The application-specified identifier used to identify the Search Advertising Platform Name."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/searchadvertising-campaign"
+    }
+  ],
+  "meta:status": "experimental"
+}

--- a/schemas/common/campaign.example.1.json
+++ b/schemas/common/campaign.example.1.json
@@ -1,0 +1,9 @@
+{
+  "xdm:id": "100001061",
+  "xdm:campaignName": "My First Campaign",
+  "xdm:campaignDescription": "Branded Mobile Campaign",
+  "xdm:campaignStatus": "Active",
+  "xdm.campaignObjective": "visit_web",
+  "repo:createDate": "2019-04-26T14:00:00+00:00",
+  "repo:modifyDate": "2019-04-26T14:00:00+00:00"
+}

--- a/schemas/common/campaign.schema.json
+++ b/schemas/common/campaign.schema.json
@@ -1,0 +1,110 @@
+{
+  "meta:license": [
+    "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/common/campaign",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:extends": ["http://ns.adobe.com/data/record"],
+  "title": "Geo",
+  "description": "Base Campaign",
+  "definitions": {
+    "campaign": {
+      "properties": {
+        "xdm:campaignName": {
+          "title": "Campaign Name",
+          "type": "string",
+          "description": "Name of the Campaign."
+        },
+        "xdm:campaignDescription": {
+          "title": "Description",
+          "type": "string",
+          "description": "Description of the Campaign."
+        },
+        "xdm:campaignStatus": {
+          "title": "Campaign Status",
+          "type": "string",
+          "description": "Campaign Status indicates if underlying ads are eligible to serve.",
+          "enum": [
+            "Active",
+            "Paused",
+            "Deleted",
+            "Ended",
+            "Pending",
+            "Inactive",
+            "Disapproved",
+            "Incomplete",
+            "Offline",
+            "On Hold (Editing)",
+            "On Hold (Other)",
+            "Duplicate",
+            "Orphan",
+            "Optimize",
+            "Disabled",
+            "Unknown",
+            "Dummy"
+          ],
+          "meta:enum": {
+            "Active": "Active",
+            "Paused": "Paused",
+            "Deleted": "Deleted",
+            "Ended": "Ended",
+            "Pending": "Pending",
+            "Inactive": "Inactive",
+            "Disapproved": "Disapproved",
+            "Incomplete": "Incomplete",
+            "Offline": "Offline",
+            "On Hold (Editing)": "On Hold (Editing)",
+            "On Hold (Other)": "On Hold (Other)",
+            "Duplicate": "Duplicate",
+            "Orphan": "Orphan",
+            "Optimize": "Optimize",
+            "Disabled": "Disabled",
+            "Unknown": "Unknown",
+            "Dummy": "Dummy"
+          }
+        },
+        "xdm:campaignObjective": {
+          "title": "Campaign Objective",
+          "type": "string",
+          "description": "Campaign Objective indicates the primary objective of the campaign - e.g. Promotions, Brands, App Installs.",
+          "enum": ["visit_web", "promote_brand", "install_app", "visit_offer"],
+          "meta:enum": {
+            "visit_web": "visit_web",
+            "promote_brand": "promote_brand",
+            "install_app": "install_app",
+            "visit_offer": "visit_offer"
+          }
+        }
+        "xdm:campaignStartDate": {
+          "title": "Campaign Start Date",
+          "type": "string",
+          "format": "date",
+          "description": "Campaign Start Date"
+        },
+        "xdm:campaignEndDate": {
+          "title": "Campaign End Date",
+          "type": "string",
+          "format": "date",
+          "description": "Campaign End Date"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/data/record"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
+    },
+    {
+      "$ref": "#/definitions/campaign"
+    }
+  ],
+  "meta:status": "experimental"
+}


### PR DESCRIPTION
This provides an alternative approach to PR https://github.com/adobe/xdm/pull/703. Do NOT merge this in if the other PR is used. 

This takes the approach of creating a base XDM Campaign object which acts as a base "class" with only the few fields that would be consistent across all its instances. It then creates an AMO specific mixin that is included when you want to extend the Campaign with the AMO specific fields. 

For the actual schema used by AEP, the schema would be defined in the registry with the following:
allOf: [
"The base XDM campaign class" + "The solution/AMO mixin(s)"
]

Important items to note:
The solution mixin is "meta:intendedToExtend" that base Campaign class. This is what makes it appear as a possible mixin inside of the AEP UI when a user tries to create a "schema" based on that class. The base Campaign object is standard XDM and thus its fields are part of the "https://ns.adobe.com/xdm" namespace. The mixin introduces solution specific fields and so those are in the solution namespace "https://ns.adobe.com/experience/adcloud". Yes these solution specific fields result in some weird nesting inside of AEP, but that is a problem with AEP and not the schema. 