### PR TITLE
Add xdm:note to the alternateDisplayInfo descriptor

### DIFF
--- a/schemas/common/descriptors/display/alternateDisplayInfo.schema.json
+++ b/schemas/common/descriptors/display/alternateDisplayInfo.schema.json
@@ -43,6 +43,16 @@
             }
           }
         },
+        "xdm:note": {
+          "title": "Note",
+          "type": "object",
+          "description": "When present, user friendly note to display. Similar to a description, but provides more details about the actual usage of the field.",
+          "patternProperties": {
+            ".+_.+": {
+              "type": "string"
+            }
+          }
+        },
         "meta:enum": {
           "title": "Extended meta:enum values",
           "type": "object",


### PR DESCRIPTION
AEP is wanting to introduce a way for users to add additional user specific "notes" to a given field (how it should be used, etc.). They see this as something different from the description and would like it to be separate. Adding this attribute to the descriptor will enable a user to add a note to one of the standard fields.


