### PR TITLE
[AdCloud DSP] Site Metadata Schema

### DIFF
--- a/extensions/adobe/experience/adcloud/dsp/site.example.1.json
+++ b/extensions/adobe/experience/adcloud/dsp/site.example.1.json
@@ -1,0 +1,12 @@
+{
+  "@id": "9",
+  "dsp:siteKey": "YFk8RnlYHwnG4KbFSQor",
+  "dsp:siteName": "Young Hollywood",
+  "dsp:siteUrl": "http://younghollywood",
+  "dsp:siteType": "Site",
+  "dsp:siteStatus": "Active",
+  "dsp:siteDataSource": "trialpay",
+  "dsp:mobileWeb": true,
+  "dsp:mobileApp": false,
+  "dsp:isTargetable": false
+}

--- a/extensions/adobe/experience/adcloud/dsp/site.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/site.schema.json
@@ -1,0 +1,109 @@
+{
+  "meta:license": [
+    "Copyright 2019 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "ttps://ns.adobe.com/xdm/adcloud/dsp/site",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "DSP Advertising Placement Site",
+  "type": "object",
+  "meta:extensible": false,
+  "meta:abstract": false,
+  "meta:auditable": true,
+  "meta:extends": ["https://ns.adobe.com/xdm/data/record"],
+  "description": "Adobe Advertising Cloud DSP Placement Site Details.",
+  "definitions": {
+    "dsp-site": {
+      "properties": {
+        "dsp:siteKey": {
+          "title": "Site Key",
+          "type": "string",
+          "description": "Placement site external unique identifier."
+        },
+        "dsp:siteName": {
+          "title": "Site Name",
+          "type": "string",
+          "description": "Placement site name."
+        },
+        "dsp:siteUrl": {
+          "title": "Site Url",
+          "type": "string",
+          "format": "uri",
+          "description": "Placement site url."
+        },
+        "dsp:siteType": {
+          "title": "Site Type",
+          "type": "string",
+          "description": "The type of the placement site.",
+          "enum": [
+            "Site",
+            "Network"
+          ],
+          "meta:enum": {
+            "Site": "Site",
+            "Network": "Network"
+          }
+        },
+        "dsp:siteStatus": {
+          "title": "Site Status",
+          "type": "string",
+          "description": "The status of the placement site.",
+          "enum": [
+            "Active",
+            "Inactive",
+            "Deleted"
+          ],
+          "meta:enum": {
+            "Active": "Active",
+            "Inactive": "Inactive",
+            "Deleted": "Deleted"
+          }
+        },
+        "dsp:siteDataSource": {
+          "title": "Site Data Source",
+          "type": "string",
+          "description": "The data source for this placement site.",
+          "enum": [
+            "Trialpay",
+            "Nielsen",
+            "Quancast"
+          ],
+          "meta:enum": {
+            "Trialpay": "trialpay",
+            "Nielsen": "nielsen",
+            "Quancast": "quancast"
+          }
+        },
+        "dsp:mobileWeb": {
+          "title": "Mobile Web",
+          "type": "boolean",
+          "description": "Flag stating whether this placement site is a mobile website."
+        },
+        "dsp:mobileApp": {
+          "title": "Mobile Application",
+          "type": "boolean",
+          "description": "Flag stating whether this placement site is a mobile application."
+        },
+        "dsp:isTargetable": {
+          "title": "Is Targetable",
+          "type": "boolean",
+          "description": "Flag stating whether this placement site can be targeted."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/data/record"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
+    },
+    {
+      "$ref": "#/definitions/dsp-site"
+    }
+  ],
+  "meta:status": "experimental"
+}


### PR DESCRIPTION
Please link to the issue #757 

**Note**: As previously agreed, AdCloud DSP uses its own namespace ( **dsp** ) .

This will introduce 1 new AdCloud DSP-specific class : Site. This will model the support for a Placement Site in DSP. 
