### PR TITLE
Revert "Experience Event and Profile mixins missing '' in defining consent preferences"

### DIFF
--- a/schemas/context/experienceevent-privacy.schema.json
+++ b/schemas/context/experienceevent-privacy.schema.json
@@ -20,7 +20,7 @@
       "properties": {
         "xdm:consentsAndPreferences":{
           "title": "Consents, Personalization and Marketing Preferences",
-          "$ref": "https://ns.adobe.com/xdm/context/consent-preferences"
+          "ref": "https://ns.adobe.com/xdm/context/consentpreferences"
         },
         "xdm:consentStrings": {
           "title": "Identity level consent information",

--- a/schemas/context/profile-privacy.schema.json
+++ b/schemas/context/profile-privacy.schema.json
@@ -22,7 +22,7 @@
           "type":"object",
           "title":"Global Privacy/Marketing Preference Values",
           "description":"Global (User/Profile-level) Privacy/Personalization/Marketing Preferences.",
-          "$ref": "https://ns.adobe.com/xdm/context/consent-preferences"
+          "ref": "https://ns.adobe.com/xdm/context/consentpreferences"
         },
         "xdm:identityPrivacyInfo":{
           "title": "Identity level privacy information",
@@ -39,7 +39,7 @@
               "properties": {
                 "xdm:consentsAndPreferences":{
                   "title": "Device/Identity-specific Consents, Personalization and Marketing Preferences",
-                  "$ref": "https://ns.adobe.com/xdm/context/consent-preferences"
+                  "ref": "https://ns.adobe.com/xdm/context/consentpreferences"
                 },
                 "xdm:identityIABConsent": {
                   "type": "object",


### PR DESCRIPTION
Reverts adobe/xdm#945