### PR TITLE
Remove couple of dup fields which are deprecated

### DIFF
--- a/schemas/context/poi-detail.schema.json
+++ b/schemas/context/poi-detail.schema.json
@@ -14,12 +14,6 @@
   "definitions": {
     "geo-interaction-detail": {
       "properties": {
-        "xdm:POIID": {
-          "title": "POI identity",
-          "type": "string",
-          "meta:status": "deprecated",
-          "description": "The unique identifier of the POI."
-        },
         "xdm:poiID": {
           "title": "POI Identity",
           "type": "string",

--- a/schemas/context/poi-interaction.schema.json
+++ b/schemas/context/poi-interaction.schema.json
@@ -14,12 +14,6 @@
   "definitions": {
     "poi-interaction": {
       "properties": {
-        "xdm:POIDetail": {
-          "title": "POI detail",
-          "meta:status": "deprecated",
-          "description": "Detail of the POI that cause the event.",
-          "$ref": "https://ns.adobe.com/xdm/context/poi-detail"
-        },
          "xdm:poiDetail": {
           "title": "POI detail",
           "description": "Detail of the POI that cause the event.",


### PR DESCRIPTION
This PR removes couple of duplicated fields which are deprecated anyway. These dup fields can not pass platform protobuf lib creation.
