### PR TITLE
Add new Environment.type 'widget'.

### DIFF
--- a/docs/reference/context/environment.schema.json
+++ b/docs/reference/context/environment.schema.json
@@ -22,13 +22,15 @@
                         "browser",
                         "application",
                         "iot",
-                        "external"
+                        "external",
+                        "widget"
                     ],
                     "meta:enum": {
                         "browser": "Browser",
                         "application": "Application",
                         "iot": "Internet of things",
-                        "external": "External system"
+                        "external": "External system",
+                        "widget": "Application extension"
                     }
                 },
                 "xdm:browserDetails": {

--- a/docs/reference/context/environment.schema.md
+++ b/docs/reference/context/environment.schema.md
@@ -319,6 +319,7 @@ The value of this property **must** be equal to one of the [known values below](
 | `application` | Application |
 | `iot` | Internet of things |
 | `external` | External system |
+| `widget` | Application extension |
 
 
 

--- a/schemas/context/environment.schema.json
+++ b/schemas/context/environment.schema.json
@@ -19,12 +19,13 @@
           "title": "Type",
           "type": "string",
           "description": "The type of the application environment.",
-          "enum": ["browser", "application", "iot", "external"],
+          "enum": ["browser", "application", "iot", "external", "widget"],
           "meta:enum": {
             "browser": "Browser",
             "application": "Application",
             "iot": "Internet of things",
-            "external": "External system"
+            "external": "External system",
+            "widget": "Application extension"
           }
         },
         "xdm:browserDetails": {


### PR DESCRIPTION
Adding new Environment.type 'widget'. A 'widget' may be used instead of 'application' when the environment is an iOS extension or Android widget. 

Change requested by Adobe Mobile SDK team to differentiate between apps and a 'widget'.

