### PR TITLE
[AdCloud DSP] Campaign Placement Metadata Hierarchy

### DIFF
--- a/extensions/adobe/experience/adcloud/dsp/account.example.1.json
+++ b/extensions/adobe/experience/adcloud/dsp/account.example.1.json
@@ -1,0 +1,10 @@
+{
+  "@id": "12",
+  "dsp:accountKey": "dsdfweW12",
+  "dsp:accountName": "Dailymotion",
+  "dsp:accountType": "Brand Direct No Agency",
+  "dsp:productName": "PrivateExchange",
+  "dsp:currency": "USD",
+  "repo:createDate": "2019-04-26T14:00:00+00:00",
+  "repo:modifyDate": "2019-04-26T14:00:00+00:00"
+}

--- a/extensions/adobe/experience/adcloud/dsp/account.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/account.schema.json
@@ -1,0 +1,92 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/adcloud/dsp/account",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "DSP Advertising Account",
+  "type": "object",
+  "meta:extensible": false,
+  "meta:abstract": false,
+  "meta:auditable": true,
+  "meta:extends": ["https://ns.adobe.com/xdm/data/record"],
+  "description": "Adobe Advertising Cloud DSP Account Details.",
+  "definitions": {
+    "dsp-account": {
+      "properties": {
+        "dsp:accountKey": {
+          "title": "Account Key",
+          "type": "string",
+          "description": "External Identifier of the account."
+        },
+        "dsp:accountName": {
+          "title": "Account Name",
+          "type": "string",
+          "description": "Name of the account."
+        },
+        "dsp:accountType": {
+          "title": "Account Type",
+          "type": "string",
+          "description": "Type of the account.",
+          "enum": [
+            "Agency",
+            "TradingDesk",
+            "BrandDirectAgencyManaged",
+            "BrandDirectNoAgency",
+            "AdNetwork",
+            "PublisherAudienceExtension",
+            "Other"
+          ],
+          "meta:enum": {
+            "Agency": "Agency",
+            "TradingDesk": "Trading Desk",
+            "BrandDirectAgencyManaged": "Brand Direct Agency Managed",
+            "BrandDirectNoAgency": "Brand Direct No Agency",
+            "AdNetwork": "Ad Network ",
+            "PublisherAudienceExtension": "Publisher Audience Extension ",
+            "Other" : "Other "
+          }
+        },
+        "dsp:productName": {
+          "title": "Product Name",
+          "type": "string",
+          "description": "The name of the product associated with this account.",
+          "enum": [
+            "PlayTime",
+            "InPlay",
+            "OneLoad",
+            "PrivateExchange"
+          ],
+          "meta:enum": {
+            "PlayTime": "PlayTime",
+            "InPlay": "InPlay",
+            "OneLoad": "OneLoad",
+            "PrivateExchange": "PrivateExchange"
+          }
+        },
+        "dsp:currency": {
+          "title": "Account Currency",
+          "type": "string",
+          "examples": ["USD", "EUR", "JPY"],
+          "pattern": "^[A-Z]{3}$",
+          "description": "The ISO 4217 billing currency code for the account."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/data/record"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
+    },
+    {
+      "$ref": "#/definitions/dsp-account"
+    }
+  ],
+  "meta:status": "experimental"
+}

--- a/extensions/adobe/experience/adcloud/dsp/advertiser.example.1.json
+++ b/extensions/adobe/experience/adcloud/dsp/advertiser.example.1.json
@@ -1,0 +1,10 @@
+{
+  "@id": "12",
+  "dsp:advertiserKey": "QEr8RnlYHwnG4KbFSQoA",
+  "dsp:advertiserName": "Workday",
+  "dsp:advertiserStatus": "Active",
+  "dsp:advertiserUrl": "http://www.workday.com",
+  "dsp:accountId": "377165",
+  "repo:createDate": "2019-04-26T14:00:00+00:00",
+  "repo:modifyDate": "2019-04-26T14:00:00+00:00"
+}

--- a/extensions/adobe/experience/adcloud/dsp/advertiser.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/advertiser.schema.json
@@ -1,0 +1,71 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/adcloud/dsp/advertiser",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "DSP Advertiser",
+  "type": "object",
+  "meta:extensible": false,
+  "meta:abstract": false,
+  "meta:auditable": true,
+  "meta:extends": ["https://ns.adobe.com/xdm/data/record"],
+  "description": "Adobe Advertising Cloud DSP Advertiser Details.",
+  "definitions": {
+    "dsp-advertiser": {
+      "properties": {
+        "dsp:advertiserKey": {
+          "title": "Advertiser Key",
+          "type": "string",
+          "description": "Unique external identifier for the advertiser."
+        },
+        "dsp:advertiserName": {
+          "title": "Advertiser Name",
+          "type": "string",
+          "description": "The name of the advertiser."
+        },
+        "dsp:advertiserStatus": {
+          "title": "Advertiser Status",
+          "type": "string",
+          "description": "Indicates the advertiser's status, whether it is active, inactive or deleted.",
+          "enum": [
+            "Active",
+            "Inactive",
+            "Deleted"
+          ],
+          "meta:enum": {
+            "Active": "Active",
+            "Inactive": "Inactive",
+            "Deleted": "Deleted"
+          }
+        },
+        "dsp:advertiserUrl": {
+          "title": "Advertiser Url",
+          "type": "string",
+          "format": "uri",
+          "description": "Advertiser Url."
+        },
+        "dsp:accountId": {
+          "title": "Account Identifier",
+          "type": "string",
+          "description": "The identifier of the account associated with this advertiser.The same accountId can serve multiple advertisers in case it represents an advertising agency."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/data/record"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
+    },
+    {
+      "$ref": "#/definitions/dsp-advertiser"
+    }
+  ],
+  "meta:status": "experimental"
+}

--- a/extensions/adobe/experience/adcloud/dsp/campaign.example.1.json
+++ b/extensions/adobe/experience/adcloud/dsp/campaign.example.1.json
@@ -1,0 +1,15 @@
+{
+  "@id": "12",
+  "dsp:campaignKey": "QEr8RnlYHwnG4KbFSQor",
+  "dsp:campaignName": "News At Cisco",
+  "dsp:campaignStatus": "Active",
+  "dsp:timezone": "America/New_York",
+  "dsp:type": "Media",
+  "dsp:userId": 495991,
+  "dsp:accountId": "1",
+  "dsp:advertiserId": "3",
+  "dsp:campaignStartTime": "2019-01-09 00:00:00",
+  "dsp:campaignEndTime": "2019-01-11 00:00:00",
+  "repo:createDate": "2019-04-26T14:00:00+00:00",
+  "repo:modifyDate": "2019-04-26T14:00:00+00:00"
+}

--- a/extensions/adobe/experience/adcloud/dsp/campaign.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/campaign.schema.json
@@ -1,0 +1,122 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/adcloud/dsp/campaign",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "DSP Advertising Campaign",
+  "type": "object",
+  "meta:extensible": false,
+  "meta:abstract": false,
+  "meta:auditable": true,
+  "meta:extends": ["https://ns.adobe.com/xdm/data/record"],
+  "description": "Adobe Advertising Cloud DSP Campaign Details.",
+  "definitions": {
+    "dsp-campaign": {
+      "properties": {
+        "dsp:campaignKey": {
+          "title": "Campaign Key",
+          "type": "string",
+          "description": "Campaign external identifier."
+        },
+        "dsp:campaignName": {
+          "title": "Campaign Name",
+          "type": "string",
+          "description": "Name of the campaign."
+        },
+        "dsp:campaignStatus": {
+          "title": "Campaign Status",
+          "type": "string",
+          "description": "Campaign Status extracted from the Insertion Order associated with this campaign.Indicates if underlying ads are eligible to serve.",
+          "enum": [
+            "Active",
+            "Inactive",
+            "Deleted",
+            "Paid"
+          ],
+          "meta:enum": {
+            "Active": "Active",
+            "Inactive": "Inactive",
+            "Deleted": "Deleted",
+            "Paid": "Paid"
+          }
+        },
+        "dsp:timezone": {
+          "title": "Campaign Timezone",
+          "type": "string",
+          "description": "Timezone of the campaign."
+        },
+        "dsp:type": {
+          "title": "Campaign Type",
+          "type": "string",
+          "description": "Campaign Type",
+          "enum": [
+            "Media",
+            "Brandsights"
+          ],
+          "meta:enum": {
+            "Media": "Media",
+            "Brandsights": "Brandsights"
+          }
+        },
+        "dsp:userId": {
+          "title": "User Identifier",
+          "type": "integer",
+          "description": "Identifier for the user who created the campaign."
+        },
+        "dsp:feeClass": {
+          "title": "The Fee Class",
+          "type": "string",
+          "description": "Fee Class needed for computing the total spend.",
+          "enum": [
+            "tubemogul",
+            "advertiser",
+            "no_io"
+          ],
+          "meta:enum": {
+            "tubemogul": "tubemogul",
+            "advertiser": "advertiser",
+            "no_io": "no_io"
+          }
+        },
+        "dsp:campaignStartTime": {
+          "title": "Campaign start time.",
+          "type": "string",
+          "format": "date-time",
+          "description": "The insertion order fields representing campaign start time."
+        },
+        "dsp:campaignEndTime": {
+          "title": "Campaign end time.",
+          "type": "string",
+          "format": "date-time",
+          "description": "The insertion order fields representing campaign end time."
+        },
+        "dsp:accountId": {
+          "title": "Account Identifier",
+          "type": "string",
+          "description": "Identifier for the account owning this campaign."
+        },
+        "dsp:advertiserId": {
+          "title": "Advertiser Identifier",
+          "type": "string",
+          "description": "Identifier for the advertiser owning this campaign."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/data/record"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
+    },
+    {
+      "$ref": "#/definitions/dsp-campaign"
+    }
+  ],
+  "meta:status": "experimental"
+}

--- a/extensions/adobe/experience/adcloud/dsp/package.example.1.json
+++ b/extensions/adobe/experience/adcloud/dsp/package.example.1.json
@@ -1,0 +1,18 @@
+{
+  "@id": "586",
+  "dsp:packageName": "Branded Overlay",
+  "dsp:packageDescription": "Social Media Apps and games branded overlay SF",
+  "dsp:packageStatus": "Active",
+  "dsp:unitsPurchased": "7566.00000",
+  "dsp:goalMetric": "SPEND",
+  "dsp:goalMetricValue": 95000000,
+  "dsp:goalType": "CAP",
+  "dsp:goalInterval": "ALLTIME",
+  "dsp:purchaseUom": "CPM",
+  "dsp:pricePerUom": 1.0,
+  "dsp:packageStartTime": "2019-02-20 00:00:00",
+  "dsp:packageEndTime": "2012-04-29 22:59:59",
+  "dsp:campaignId": "426170",
+  "repo:createDate": "2012-04-26T14:00:00+00:00",
+  "repo:modifyDate": "2012-04-26T14:00:00+00:00"
+}

--- a/extensions/adobe/experience/adcloud/dsp/package.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/package.schema.json
@@ -1,0 +1,150 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/adcloud/dsp/package",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "DSP Advertising Package",
+  "type": "object",
+  "meta:extensible": false,
+  "meta:abstract": false,
+  "meta:auditable": true,
+  "meta:extends": ["https://ns.adobe.com/xdm/data/record"],
+  "description": "Adobe Advertising Cloud DSP Package Details.",
+  "definitions": {
+    "dsp-package": {
+      "properties": {
+        "dsp:packageName": {
+          "title": "Package Name",
+          "type": "string",
+          "description": "The name of the package."
+        },
+        "dsp:packageDescription": {
+          "title": "Package Description",
+          "type": "string",
+          "description": "The description of the package."
+        },
+        "dsp:packageStatus": {
+          "title": "Package Status",
+          "type": "string",
+          "description": "Package Status indicates if underlying ads are eligible to serve.",
+          "enum": [
+            "Active",
+            "Inactive",
+            "Deleted"
+          ],
+          "meta:enum": {
+            "Active": "Active",
+            "Inactive": "Inactive",
+            "Deleted": "Deleted"
+          }
+        },
+        "dsp:unitsPurchased": {
+          "title": "Units Purchased",
+          "type": "number",
+          "description": "The number of purchased units."
+        },
+        "dsp:goalMetric": {
+          "title": "Goal Metric",
+          "type": "string",
+          "description": "The metric on which the pacing occurs so that the campaign hits the desired metric value over the course of its lifetime. E.g. SPEND, IMPRESSIONS"
+        },
+        "dsp:goalMetricValue": {
+          "title": "Goal Interval",
+          "type": "integer",
+          "description": "The maximum value allowed for the metric to reach in a certain interval."
+        },
+        "dsp:goalType": {
+          "title": "Goal Type",
+          "type": "string",
+          "description": "The action taken when the metric hits the maximum value.",
+          "enum": [
+            "CAP",
+            "PACE"
+          ],
+          "meta:enum": {
+            "CAP": "CAP",
+            "PACE": "PACE"
+          }
+        },
+        "dsp:goalInterval": {
+          "title": "Goal Interval",
+          "type": "string",
+          "description": "The time frame for which the metric value is computed. E.g. DAY, ALLTIME ",
+          "enum": [
+            "ALLTIME",
+            "DAY",
+            "HOUR",
+            "MONTH",
+            "WEEK"
+          ],
+          "meta:enum": {
+            "ALLTIME": "ALLTIME",
+            "DAY": "DAY",
+            "HOUR": "HOUR",
+            "MONTH": "MONTH",
+            "WEEK": "WEEK"
+          }
+        },
+        "dsp:purchaseUom": {
+          "title": "Purchase Unit of Measure",
+          "type": "string",
+          "description": "The unit-of-measure of the purchase.",
+          "enum": [
+            "CPM",
+            "CPV",
+            "CPE",
+            "CPCV",
+            "CPC",
+            "OTCPM",
+            "vCPM",
+            "GRP",
+            "vCPCV"
+          ],
+          "meta:enum": {
+            "CPM": "CPM",
+            "CPV": "CPV",
+            "CPE": "CPE",
+            "CPCV": "CPCV",
+            "CPC": "CPC",
+            "OTCPM": "OTCPM",
+            "vCPM": "vCPM",
+            "GRP": "GRP",
+            "vCPCV": "vCPCV"
+          }
+        },
+        "dsp:pricePerUom": {
+          "title": "Price per Unit of Measure",
+          "type": "number",
+          "description": "The price per unit of measure."
+        },
+        "dsp:packageStartTime": {
+          "title": "Package Start Time",
+          "type": "string",
+          "format": "date-time",
+          "description": "The starting time of serving ads in placements linked to the campaign belonging to this package."
+        },
+        "dsp:packageEndTime": {
+          "title": "Package End Time",
+          "type": "string",
+          "format": "date-time",
+          "description": "The end time of serving ads in placements linked to the campaign belonging to this package."
+        },
+        "dsp:campaignId": {
+          "title": "Campaign Identifier",
+          "type": "string",
+          "description": "Campaign Identifier on the display advertising platform which has this package associated."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/dsp-package"
+    }
+  ],
+  "meta:status": "experimental"
+}

--- a/extensions/adobe/experience/adcloud/dsp/placement.example.1.json
+++ b/extensions/adobe/experience/adcloud/dsp/placement.example.1.json
@@ -1,0 +1,15 @@
+{
+  "@id": "1",
+  "dsp:placementKey": "YFk8RnlYHwnG4KbFSQor",
+  "dsp:placementName": "Yahoo : CTP : UK : YouTube",
+  "dsp:placementType": "Site",
+  "dsp:placementStartTime": "2017-02-26T15:52:25+00:00",
+  "dsp:placementEndTime": "2017-09-26T15:52:25+00:00",
+  "dsp:placementBudget": 123,
+  "dsp:campaignId": "12",
+  "dsp:packageId": "1",
+  "dsp:siteId": "12334",
+  "dsp:adIds": ["1","2"],
+  "repo:createDate": "2019-04-26T14:00:00+00:00",
+  "repo:modifyDate": "2019-04-27T14:00:00+00:00"
+}

--- a/extensions/adobe/experience/adcloud/dsp/placement.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/placement.schema.json
@@ -1,0 +1,112 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/adcloud/dsp/placement",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "DSP Advertising Campaign Placement",
+  "type": "object",
+  "meta:extensible": false,
+  "meta:abstract": false,
+  "meta:auditable": true,
+  "meta:extends": ["https://ns.adobe.com/xdm/data/record"],
+  "description": "Adobe Advertising Cloud DSP Campaign Placement Details.",
+  "definitions": {
+    "dsp-placement": {
+      "properties": {
+        "dsp:placementKey": {
+          "title": "Placement Key",
+          "type": "string",
+          "description": "Campaign Placement external unique identifier."
+        },
+        "dsp:placementName": {
+          "title": "Name",
+          "type": "string",
+          "description": "Campaign Placement name."
+        },
+        "dsp:placementType": {
+          "title": "Placement Type",
+          "type": "string",
+          "description": "Budget Type indicates how the allocated budget will be spent",
+          "enum": [
+            "Direct",
+            "Site",
+            "Network",
+            "Planner",
+            "Audit",
+            "ParentPlan",
+            "ChildPlan",
+            "Template",
+            "SAS"
+          ],
+          "meta:enum": {
+            "Direct": "Direct",
+            "Site": "Site",
+            "Network": "Network",
+            "Planner": "Planner",
+            "Audit": "Audit",
+            "ParentPlan": "ParentPlan",
+            "ChildPlan": "ChildPlan",
+            "Template": "Template",
+            "SAS": "SAS "
+          }
+        },
+        "dsp:placementStartTime": {
+          "title": "Campaign Placement Start Date and Time",
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which a placement starts showing ads (ms since Jan 1, 1970)"
+          },
+        "dsp:placementEndTime": {
+          "title": "Campaign Placement End Date and Time",
+          "type": "string",
+          "format": "date-time",
+          "description": "The date after which a placement stops showing ads (ms since Jan 1, 1970)."
+        },
+        "dsp:placementBudget": {
+          "title": "Campaign Placement Budget",
+          "type": "integer",
+          "description": "Campaign placement budget."
+        },
+        "dsp:campaignId": {
+          "title": "Campaign Identifier",
+          "type": "string",
+          "description": "Identifier of the campaign this placement belongs to."
+        },
+        "dsp:packageId": {
+          "title": "Package Identifier",
+          "type": "string",
+          "description": "Identifier of the package the placement belongs to."
+        },
+        "dsp:siteId": {
+          "title": "Site Identifier",
+          "type": "string",
+          "description": "Identifier of the site where the placement will be shown."
+        },
+        "dsp:adIds": {
+          "title": "Ad Identifiers",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of identifiers for the ads which are linked to this campaign placement."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/data/record"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
+    },
+    {
+      "$ref": "#/definitions/dsp-placement"
+    }
+  ],
+  "meta:status": "experimental"
+}


### PR DESCRIPTION
Please link to the issue #726 

**Note**: As previously agreed, AdCloud DSP uses its own namespace ( **dsp** ) .

This will introduce 5 new AdCloud DSP-specific classes : Placement, Campaign, Package, Account, Advertiser

In DSP we have the Placement as the most atomic part of the model so we start the hierarchy from there. 
A Campaign is composed of one or more placements.  
Also, a Package is composed of one or more placements.  
The Placements in a Campaign don't all necessarily have to belong to the same Package.  
The hierarchy can go

- account → campaign → placement 

         OR

- account → campaign → package → placement

Regarding the relationship between Accounts and Advertisers, in the simple case, there is a 1:1 correspondence between them.  But in some cases, most notably advertising agencies that serve lots of brands then there can be many advertisers per account.  Also, sometimes different desks within agencies might have two different accounts and the same advertiser might be served by two different accounts.

A more extended documentation regarding the part of the DSP Advertising model we want to expose can be found in our [wiki page](https://wiki.corp.adobe.com/display/EfficientFrontier/%5BXDM+Mapping%5D+Campaign+Placement-related+hierarchy).

@prabhum2 , @cfraser Can you please help us with the review? 

