### PR TITLE
Deprecate unused mixin

### DIFF
--- a/components/mixins/profile/profile-push-details.schema.json
+++ b/components/mixins/profile/profile-push-details.schema.json
@@ -35,5 +35,5 @@
       "$ref": "#/definitions/profile-push-details"
     }
   ],
-  "meta:status": "stable"
+  "meta:status": "deprecated"
 }


### PR DESCRIPTION
The Push Notification Token Details is no longer used and causing confusing between the new Push Notification Details which is used.

Please link to the issue #…
