### PR TITLE
[AdCloud DSP] Fix package, advertisement and site schemas

### DIFF
--- a/extensions/adobe/experience/adcloud/dsp/advertisement.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/advertisement.schema.json
@@ -17,6 +17,11 @@
   "definitions": {
     "dsp-advertisement": {
       "properties": {
+        "dsp:adName": {
+          "title": "Ad Name",
+          "type": "string",
+          "description": "Ad name."
+        },
         "dsp:adKey": {
           "title": "Ad Key",
           "type": "string",
@@ -111,25 +116,25 @@
             "postroll": "postroll",
             "mobile_web": "mobile_web"
           }
-        }
-      },
-      "dsp:promotedVideoId": {
-        "title": "Promoted Video Identifier",
-        "type": "string",
-        "description": "Promoted video Identifier contained in this Ad."
-      },
-      "dsp:adServerId": {
-        "title": "Ad Server Identifier",
-        "type": "string",
-        "description": "Identifier for the Ad Server providing this Ad."
-      },
-      "dsp:placementIds": {
-        "title": "Placement Ids",
-        "type": "array",
-        "items": {
-          "type": "string"
         },
-        "description": "List of Placement Ids where this Ad is used."
+        "dsp:promotedVideoId": {
+          "title": "Promoted Video Identifier",
+          "type": "string",
+          "description": "Promoted video Identifier contained in this Ad."
+        },
+        "dsp:adServerId": {
+          "title": "Ad Server Identifier",
+          "type": "string",
+          "description": "Identifier for the Ad Server providing this Ad."
+        },
+        "dsp:placementIds": {
+          "title": "Placement Ids",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of Placement Ids where this Ad is used."
+        }
       }
     }
   },

--- a/extensions/adobe/experience/adcloud/dsp/advertiser.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/advertiser.schema.json
@@ -45,7 +45,6 @@
         "dsp:advertiserUrl": {
           "title": "Advertiser Url",
           "type": "string",
-          "format": "uri",
           "description": "Advertiser Url."
         },
         "dsp:accountId": {

--- a/extensions/adobe/experience/adcloud/dsp/package.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/package.schema.json
@@ -143,6 +143,12 @@
   },
   "allOf": [
     {
+      "$ref": "https://ns.adobe.com/xdm/data/record"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/auditable"
+    },
+    {
       "$ref": "#/definitions/dsp-package"
     }
   ],

--- a/extensions/adobe/experience/adcloud/dsp/site.schema.json
+++ b/extensions/adobe/experience/adcloud/dsp/site.schema.json
@@ -30,7 +30,6 @@
         "dsp:siteUrl": {
           "title": "Site Url",
           "type": "string",
-          "format": "uri",
           "description": "Placement site url."
         },
         "dsp:siteType": {


### PR DESCRIPTION
This is an addendum to the new DSP name spaced schemas with dsp specific fields :

- Update 'package' to inherit 'id' field from record 
- Fix 'advertisement' to include all of the fields under its own properties section
- Remove uri validation because the data source is not reliable in providing the expected format
