### PR TITLE
DSP Feed-related Metadata Hierarchy

### DIFF
--- a/extensions/adobe/experience/adcloud/dsp/adserver.example.1.json
+++ b/extensions/adobe/experience/adcloud/dsp/adserver.example.1.json
@@ -1,0 +1,8 @@
+{
+  "xdm:id": "12",
+  "xdm:adServerName": "LiveRail",
+  "xdm:adServerStatus": "Active",
+  "xdm:dealIdSupported": true,
+  "xdm:partnerId": 567,
+  "xdm:inventoryMediaPropertyId": "44"
+}

--- a/extensions/adobe/experience/adcloud/dsp/adserver.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/adserver.schema.json
@@ -1,0 +1,60 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/experience/adcloud/dsp/adserver",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Display Advertising Ad Server",
+  "type": "object",
+  "description": "Adobe Advertising Cloud Ad Server details.",
+  "definitions": {
+    "dsp-adserver": {
+      "properties": {
+        "xdm:adServerName": {
+          "title": "Ad Server name",
+          "type": "string",
+          "description": "Ad Server name."
+          },
+        "xdm:adServerStatus": {
+          "title": "Ad Server Status",
+          "type": "string",
+          "description": "The Ad Server Status determines if this Ad Server is active, inactive or deleted.",
+          "enum": [
+            "Active",
+            "Inactive",
+            "Deleted"
+          ],
+          "meta:enum": {
+            "Active": "Active",
+            "Inactive": "Inactive",
+            "Deleted": "Deleted"
+          }
+        },
+        "xdm:dealIdSupported": {
+          "title": "Deal Id Supported",
+          "type": "boolean",
+          "description": "If this Ad Server supports SSP deal ID mechanism."
+        },
+        "xdm:partnerId": {
+          "title": "Partner Id",
+          "type": "integer",
+          "description": "A reference to the partner if a 3rd party ad server or null."
+        },
+        "xdm:inventoryMediaPropertyId": {
+          "title": "Media Property Identifier",
+          "type": "string",
+          "description": "The identifier of the Media Property servicing the Ad Server Inventory."
+        }
+        }
+      }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/dsp-adserver"
+    }
+  ],
+  "meta:status": "experimental"
+}

--- a/extensions/adobe/experience/adcloud/dsp/feed.example.1.json
+++ b/extensions/adobe/experience/adcloud/dsp/feed.example.1.json
@@ -1,0 +1,15 @@
+{
+  "xdm:id": "1",
+  "xdm:feedKey": "YFk8RnlYHwnG4KbFSQor",
+  "xdm:feedName": "DailyMotion : CTP : USA : Video 1 : Karate Kid",
+  "xdm:feedType": "TMEmbed",
+  "xdm:mediaType": "desktop_video",
+  "xdm:feedTargetImpressions": 90222,
+  "xdm:feedStartDate": "2019-08-26 00:00:00",
+  "xdm:feedEndDate": "2019-09-30 23:59:59",
+  "xdm:feedStatus": "Active",
+  "xdm:adServerId": "12",
+  "xdm:mediaPropertyId": "44",
+  "repo:createDate": "2019-08-26T14:00:00+00:00",
+  "repo:modifyDate": "2019-08-26T14:00:00+00:00"
+}

--- a/extensions/adobe/experience/adcloud/dsp/feed.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/feed.schema.json
@@ -1,0 +1,135 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/experience/adcloud/dsp/feed",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "DSP Advertising Feed",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:auditable": true,
+  "meta:abstract": true,
+  "meta:extends": ["https://ns.adobe.com/xdm/data/record"],
+  "description": "Adobe Advertising Cloud DSP Feed Hierarchy Details.",
+  "definitions": {
+    "dsp-feed": {
+      "properties": {
+        "xdm:feedKey": {
+          "title": "Feed Key",
+          "type": "string",
+          "description": "Feed external unique identifier."
+        },
+        "xdm:feedName": {
+          "title": "Feed Name",
+          "type": "string",
+          "description": "Name of the feed."
+        },
+        "xdm:feedType": {
+          "title": "Feed Type",
+          "type": "string",
+          "description": "Feed Type",
+          "enum": [
+            "Onsite",
+            "TMEmbed",
+            "PartnerEmbed",
+            "RTB",
+            "Vast",
+            "VastProxy",
+            "TrialPay",
+            "DealID",
+            "SAS"
+          ],
+          "meta:enum": {
+            "Onsite": "Onsite",
+            "TMEmbed": "TMEmbed",
+            "PartnerEmbed": "PartnerEmbed",
+            "RTB": "RTB",
+            "Vast": "vast",
+            "VastProxy": "vast_proxy",
+            "TrialPay": "trialpay",
+            "DealID": "DealID",
+            "SAS": "SAS"
+          }
+        },
+        "xdm:mediaType": {
+          "title": "Media Type",
+          "type": "string",
+          "description": "Media Type",
+          "enum": [
+            "DesktopVideo",
+            "MobileVideo",
+            "ConnectedtvVideo",
+            "PtvVideo",
+            "Display",
+            "Audio"
+          ],
+          "meta:enum": {
+            "DesktopVideo": "desktop_video",
+            "MobileVideo": "mobile_video",
+            "ConnectedtvVideo": "connectedtv_video",
+            "PtvVideo": "ptv_video",
+            "Display": "display",
+            "Audio": "audio"
+          }
+        },
+        "xdm:feedTargetImpressions": {
+          "title": "Feed Target Impressions",
+          "type": "integer",
+          "description": "The number of impressions targeted by this feed."
+        },
+        "xdm:feedStartDate": {
+          "title": "Feed Start Date",
+          "type": "string",
+          "format": "date",
+          "description": "Feed Start Date"
+        },
+        "xdm:feedEndDate": {
+          "title": "Feed End Date",
+          "type": "string",
+          "format": "date",
+          "description": "Feed End Date"
+        },
+        "xdm:feedStatus": {
+          "title": "Feed Status",
+          "type": "string",
+          "description": "Feed Status determines if active, inactive or deleted.",
+          "enum": [
+            "Active",
+            "Inactive",
+            "Deleted"
+          ],
+          "meta:enum": {
+            "Active": "Active",
+            "Inactive": "Inactive",
+            "Deleted": "Deleted"
+          }
+        },
+        "xdm:adServerId": {
+          "title": "Ad Server Identifier",
+          "type": "string",
+          "description": "The identifier of the Ad Server providing this feed."
+        },
+        "xdm:mediaPropertyId": {
+          "title": "Media Property Identifier",
+          "type": "string",
+          "description": "The identifier of the Media Property servicing this feed."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/data/record"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
+    },
+    {
+      "$ref": "#/definitions/dsp-feed"
+    }
+  ],
+  "meta:status": "experimental"
+}

--- a/extensions/adobe/experience/adcloud/dsp/mediaproperty.example.1.json
+++ b/extensions/adobe/experience/adcloud/dsp/mediaproperty.example.1.json
@@ -1,0 +1,12 @@
+{
+  "xdm:id": "123",
+  "xdm:mediaPropertyName": "Google AdEx",
+  "xdm:source": "google",
+  "xdm:publisher": "Google AdEx",
+  "xdm:videoCertified": true,
+  "xdm:displayCertified": true,
+  "xdm:audioCertified": false,
+  "xdm:vpaidAccepted": true,
+  "xdm:mobileAds": true,
+  "xdm:connectedTvOnly": false
+}

--- a/extensions/adobe/experience/adcloud/dsp/mediaproperty.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/mediaproperty.schema.json
@@ -1,0 +1,80 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/experience/adcloud/dsp/advertiser",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "DSP Advertising Media Property",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:auditable": true,
+  "meta:abstract": true,
+  "meta:extends": ["https://ns.adobe.com/xdm/data/record"],
+  "description": "Adobe Advertising Cloud DSP Media Property Details.",
+  "definitions": {
+    "dsp-mediaproperty": {
+      "properties": {
+        "xdm:mediaPropertyName": {
+          "title": "Media Property Name",
+          "type": "string",
+          "description": "Name of the Media Property."
+        },
+        "xdm:source": {
+          "title": "Source",
+          "type": "string",
+          "description": "Source of the Media Property."
+        },
+        "xdm:publisher": {
+          "title": "Publisher",
+          "type": "string",
+          "description": "Publisher of the Media Property."
+        },
+        "xdm:videoCertified": {
+          "title": "Video Certified",
+          "type": "boolean",
+          "description": "Indicates if this media property supports video ads."
+        },
+        "xdm:displayCertified": {
+          "title": "Display Certified",
+          "type": "boolean",
+          "description": "Indicates if this media property supports display ads."
+        },
+        "xdm:audioCertified": {
+          "title": "Audio Certified",
+          "type": "boolean",
+          "description": "Indicates if this media property supports audio ads."
+        },
+        "xdm:vpaidAccepted": {
+          "title": "VPaid Accepted",
+          "type": "boolean",
+          "description": "Indicates if this media property supports VPaid ads."
+        },
+        "xdm:mobileAds": {
+          "title": "Mobile Ads",
+          "type": "boolean",
+          "description": "Indicates if this media property supports mobile ads."
+        },
+        "xdm:connectedTvOnly": {
+          "title": "Connected TV Only",
+          "type": "boolean",
+          "description": "Indicates if this media property supports only connected tv ads."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/data/record"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
+    },
+    {
+      "$ref": "#/definitions/dsp-mediaproperty"
+    }
+  ],
+  "meta:status": "experimental"
+}


### PR DESCRIPTION
Please link to the issue #734 

This will introduce 3 new global classes : Feed, Ad Server and Media Property. These will model the support for feed-based advertising.
Inventory (bid requests, auctions, ad calls) are the means by with we buy media and are the key input to the DSP. Bid requests are fed to via media placements (feeds).  

Each feed belongs to a media property, which tries to represent a) the media owner (publisher) and b) the entity that will bill us for the media (service provider, which often maps to the SSP).
Additionally each feed has an ad server, which indicates the technology used to convey the feed.  Often this maps to the SSP.

A more extended documentation regarding the part of the DSP Advertising model we want to expose can be found in our [wiki page](https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=EfficientFrontier&title=%5BXDM+Mapping%5D+Feed-related+hierarchy).

@prabhum2 , @cfraser Can you please help us with the review? 
