### PR TITLE
New adcloud:advertisingStitchID field

### DIFF
--- a/extensions/adobe/experience/adcloud/stitch.example.1.json
+++ b/extensions/adobe/experience/adcloud/stitch.example.1.json
@@ -1,0 +1,3 @@
+{
+  "adcloud:advertisingStitchID": "13"
+}

--- a/extensions/adobe/experience/adcloud/stitch.schema.json
+++ b/extensions/adobe/experience/adcloud/stitch.schema.json
@@ -1,0 +1,31 @@
+{
+  "meta:license": [
+    "Copyright 2018 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "https://ns.adobe.com/experience/adcloud/stitchid",
+  "title": "AdCloud to Analytics StitchID Mixin",
+  "type": "object",
+  "description": "Defines the advertising stitch ID used for the AdCloud to Adobe Analytics integration",
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
+  "definitions": {
+    "stitch": {
+      "properties": {
+        "adcloud:advertisingStitchID": {
+          "title": "Advertising Stitch ID",
+          "type": "string",
+          "description": "Stitch ID passed to Adobe Analytics"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/stitch"
+    }
+  ],
+  "meta:status": "stable"
+}


### PR DESCRIPTION
Used for the Adcloud -> Adobe Analytics integration

Alternative to PR https://github.com/adobe/xdm/pull/1203