### PR TITLE
Fix XDM registry and npm test validation for user schema and its examples

### DIFF
--- a/extensions/ims/user.schema.json
+++ b/extensions/ims/user.schema.json
@@ -52,7 +52,7 @@
   "allOf": [
     {
       "$ref": "https://ns.adobe.com/xdm/common/principal"
-    },    
+    },
     {
       "$ref": "#/definitions/user"
     },

--- a/extensions/ims/user.schema.json
+++ b/extensions/ims/user.schema.json
@@ -51,9 +51,6 @@
   },
   "allOf": [
     {
-      "$ref": "https://ns.adobe.com/xdm/common/principal"
-    },
-    {
       "$ref": "#/definitions/user"
     },
     {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "aem_user": "packageUser",
     "aem_password": "override me securely",
     "markdown-importer-version": "0.0.4",
-    "schemas": 251
+    "schemas": 252
   },
   "scripts": {
     "clean": "rm -rf docs/reference",

--- a/schemas/common/identity.example.1.json
+++ b/schemas/common/identity.example.1.json
@@ -1,0 +1,5 @@
+{
+  "xdm:identityProvider": "ims",
+  "xdm:id": "C0B648DE57D701277F000101@AdobeID",
+  "xdm:type": "https://ns.adobe.com/xdm/common/user"
+}

--- a/schemas/common/identity.example.2.json
+++ b/schemas/common/identity.example.2.json
@@ -1,0 +1,7 @@
+{
+  "xdm:identityProvider": "ims",
+  "xdm:id": "C0B648DE57D701277F000101@AdobeID",
+  "xdm:type": "https://ns.adobe.com/xdm/common/user",
+  "xdm:displayName": "The users name",
+  "xdm:profileImage": "https://mir-s3-cdn-cf.behance.net/user/276/b9c11633104347.57a9c2152b78e.jpg"
+}

--- a/schemas/common/identity.schema.json
+++ b/schemas/common/identity.schema.json
@@ -6,17 +6,20 @@
     "of the License at https://creativecommons.org/licenses/by/4.0/"
   ],
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "$id": "https://ns.adobe.com/adobecloudplatform/ims/user",
-  "title": "IMS User",
+  "$id": "https://ns.adobe.com/xdm/common/identity",
+  "title": "User identity",
+  "type": "object",  
+  "meta:extensible": true,
   "description":
     "This model represents an authenticated IMS User. The IMS user principal is a user account under Adobe's identity management system (IMS).",
   "definitions": {
-    "user": {
+    "identity": {
       "type": "object",
       "properties": {
         "xdm:identityProvider": {
+          "description": "The identity provider that manages this principal.",
           "type": "string",
-          "const": "ims"
+          "meta:enum": ["ims"]
         },
         "xdm:id": {
           "description":
@@ -25,7 +28,10 @@
         },
         "xdm:type": {
           "type": "string",
-          "const": "https://ns.adobe.com/adobecloudplatform/ims/user"
+          "meta:enum": ["https://ns.adobe.com/xdm/common/user"],
+          "format": "uri",
+          "description":
+            "The type of the identity. Acts as a processing hint to the client. Ideally, each value should be identified as a [URI](https://tools.ietf.org/html/rfc3986)."
         }
       }
     },
@@ -51,15 +57,12 @@
   },
   "allOf": [
     {
-      "$ref": "https://ns.adobe.com/xdm/common/principal"
-    },    
-    {
-      "$ref": "#/definitions/user"
+      "$ref": "#/definitions/identity"
     },
     {
       "$ref": "#/definitions/publicprofile"
     }
   ],
   "required" : ["xdm:identityProvider", "xdm:id", "xdm:type"],
-  "meta:status": "deprecated"
+  "meta:status": "experimental"
 }


### PR DESCRIPTION
Please link to the issue #724

Summary: user schema and its checked-in examples do not work for XDM registry which breaks at npm test schema validation stage. This PR marks user schema as deprecated. Since it is not known who uses user schema, suggestion from XDM team is to mark it deprecated instead of making backward incompatible changes to it. User schema is experimental. So, it should be okay to mark it to "deprecated".

This PR ensures that mandatory similar properties of principal do not become mandatory properties for new replacement schema - named - identity.schema.json. The replacement schema is in location that is covered by `npm test` which used to ignore user.schema.json and its example because of its location (/extensions).

Original issue - 
I think the existing user.example.1.json example makes it seem that “principal” properties in user.schema.json were supposed to be optional. For example, @id is optional.

This is the current user.example.1.json


```
    {
      "xdm:identityProvider": "ims",
      "xdm:id": "C0B648DE57D701277F000101@AdobeID",
      "xdm:type": "https://ns.adobe.com/adobecloudplatform/ims/user"
    }

```

XDM registry rejects this example and expects a XDM object that matches user.schema.json to be like -

```
    {
      "xdm:identityProvider": "ims",
      "xdm:id": "C0B648DE57D701277F000101@AdobeID",
      "xdm:type": "https://ns.adobe.com/adobecloudplatform/ims/user"
      "xdm:provider": {
        "@id": "https://ims-na1.adobelogin.com/"
      },
      "@id": "C0B648DE57D701277F000101@AdobeID",
      "@type": "https://ns.adobe.com/adobecloudplatform/ims/user"
    }
```
---

This looks really awkward to have the similar values duplicated twice in `xdm:id` and `@id`. Similarly, `@type` and `xdm:type`. I think `@type` is not the preferred option compared to `xdm:type` as the latter has a namespace. This pull request drops import of principal.schema.json in identity.schema.json (user.schema.json's replacement). This would ensure that identity.example.1.json passes XDM registry test for identity.schema.json.

---

Please find a list of minor differences in identity schema compared to user schema -
    1. "xdm:identityProvider" is a meta:enum with known value of "ims" instead of being a const. This lets the schema be used for other identity providers in future.
    2. xdm:type is a meta:enum with a known value of ""https://ns.adobe.com/xdm/common/user" instead of a being a const "https://ns.adobe.com/adobecloudplatform/ims/user". The constant should not contain a specific identity provider name since a user is a user, and the value of this field should be a general user. This schema can be easily used for defining a group later on, if the property is an enum instead of being a const. So, it opens the door for that as well.
    3. Dropping $ref to "https://ns.adobe.com/xdm/common/principal" based on issue raised above. The reference was causing issues with XDM registry validation for user.example.1.json and similar XDM objects that were built for now deprecated user.schema.json
    4. The schema is marked extensible, so it can be used for defining other schemas if required.