### PR TITLE
Field with no "type" bug

### DIFF
--- a/components/datatypes/optinout.schema.json
+++ b/components/datatypes/optinout.schema.json
@@ -293,6 +293,7 @@
           "default": false
         },
         "xdm:optOutDetails": {
+          "type": "object",
           "properties": {
             "xdm:email": {
               "title": "Additional Details for Email Opt Out",


### PR DESCRIPTION
All schemas require a field to have a declared "type". 
