### PR TITLE
Add more mergeAllOf resolvers

### DIFF
--- a/bin/xed-validation/xedConverter.js
+++ b/bin/xed-validation/xedConverter.js
@@ -309,6 +309,22 @@ class Converter extends EventEmitter {
               if (statusList.length >1 )
                 console.log("!!!This schema contains multiple meta:status after resolving allOf!!!")
               return Array.from(new Set(statusList));
+            },
+            "meta:extensible" : function(values) {
+                var extensibleList = [];
+                for (var i in values)
+                    extensibleList = extensibleList.concat(values[i]);
+                if (extensibleList.length >1 )
+                    console.log("!!!This schema contains multiple meta:extensible after resolving allOf!!!")
+                return Array.from(new Set(extensibleList));
+            },
+            "meta:abstract" : function(values) {
+                var abstractList = [];
+                for (var i in values)
+                    abstractList = abstractList.concat(values[i]);
+                if (abstractList.length >1 )
+                    console.log("!!!This schema contains multiple meta:abstract after resolving allOf!!!")
+                return Array.from(new Set(abstractList));
             }
         }
     });


### PR DESCRIPTION
This PR links to the issue #766. It add more mergeAllOf resolvers for meta:extensible and meta:abstract etc. This will avoid merging conflict errors during xed validation.
