### PR TITLE
[AdCloud DSP] Ad-related Metadata Schemas 

### DIFF
--- a/extensions/adobe/experience/adcloud/dsp/advertisement.example.1.json
+++ b/extensions/adobe/experience/adcloud/dsp/advertisement.example.1.json
@@ -1,0 +1,11 @@
+{
+  "@id": "14",
+  "dsp:adKey": "yyyy029YLCDvseo8QhTE",
+  "dsp:adStatus": "Active",
+  "dsp:adClass": "inbanner",
+  "dsp:adUnitType": "Flash",
+  "dsp:externalCreativeId": "5121209",
+  "dsp:promotedVideoId": "14",
+  "dsp:adServerId": "2",
+  "dsp:placementIds": ["1"]
+}

--- a/extensions/adobe/experience/adcloud/dsp/advertisement.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/advertisement.schema.json
@@ -1,0 +1,148 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/adcloud/dsp/advertisement",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "DSP Advertising Advertisement",
+  "type": "object",
+  "meta:extensible": false,
+  "meta:abstract": false,
+  "meta:auditable": true,
+  "meta:extends": ["https://ns.adobe.com/xdm/data/record"],
+  "description": "Adobe Advertising Cloud DSP Advertisement Details.",
+  "definitions": {
+    "dsp-advertisement": {
+      "properties": {
+        "dsp:adKey": {
+          "title": "Ad Key",
+          "type": "string",
+          "description": "Ad external unique identifier."
+        },
+        "dsp:externalCreativeId": {
+          "title": "External Creative Identifier",
+          "type": "string",
+          "description": "Identifier for the creative which this ad is associated with."
+        },
+        "dsp:adStatus": {
+          "title": "Ad Status",
+          "type": "string",
+          "description": "Ad Status indicates if it is eligible to be served.",
+          "enum": [
+            "Active",
+            "Inactive",
+            "Deleted"
+          ],
+          "meta:enum": {
+            "Active": "Active",
+            "Inactive": "Inactive",
+            "Deleted": "Deleted"
+          }
+        },
+        "dsp:adUnitType": {
+          "title": "Ad Unit Type",
+          "type": "string",
+          "description": "Identifier for the literal piece of code driving display of the ad in a browser/device.",
+          "enum": [
+            "Onsite",
+            "Flash",
+            "Embed",
+            "YouTube",
+            "New Flash",
+            "HTML5",
+            "instream",
+            "vast_proxy",
+            "external_instream",
+            "instream_selector",
+            "inbanner_3rd_party",
+            "external_inbanner",
+            "mraid_3rd_party",
+            "dooh",
+            "standard_display",
+            "fb_news_feed_post",
+            "fb_news_feed"
+          ],
+          "meta:enum": {
+            "Onsite": "Onsite",
+            "Flash": "Flash",
+            "Embed": "Embed",
+            "YouTube": "YouTube",
+            "New Flash": "New Flash",
+            "HTML5": "HTML5",
+            "instream": "instream",
+            "vast_proxy": "vast_proxy",
+            "external_instream": "external_instream",
+            "instream_selector": "instream_selector",
+            "inbanner_3rd_party": "inbanner_3rd_party",
+            "external_inbanner": "external_inbanner",
+            "mraid_3rd_party": "mraid_3rd_party",
+            "dooh": "dooh",
+            "standard_display": "standard_display",
+            "fb_news_feed_post": "fb_news_feed_post",
+            "fb_news_feed": "fb_news_feed"
+          }
+        },
+        "dsp:adClass": {
+          "title": "Ad Class",
+          "type": "string",
+          "description": "Ad class of driving event.",
+          "enum": [
+            "inbanner",
+            "CTP",
+            "ROTP",
+            "SMA",
+            "BAP",
+            "preroll",
+            "midroll",
+            "postroll",
+            "mobile_web"
+          ],
+          "meta:enum": {
+            "inbanner": "inbanner",
+            "CTP": "CTP",
+            "ROTP": "ROTP",
+            "SMA": "SMA",
+            "BAP": "BAP",
+            "preroll": "preroll",
+            "midroll": "midroll",
+            "postroll": "postroll",
+            "mobile_web": "mobile_web"
+          }
+        }
+      },
+      "dsp:promotedVideoId": {
+        "title": "Promoted Video Identifier",
+        "type": "string",
+        "description": "Promoted video Identifier contained in this Ad."
+      },
+      "dsp:adServerId": {
+        "title": "Ad Server Identifier",
+        "type": "string",
+        "description": "Identifier for the Ad Server providing this Ad."
+      },
+      "dsp:placementIds": {
+        "title": "Placement Ids",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "List of Placement Ids where this Ad is used."
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/data/record"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
+    },
+    {
+      "$ref": "#/definitions/dsp-advertisement"
+    }
+  ],
+  "meta:status": "experimental"
+}

--- a/extensions/adobe/experience/adcloud/dsp/promotedvideo.example.1.json
+++ b/extensions/adobe/experience/adcloud/dsp/promotedvideo.example.1.json
@@ -1,0 +1,9 @@
+{
+  "@id": "14",
+  "dsp:promotedVideoKey": "pJw0SLRbgeIXbjsKEJsU",
+  "dsp:campaignKey": "PIO446D9mff9OgS9YBY2",
+  "dsp:promotedVideoName": "Karate Kid Long Form",
+  "dsp:promoteVideoDuration": 30,
+  "dsp:promotedVideoTags": "karate kid, new karate kid, karate kid soundtrack, jackie chan, jaden smith, karate kid trailer, karate kid movie",
+  "dsp:promotedVideoDescription" : "Visit http://www.karatekidmovie.com.au/ THE KARATE KID, starring Jaden Smith and Jackie Chan, is a story about a bullied boy who learns self-defense and much more under the tutelage of an unlikely kung-fu master - On July only at the movies!"
+}

--- a/extensions/adobe/experience/adcloud/dsp/promotedvideo.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/promotedvideo.schema.json
@@ -1,0 +1,65 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/adcloud/dsp/promotedvideo",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "DSP Advertising Promoted Video",
+  "type": "object",
+  "meta:extensible": false,
+  "meta:abstract": false,
+  "meta:auditable": true,
+  "meta:extends": ["https://ns.adobe.com/xdm/data/record"],
+  "description": "Adobe Advertising Cloud DSP Promoted Video Details.",
+  "definitions": {
+    "dsp-promotedvideo": {
+      "properties": {
+        "dsp:promotedVideoKey": {
+          "title": "promotedVideoKey",
+          "type": "string",
+          "description": "External unique identifier for a promoted video the ad is displaying."
+        },
+        "dsp:campaignKey": {
+          "title": "campaignKey",
+          "type": "string",
+          "description": "Identifier for the campaign that belongs to the displayed video."
+        },
+        "dsp:promotedVideoName": {
+          "title": "promotedVideoName",
+          "type": "string",
+          "description": "A name that uniquely identifies the promoted video within the campaign."
+        },
+        "dsp:promoteVideoDuration": {
+          "title": "promoteVideoDuration",
+          "type": "integer",
+          "description": "The duration of the video."
+        },
+        "dsp:promotedVideoTags": {
+          "title": "Promoted Video Tags",
+          "type": "string",
+          "description": "Labels describing ad categories for this video."
+        },
+        "dsp:promotedVideoDescription": {
+          "title": "Promoted Video Description",
+          "type": "string",
+          "description": "Detailed description for this video."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/data/record"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
+    },
+    {
+      "$ref": "#/definitions/dsp-promotedvideo"
+    }
+  ],
+  "meta:status": "experimental"
+}


### PR DESCRIPTION
Please link to the issue #735 

**Note**: As previously agreed, AdCloud DSP uses its own namespace ( **dsp** ) .

This will introduce 2 new AdCloud DSP-specific  classes : Advertisement and Promoted Video. These will model the support for ads in DSP. 

Ads are attached to Campaign Placements. But the same Ad can be attached to any number of placements, and those placements don't have to all belong to the same campaign. The same hierarchy relationship is valid related to Ads and Feeds. Each Ad contains a Promoted Video referenced by its identifier.

A more extended documentation regarding the part of the DSP Advertising model we want to expose can be found in our [wiki](https://wiki.corp.adobe.com/display/EfficientFrontier/%5BXDM+Mapping%5D+Ad-related+hierarchy) page.
