### PR TITLE
Creation related fields added to the WorkObject

### DIFF
--- a/extensions/adobe/experience/workfront/changeevent.schema.json
+++ b/extensions/adobe/experience/workfront/changeevent.schema.json
@@ -77,7 +77,7 @@
           "format": "date-time"
         },
         "workfront:createdByEmployeeID": {
-          "title": "Entry Date",
+          "title": "Created By ID",
           "type": "string",
           "description": "The employeeID involved in the CREATE event"
         }

--- a/extensions/adobe/experience/workfront/changeevent.schema.json
+++ b/extensions/adobe/experience/workfront/changeevent.schema.json
@@ -49,8 +49,7 @@
         "workfront:objectType": {
           "title": "Object Type",
           "description": "The type of object",
-          "type": "string",
-          "enum": ["TASK", "PROJECT", "ISSUE"]
+          "type": "string"
         },
         "workfront:parentID": {
           "title": "Parent Object ID",
@@ -70,6 +69,18 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "workfront:creationDate": {
+          "title": "Creation Date",
+          "description": "The entry date from the source system",
+          "type": "string", 
+          "format": "date-time"
+        },
+        "workfront:createdByEmployeeID": {
+          "title": "Entry Date" 
+          "description": 
+          "type": "string", 
+          "description": "The employeeID involved in the CREATE event"
         }
       }
     }

--- a/extensions/adobe/experience/workfront/changeevent.schema.json
+++ b/extensions/adobe/experience/workfront/changeevent.schema.json
@@ -73,13 +73,12 @@
         "workfront:creationDate": {
           "title": "Creation Date",
           "description": "The entry date from the source system",
-          "type": "string", 
+          "type": "string",
           "format": "date-time"
         },
         "workfront:createdByEmployeeID": {
-          "title": "Entry Date" 
-          "description": 
-          "type": "string", 
+          "title": "Entry Date",
+          "type": "string",
           "description": "The employeeID involved in the CREATE event"
         }
       }


### PR DESCRIPTION
Introduced two field used to store attributes to help identify the user and time of a create event. 
