### PR TITLE
Define the category as String.

### DIFF
--- a/schemas/destinations/destination.schema.json
+++ b/schemas/destinations/destination.schema.json
@@ -87,29 +87,7 @@
         "xdm:destinationCategory": {
           "title": "Destination Category",
           "type": "string",
-          "description": "Grouping of the destinations in the catalog depending on the marketing action that they help achieve",
-          "enum": [
-            "adobeSolutions",
-            "advertising",
-            "cloudStorage",
-            "emailMarketing",
-            "mobile engagement",
-            "personalization",
-            "social",
-            "streaming",
-            "mobile"
-          ],
-          "meta:enum": {
-            "adobeSolutions": "adobeSolutions",
-            "advertising": "advertising",
-            "cloudStorage": "cloudStorage",
-            "emailMarketing": "emailMarketing",
-            "mobile engagement": "mobile engagement",
-            "personalization": "personalization",
-            "social": "social",
-            "streaming": "streaming",
-            "mobile": "mobile"
-          }
+          "description": "Grouping of the destinations in the catalog depending on the marketing action that they help achieve"
         },
         "xdm:destinationFrequency": {
           "title": "Destination Frequency",


### PR DESCRIPTION
Please link to the issue - https://jira.corp.adobe.com/browse/PLAT-120998

We have been running into issues where the destinations exporter is failing to export the data when some of the orgs/sandboxes have destination categories that have not been defined in the connection specs from here - https://git.corp.adobe.com/experience-platform/flow-service/tree/master/flow-service-core/src/main/resources/providers/dis/connectionSpecs
Hence the destination category cannot be limited to a definitive list and so changing the field to a String type. 