### PR TITLE
Updated subscription info

### DIFF
--- a/components/datatypes/industry-verticals/telecom-subscription.schema.json
+++ b/components/datatypes/industry-verticals/telecom-subscription.schema.json
@@ -100,7 +100,13 @@
           "title": "Billing start date",
           "type": "string",
           "format": "date",
-          "description": "The date when the first bill is due."
+          "description": "The date when the billing period begins."
+        },
+        "xdm:paymentDueDate": {
+          "title": "Payment Due Date",
+          "type": "string",
+          "format": "date",
+          "description": "The date when the subscription payment is due."
         },
         "xdm:chargeMethod": {
           "title": "Charge method",

--- a/components/mixins/profile/profile-telecom-subscription.schema.json
+++ b/components/mixins/profile/profile-telecom-subscription.schema.json
@@ -22,15 +22,15 @@
         "xdm:telecomSubscription": {
           "type": "object",
           "properties": {
-            "xdm:subscriptionDetails": {
-              "title": "Subscription Details",
-              "$ref": "https://ns.adobe.com/xdm/datatypes/telecom-subscription",
-              "description": "Extension of the subscription data type to include subscription length, fees, status, etc."
+            "xdm:primarySubscriber": {
+              "title": "Primary Subscriber",
+              "$ref": "https://ns.adobe.com/xdm/context/person",
+              "description": "The owner of the subscription."
             },
-            "xdm:responsiblePartyID": {
-              "title": "Responsible Party ID",
+            "xdm:primaryPartyID": {
+              "title": "Primary Party ID",
               "type": "string",
-              "description": "Identifier for the person responsible for the subscription, which typically could be their device phone number."
+              "description": "Identifier for the primary person responsible for the subscription, which typically could be their device phone number."
             },
             "xdm:bundleName": {
               "title": "Bundle Name",


### PR DESCRIPTION
- Moved subscriber type to root level of telecomSubscription field grouping
- Renamed "responsiblePartyID" to "primaryPartyID"
- Updated description for billingStartDate in datatype
- Added paymentDueDate field to datatype.