### PR TITLE
Added AAM Extension for segment definition

### DIFF
--- a/extensions/adobe/experience/audiencemanager/segmentdefinition.example.1.json
+++ b/extensions/adobe/experience/audiencemanager/segmentdefinition.example.1.json
@@ -1,0 +1,9 @@
+{
+  "xdm:segmentExpression": {
+    "xdm:expressionType": "AAM",
+    "xdm:mimeType": "text/plain",
+    "xdm:value": "c_contextdata.catname matchesregex \"\"^sony -.+\"\""
+  },
+  "xdm:segmentFolderId": "1123",
+  "xdm:segmentSubType": "SEGMENT"
+}

--- a/extensions/adobe/experience/audiencemanager/segmentdefinition.schema.json
+++ b/extensions/adobe/experience/audiencemanager/segmentdefinition.schema.json
@@ -1,0 +1,55 @@
+{
+  "meta:license": [
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/experience/audiencemanager/segmentdefinition",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Adobe Audience Manager Segment Definition Mixin",
+  "type": "object",
+  "description": "Adobe Audience Manager Segment Definition mixin for use with schemas for Segment metadata ingestion.",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:intendedToExtend": [
+    "https://ns.adobe.com/xdm/context/segmentdefinition"
+  ],
+  "definitions": {
+    "segmentdefinition": {
+      "properties": {
+        "xdm:segmentFolderId": {
+          "title": "Folder Id",
+          "type": "string",
+          "description": "id of parent folder if present"
+        },
+        "xdm:segmentSubType": {
+          "title": "Sub Type",
+          "type": "string",
+          "description": "Further classification of AAM Entity",
+          "meta:enum": [
+            "FOLDER",
+            "FOLDER_TRAIT",
+            "SEGMENT",
+            "UNDEFINED",
+            "RULE_BASED_TRAIT",
+            "NON_ALGO_TRAIT",
+            "TEST_SEGMENT",
+            "COMPANY_ACTIVITY_TRAIT",
+            "ALGO_TRAIT",
+            "ON_BOARDED_TRAIT"
+          ]
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/context/segmentdefinition-expression"
+    },
+    {
+      "$ref": "#/definitions/segmentdefinition"
+    }
+  ],
+  "meta:status": "experimental"
+}


### PR DESCRIPTION
AAM extension will add audience manager specific fields to Segment Definition. These fields are
- segmentFolderId - In case segment definition belongs to specific segment folder
- segmentSubType - Further classification of segments
