### PR TITLE
Add REVOKED segment status to signal a segment that was shared is revoked

### DIFF
--- a/components/classes/segmentdefinition.schema.json
+++ b/components/classes/segmentdefinition.schema.json
@@ -43,8 +43,8 @@
         "xdm:segmentStatus": {
           "type": "string",
           "title": "Segment status",
-          "description": "Current status of segment from external system normalized to active, inactive, deleted or draft.",
-          "enum": ["ACTIVE", "INACTIVE", "DELETED", "DRAFT"]
+          "description": "Current status of segment from external system normalized to active, inactive, deleted, draft or revoked.",
+          "enum": ["ACTIVE", "INACTIVE", "DELETED", "DRAFT", "REVOKED"]
         }
       }
     }


### PR DESCRIPTION
Adding REVOKED segment status to explicitly revoke a segment from the sharee so that Ansible/Segment Builder can act differently for such segments.

Please link to the issue 

Issue Tracked => #1147
