### PR TITLE
WebPageDetails URL Pattern

### DIFF
--- a/components/datatypes/web/webpagedetails.schema.json
+++ b/components/datatypes/web/webpagedetails.schema.json
@@ -32,7 +32,7 @@
         "xdm:URL": {
           "title": "URL",
           "type": "string",
-          "pattern": "^(\\w+:\\/\\/)([^\\s]+\\.\\w+)([^\\s]*)$",
+          "pattern": "^(\\w+:\\/\\/)([^\\s]+)$",
           "description": "The normative or usual URL of the web page.  This may or may not be the actual URL used to reach the page, which would be recorded using `Web Link`."
         },
         "xdm:server": {

--- a/components/datatypes/web/webpagedetails.schema.json
+++ b/components/datatypes/web/webpagedetails.schema.json
@@ -32,7 +32,7 @@
         "xdm:URL": {
           "title": "URL",
           "type": "string",
-          "format": "uri",
+          "pattern": "^(\\w+:\\/\\/)([^:\\/\\s]+.+\\.\\w+)([^\\s]*)$",
           "description": "The normative or usual URL of the web page.  This may or may not be the actual URL used to reach the page, which would be recorded using `Web Link`."
         },
         "xdm:server": {

--- a/components/datatypes/web/webpagedetails.schema.json
+++ b/components/datatypes/web/webpagedetails.schema.json
@@ -32,7 +32,7 @@
         "xdm:URL": {
           "title": "URL",
           "type": "string",
-          "pattern": "^(\\w+:\\/\\/)([^\\s]+)$",
+          "pattern": "^(\\w+:\\/\\/)(localhost[^\\s]*|[^\\s]+\\.[^\\s]+)$",
           "description": "The normative or usual URL of the web page.  This may or may not be the actual URL used to reach the page, which would be recorded using `Web Link`."
         },
         "xdm:server": {

--- a/components/datatypes/web/webpagedetails.schema.json
+++ b/components/datatypes/web/webpagedetails.schema.json
@@ -32,7 +32,7 @@
         "xdm:URL": {
           "title": "URL",
           "type": "string",
-          "pattern": "^(\\w+:\\/\\/)([^:\\/\\s]+.+\\.\\w+)([^\\s]*)$",
+          "pattern": "^(\\w+:\\/\\/)([^\\s]+\\.\\w+)([^\\s]*)$",
           "description": "The normative or usual URL of the web page.  This may or may not be the actual URL used to reach the page, which would be recorded using `Web Link`."
         },
         "xdm:server": {


### PR DESCRIPTION
Updating the URL field to be our own custom pattern rather then the standard URI format. The URI format is too restrictive for what browsers can provide.