### PR TITLE
Added IAB in privacy mixin's name and fixed examples

### DIFF
--- a/schemas/context/consentstring.example.1.json
+++ b/schemas/context/consentstring.example.1.json
@@ -3,5 +3,5 @@
     "xdm:consentStandardVersion": "2.0",
     "xdm:consentStringValue": "BObdrPUOevsguAfDqFENCNAAAAAmeAAA.PVAfDObdrA.DqFENCAmeAENCDA",
     "xdm:gdprApplies": true,
-    "xdm:gdprContainsPersonalData": false
+    "xdm:containsPersonalData": false
 }

--- a/schemas/context/experienceevent-privacy.example.1.json
+++ b/schemas/context/experienceevent-privacy.example.1.json
@@ -5,7 +5,7 @@
             "xdm:consentStandardVersion": "2.0",
             "xdm:consentStringValue": "BObdrPUOevsguAfDqFENCNAAAAAmeAAA.PVAfDObdrA.DqFENCAmeAENCDA",
             "xdm:gdprApplies": true,
-            "xdm:gdprContainsPersonalData": false
+            "xdm:containsPersonalData": false
         }
     ]
 }

--- a/schemas/context/profile-privacy.example.1.json
+++ b/schemas/context/profile-privacy.example.1.json
@@ -11,14 +11,14 @@
 	"xdm:identityPrivacyInfo": {
 		"ECID": {
 			"11112222233333444": {
-				"xdm:identityConsent": {
+				"xdm:identityIABConsent": {
 					"xdm:consentTimestamp": "2020-04-11T05:05:05Z",
 					"xdm:consentString": {
 						"xdm:consentStandard": "IAB TCF",
 						"xdm:consentStandardVersion": "2.0",
 						"xdm:consentStringValue": "BObdrPUOevsguAfDqFENCNAAAAAmeAAA.PVAfDObdrA.DqFENCAmeAENCDA",
 						"xdm:gdprApplies": true,
-						"xdm:gdprContainsPersonalData": false
+						"xdm:containsPersonalData": false
 					}
 				}
 			}

--- a/schemas/context/profile-privacy.schema.json
+++ b/schemas/context/profile-privacy.schema.json
@@ -84,7 +84,7 @@
                      "type": "object",
                      "title": "User Identity",
                      "properties": {
-                        "xdm:identityConsent": {
+                        "xdm:identityIABConsent": {
                            "type": "object",
                            "title": "Identity level consent information",
                            "description": "Consent collected for an identity via consent management services.",


### PR DESCRIPTION
In order to make profile privacy mixin extensible to add multiple standards, rename value in internal map as identityIABConsent. This will allow to add other standards in future.
Also fixed consentString exmaples.
