### PR TITLE
Update meta.schema.json pattern regex

### DIFF
--- a/meta.schema.json
+++ b/meta.schema.json
@@ -40,7 +40,7 @@
     "$id": {
       "type": "string",
       "format": "uri",
-      "pattern": "(https://ns\\.adobe\\.com/xdm/[a-z0-9-/]*)|(http://schema\\.org/.*)|(http://ns.adobe.com/adobecloud/core/1.0.*)|(https://ns\\.adobe\\.com/adobecloudplatform/.*)|(https://tools\\.ietf\\.org/html/draft-kelly-json-hal-08/.*)|(http://www.iptc\\.org/.*)"
+      "pattern": "(https://ns\\.adobe\\.com/xdm/[a-z0-9-/]*)|(http://schema\\.org/.*)|(http://ns.adobe.com/adobecloud/core/1.0.*)|([http|https]://ns\\.adobe\\.com/adobecloudplatform/.*)|(https://tools\\.ietf\\.org/html/draft-kelly-json-hal-08/.*)|(http://www.iptc\\.org/.*)"
     },
     "meta:license": {
       "type": "array",

--- a/meta.schema.json
+++ b/meta.schema.json
@@ -40,7 +40,7 @@
     "$id": {
       "type": "string",
       "format": "uri",
-      "pattern": "(https://ns\\.adobe\\.com/xdm/[a-z0-9-/]*)|(http://schema\\.org/.*)|(http://ns.adobe.com/adobecloud/core/1.0.*)|(https://tools\\.ietf\\.org/html/draft-kelly-json-hal-08/.*)|(http://www.iptc\\.org/.*)"
+      "pattern": "(https://ns\\.adobe\\.com/xdm/[a-z0-9-/]*)|(http://schema\\.org/.*)|(http://ns.adobe.com/adobecloud/core/1.0.*)|(https://ns\\.adobe\\.com/adobecloudplatform/.*)|(https://tools\\.ietf\\.org/html/draft-kelly-json-hal-08/.*)|(http://www.iptc\\.org/.*)"
     },
     "meta:license": {
       "type": "array",


### PR DESCRIPTION
Added `adobecloudplatform` in the `$id` pattern section to be allowed for `user.schema.json`
