### PR TITLE
Updates to webpagedetails.url pattern

### DIFF
--- a/components/datatypes/web/webpagedetails.schema.json
+++ b/components/datatypes/web/webpagedetails.schema.json
@@ -32,7 +32,7 @@
         "xdm:URL": {
           "title": "URL",
           "type": "string",
-          "pattern": "^(\\w+:\\/\\/)(localhost[^\\s]*|[^\\s]+\\.[^\\s]+)$",
+          "pattern": "^(\\w+:\\/\\/)(localhost[^\\s\\/]*|[^\\s\\/]+\\.[^\\s\\/]+)([^\\s]*)$",
           "description": "The normative or usual URL of the web page.  This may or may not be the actual URL used to reach the page, which would be recorded using `Web Link`."
         },
         "xdm:server": {


### PR DESCRIPTION
Do not allow something like https://test/file.html

The only time a full domain name (.{something}) is not needed in the domain is if it's the "localhost" domain

Please link to the issue #…
