### PR TITLE
Extend eventType in time-series schema for AJO web-channel inbound usecase

### DIFF
--- a/components/behaviors/time-series.schema.json
+++ b/components/behaviors/time-series.schema.json
@@ -62,6 +62,7 @@
             "commerce.saveForLaters": "Commerce Save For Laters",
             "decisioning.propositionDisplay": "Decisioning Proposition Display",
             "decisioning.propositionInteract": "Decisioning Proposition Interact",
+            "decisioning.propositionDeliver": "Decisioning Proposition Deliver",
             "delivery.feedback": "Delivery Feedback",
             "message.feedback": "Message Feedback",
             "message.tracking": "Message Tracking",

--- a/docs/reference/adobe/experience/journeyOrchestration/stepEvents/journeyStepEventClass.schema.md
+++ b/docs/reference/adobe/experience/journeyOrchestration/stepEvents/journeyStepEventClass.schema.md
@@ -120,6 +120,7 @@ The primary event type for this time-series record.
 | `commerce.saveForLaters` | Commerce Save For Laters |
 | `decisioning.propositionDisplay` | Decisioning Proposition Display |
 | `decisioning.propositionInteract` | Decisioning Proposition Interact |
+| `decisioning.propositionDeliver` | Decisioning Proposition Deliver |
 | `delivery.feedback` | Delivery Feedback |
 | `message.feedback` | Message Feedback |
 | `message.tracking` | Message Tracking |

--- a/docs/reference/behaviors/time-series.schema.json
+++ b/docs/reference/behaviors/time-series.schema.json
@@ -62,6 +62,7 @@
                         "commerce.saveForLaters": "Commerce Save For Laters",
                         "decisioning.propositionDisplay": "Decisioning Proposition Display",
                         "decisioning.propositionInteract": "Decisioning Proposition Interact",
+                        "decisioning.propositionDeliver": "Decisioning Proposition Deliver",
                         "delivery.feedback": "Delivery Feedback",
                         "message.feedback": "Message Feedback",
                         "message.tracking": "Message Tracking",

--- a/docs/reference/behaviors/time-series.schema.md
+++ b/docs/reference/behaviors/time-series.schema.md
@@ -101,6 +101,7 @@ The primary event type for this time-series record.
 | `commerce.saveForLaters` | Commerce Save For Laters |
 | `decisioning.propositionDisplay` | Decisioning Proposition Display |
 | `decisioning.propositionInteract` | Decisioning Proposition Interact |
+| `decisioning.propositionDeliver` | Decisioning Proposition Deliver |
 | `delivery.feedback` | Delivery Feedback |
 | `message.feedback` | Message Feedback |
 | `message.tracking` | Message Tracking |


### PR DESCRIPTION
Please link to the issue:
Jira: https://jira.corp.adobe.com/browse/CJM-23839
Github Issue: https://github.com/adobe/xdm/issues/1519

Summary:
Added the following new event types to the meta:enum in time-series schema:
decisioning.propositionDeliver

