### PR TITLE
 Removed unwanted Mixin references from the meta:intendedToExtend

### DIFF
--- a/schemas/common/external-source-system-audit-details.schema.json
+++ b/schemas/common/external-source-system-audit-details.schema.json
@@ -13,8 +13,6 @@
   "meta:intendedToExtend": [
     "https://ns.adobe.com/xdm/context/opportunity",
     "https://ns.adobe.com/xdm/context/account",
-    "https://ns.adobe.com/xdm/context/profile-lead-crm",
-    "https://ns.adobe.com/xdm/context/profile-contact-crm",
     "https://ns.adobe.com/xdm/context/opportunity-contactrole",
     "https://ns.adobe.com/xdm/context/activitylog",
     "https://ns.adobe.com/xdm/context/profile"


### PR DESCRIPTION
Removed unnecessary references to the below mixins from the "meta:intendedToExtend" array as both thee mixins are extending the "profile" class and the profile "class is already referenced.
"https://ns.adobe.com/xdm/context/profile-lead-crm"
"https://ns.adobe.com/xdm/context/profile-contact-crm"