### PR TITLE
Deprecating the associatedIdentites field in profile union schema

### DIFF
--- a/extensions/adobe/experience/profile/profile-all.schema.json
+++ b/extensions/adobe/experience/profile/profile-all.schema.json
@@ -30,6 +30,7 @@
           }
         },
         "https://ns.adobe.com/experience/profile/associatedIdentities": {
+          "meta:status": "deprecated",
           "type": "object",
           "meta:xdmType": "map",
           "additionalProperties": {


### PR DESCRIPTION
This field is not needed anymore for Shared device feature

Please link to the issue #…
https://jira.corp.adobe.com/browse/CORE-68551