### PR TITLE
Adding search annotations for metadata for Windrose

### DIFF
--- a/components/datatypes/product.schema.json
+++ b/components/datatypes/product.schema.json
@@ -22,7 +22,13 @@
         "xdm:SKU": {
           "title": "SKU",
           "type": "string",
-          "description": "The unique SKU (stock keeping unit) of the product assigned by the vendor."
+          "description": "The unique SKU (stock keeping unit) of the product assigned by the vendor.",
+          "meta:descriptors": [
+            {
+              "@type": "xdm:searchdescriptor",
+              "search:indexed": true
+            }
+          ]
         },
         "xdm:name": {
           "title": "Name",
@@ -32,7 +38,19 @@
         "schema:description": {
           "title": "Description",
           "type": "string",
-          "description": "The localized description of the product."
+          "description": "The localized description of the product.",
+          "meta:status": "deprecated"
+        },
+        "xdm:productDescription": {
+          "title": "Description",
+          "type": "string",
+          "description": "The localized description of the product.",
+          "meta:descriptors": [
+            {
+              "@type": "xdm:searchdescriptor",
+              "search:indexed": true
+            }
+          ]
         },
         "xdm:category": {
           "title": "Category",
@@ -47,7 +65,13 @@
         "xdm:brand": {
           "title": "Brand",
           "type": "string",
-          "description": "The brand of the product."
+          "description": "The brand of the product.",
+          "meta:descriptors": [
+            {
+              "@type": "xdm:searchdescriptor",
+              "search:indexed": true
+            }
+          ]
         },
         "xdm:masterProductID": {
           "title": "Master product identifier",
@@ -73,7 +97,19 @@
         "xdm:fabrication": {
           "title": "Fabrication",
           "type": "string",
-          "description": "Primary material of the product construction."
+          "description": "Primary material of the product construction.",
+          "meta:status": "deprecated"
+        },
+        "xdm:material": {
+          "title": "Material",
+          "type": "string",
+          "description": "Primary material of the product construction.",
+          "meta:descriptors": [
+            {
+              "@type": "xdm:searchdescriptor",
+              "search:indexed": true
+            }
+          ]
         },
         "xdm:gender": {
           "title": "Gender",


### PR DESCRIPTION
Project Windrose plans to use these metadata and an important aspect is being able to search based on them.
This commit is marking some metadata for search indexing.
It also deprecates xdm:fabrication in favor of xdm:material and schema:description in favor of xdm:productDescription.
