### PR TITLE
Fixing Segment Definition Class. Removed deprecated flag from segment…

### DIFF
--- a/components/classes/segmentdefinition.example.1.json
+++ b/components/classes/segmentdefinition.example.1.json
@@ -7,6 +7,9 @@
       }
     ]
   },
+  "xdm:segmentIdentity": {
+    "@id": "seg-id"
+  },
   "xdm:segmentName": "Users with TV segment",
   "xdm:description": "Segment is about users who have TV",
   "xdm:segmentStatus": "ACTIVE",

--- a/components/classes/segmentdefinition.schema.json
+++ b/components/classes/segmentdefinition.schema.json
@@ -22,8 +22,7 @@
         "xdm:segmentIdentity": {
           "title": "Segment identity",
           "$ref": "https://ns.adobe.com/xdm/context/segmentidentity",
-          "description": "Identity of the segment.",
-          "meta:status": "deprecated"
+          "description": "Identity of the segment."
         },
         "xdm:segmentName": {
           "title": "Segment name",
@@ -49,7 +48,7 @@
       }
     }
   },
-  "required": ["xdm:identityMap", "xdm:segmentName"],
+  "required": ["xdm:segmentName"],
   "allOf": [
     {
       "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"


### PR DESCRIPTION
…Identity.id. Removed identityMap from required list.

This is a long pending fix required in the segment definition class. segmentIdentity (since its a single namespace) is a preferred way of passing identity for a segment definition. Hence removed deprecated flag from it. Since it is now available, identityMap is no longer an mandatory attribute.

