### PR TITLE
Change Edge Autofilled Environment Details status to stable

### DIFF
--- a/components/datatypes/demographic/geo.schema.json
+++ b/components/datatypes/demographic/geo.schema.json
@@ -15,7 +15,7 @@
   "definitions": {
     "countrycode": {
       "properties": {
-         "xdm:countryCode": {
+        "xdm:countryCode": {
           "title": "Country code",
           "type": "string",
           "pattern": "^[A-Z]{2}$",

--- a/components/datatypes/demographic/geo.schema.json
+++ b/components/datatypes/demographic/geo.schema.json
@@ -13,36 +13,56 @@
   "title": "Geo",
   "description": "The geographic related data where an event was observed.",
   "definitions": {
-    "geo": {
+    "countrycode": {
       "properties": {
-        "xdm:countryCode": {
+         "xdm:countryCode": {
           "title": "Country code",
           "type": "string",
           "pattern": "^[A-Z]{2}$",
           "description": "The two-character [ISO 3166-1 alpha-2](https://datahub.io/core/country-list) code for the country."
-        },
+        }
+      }
+    },
+    "stateprovince": {
+      "properties": {
         "xdm:stateProvince": {
           "title": "State or province",
           "type": "string",
           "description": "The state, or province portion of the observation. The format follows the [ISO 3166-2 (country and subdivision)][http://www.unece.org/cefact/locode/subdivisions.html] standard.",
           "examples": ["US-CA", "DE-BB", "JP-13"],
           "pattern": "([A-Z]{2}-[A-Z0-9]{1,3}|)"
-        },
+        }
+      }
+    },
+    "city": {
+      "properties": {
         "xdm:city": {
           "title": "City",
           "type": "string",
           "description": "The name of the city."
-        },
+        }
+      }
+    },
+    "postalcode": {
+      "properties": {
         "xdm:postalCode": {
           "title": "Postal code",
           "type": "string",
           "description": "The postal code of the location. Postal codes are not available for all countries. In some countries, this will only contain part of the postal code."
-        },
+        }
+      }
+    },
+    "dmaid": {
+      "properties": {
         "xdm:dmaID": {
           "title": "Designated market area",
           "type": "integer",
           "description": "The Nielsen media research designated market area."
-        },
+        }
+      }
+    },
+    "msaid": {
+      "properties": {
         "xdm:msaID": {
           "title": "Metropolitan statistical area",
           "type": "integer",
@@ -56,7 +76,22 @@
       "$ref": "http://schema.org/GeoCoordinates"
     },
     {
-      "$ref": "#/definitions/geo"
+      "$ref": "#/definitions/countrycode"
+    },
+    {
+      "$ref": "#/definitions/stateprovince"
+    },
+    {
+      "$ref": "#/definitions/city"
+    },
+    {
+      "$ref": "#/definitions/postalcode"
+    },
+    {
+      "$ref": "#/definitions/dmaid"
+    },
+    {
+      "$ref": "#/definitions/msaid"
     }
   ],
   "meta:status": "stable",

--- a/components/datatypes/external/schema/geocoordinates.schema.json
+++ b/components/datatypes/external/schema/geocoordinates.schema.json
@@ -12,33 +12,49 @@
   "meta:extensible": true,
   "description": "The geographic coordinates of a place. Based on [schema.org](http://schema.org/GeoCoordinates).",
   "definitions": {
-    "geocoordinates": {
+    "coordinatesid": {
       "properties": {
         "@id": {
           "title": "Coordinates ID",
           "type": "string",
           "format": "uri-reference",
           "description": "The unique identifier of the coordinates."
-        },
+        }
+      }
+    },
+    "description": {
+      "properties": {
         "schema:description": {
           "title": "Description",
           "type": "string",
           "description": "A description of what the coordinates identify."
-        },
+        }
+      }
+    },
+    "latitude": {
+      "properties": {
         "schema:latitude": {
           "title": "Latitude",
           "type": "number",
           "minimum": -90,
           "maximum": 90,
           "description": "The signed vertical coordinate of a geographic point."
-        },
+        }
+      }
+    },
+    "longitude": {
+      "properties": {
         "schema:longitude": {
           "title": "Longitude",
           "type": "number",
           "minimum": -180,
           "maximum": 180,
           "description": "The signed horizontal coordinate of a geographic point."
-        },
+        }
+      }
+    },
+    "elevation": {
+      "properties": {
         "schema:elevation": {
           "title": "Elevation",
           "type": "number",
@@ -49,7 +65,19 @@
   },
   "allOf": [
     {
-      "$ref": "#/definitions/geocoordinates"
+      "$ref": "#/definitions/coordinatesid"
+    },
+    {
+      "$ref": "#/definitions/description"
+    },
+    {
+      "$ref": "#/definitions/latitude"
+    },
+    {
+      "$ref": "#/definitions/longitude"
+    },
+    {
+      "$ref": "#/definitions/elevation"
     }
   ],
   "meta:status": "stable",

--- a/extensions/adobe/experience/edge-autofilled-environment-details.schema.json
+++ b/extensions/adobe/experience/edge-autofilled-environment-details.schema.json
@@ -43,15 +43,53 @@
         }
       }
     },
-    "edge-environment-geo": {
+    "edge-environment-countrycode": {
       "properties": {
         "xdm:placeContext": {
           "type": "object",
           "properties": {
             "xdm:geo": {
               "title": "Geo",
-              "$ref": "https://ns.adobe.com/xdm/common/geo",
-              "description": "The geographic location where the experience was delivered based on the IP address from the client request."
+              "$ref": "https://ns.adobe.com/xdm/common/geo#/definitions/countrycode",
+            }
+          }
+        }
+      }
+    },
+    "edge-environment-postalcode": {
+      "properties": {
+        "xdm:placeContext": {
+          "type": "object",
+          "properties": {
+            "xdm:geo": {
+              "title": "Geo",
+              "$ref": "https://ns.adobe.com/xdm/common/geo#/definitions/postalcode",
+            }
+          }
+        }
+      }
+    },
+    "edge-environment-latitude": {
+      "properties": {
+        "xdm:placeContext": {
+          "type": "object",
+          "properties": {
+            "xdm:geo": {
+              "title": "Geo",
+              "$ref": "http://schema.org/GeoCoordinates#/definitions/latitude",
+            }
+          }
+        }
+      }
+    },
+    "edge-environment-longitude": {
+      "properties": {
+        "xdm:placeContext": {
+          "type": "object",
+          "properties": {
+            "xdm:geo": {
+              "title": "Geo",
+              "$ref": "http://schema.org/GeoCoordinates#/definitions/longitude",
             }
           }
         }
@@ -69,7 +107,16 @@
       "$ref": "#/definitions/edge-environment-user-agent"
     },
     {
-      "$ref": "#/definitions/edge-environment-geo"
+      "$ref": "#/definitions/edge-environment-countrycode"
+    },
+    {
+      "$ref": "#/definitions/edge-environment-postalcode"
+    },
+    {
+      "$ref": "#/definitions/edge-environment-latitude"
+    },
+    {
+      "$ref": "#/definitions/edge-environment-longitude"
     }
   ],
   "meta:status": "experimental"

--- a/extensions/adobe/experience/edge-autofilled-environment-details.schema.json
+++ b/extensions/adobe/experience/edge-autofilled-environment-details.schema.json
@@ -56,14 +56,14 @@
         }
       }
     },
-    "edge-environment-postalcode": {
+    "edge-environment-stateprovince": {
       "properties": {
         "xdm:placeContext": {
           "type": "object",
           "properties": {
             "xdm:geo": {
               "title": "Geo",
-              "$ref": "https://ns.adobe.com/xdm/common/geo#/definitions/postalcode"
+              "$ref": "https://ns.adobe.com/xdm/common/geo#/definitions/stateprovince"
             }
           }
         }
@@ -110,7 +110,7 @@
       "$ref": "#/definitions/edge-environment-countrycode"
     },
     {
-      "$ref": "#/definitions/edge-environment-postalcode"
+      "$ref": "#/definitions/edge-environment-stateprovince"
     },
     {
       "$ref": "#/definitions/edge-environment-latitude"

--- a/extensions/adobe/experience/edge-autofilled-environment-details.schema.json
+++ b/extensions/adobe/experience/edge-autofilled-environment-details.schema.json
@@ -50,7 +50,7 @@
           "properties": {
             "xdm:geo": {
               "title": "Geo",
-              "$ref": "https://ns.adobe.com/xdm/common/geo#/definitions/countrycode",
+              "$ref": "https://ns.adobe.com/xdm/common/geo#/definitions/countrycode"
             }
           }
         }
@@ -63,7 +63,7 @@
           "properties": {
             "xdm:geo": {
               "title": "Geo",
-              "$ref": "https://ns.adobe.com/xdm/common/geo#/definitions/postalcode",
+              "$ref": "https://ns.adobe.com/xdm/common/geo#/definitions/postalcode"
             }
           }
         }
@@ -76,7 +76,7 @@
           "properties": {
             "xdm:geo": {
               "title": "Geo",
-              "$ref": "http://schema.org/GeoCoordinates#/definitions/latitude",
+              "$ref": "http://schema.org/GeoCoordinates#/definitions/latitude"
             }
           }
         }
@@ -89,7 +89,7 @@
           "properties": {
             "xdm:geo": {
               "title": "Geo",
-              "$ref": "http://schema.org/GeoCoordinates#/definitions/longitude",
+              "$ref": "http://schema.org/GeoCoordinates#/definitions/longitude"
             }
           }
         }

--- a/extensions/adobe/experience/edge-autofilled-environment-details.schema.json
+++ b/extensions/adobe/experience/edge-autofilled-environment-details.schema.json
@@ -119,5 +119,5 @@
       "$ref": "#/definitions/edge-environment-longitude"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }


### PR DESCRIPTION
- Change the Edge Autofilled Environment Details field group status to "stable".
- Create dedicated definitions for each field in the Geo and GeoCoordinates data types
- Reference only the needed field definitions for Geo and GeoCoordinates in the Edge Autofilled Environment Details field group.

Locally on my system, `npm run incompatibility-check` fails because I have removed the references `$ref": "#/definitions/geo` and `$ref": "#/definitions/geocoordinates`. I've searched the repo and did find any direct usages of these references.