### PR TITLE
Add xdm:note to the anyOf required list

### DIFF
--- a/schemas/descriptors/display/alternateDisplayInfo.schema.json
+++ b/schemas/descriptors/display/alternateDisplayInfo.schema.json
@@ -78,6 +78,9 @@
           "required": ["xdm:description"]
         },
         {
+          "required": ["xdm:note"]
+        },
+        {
           "required": ["meta:enum"]
         }
       ],


### PR DESCRIPTION
We have a bug today where the schema does not allow only an xdm:note being supplied without a title or description along with it. 
