### PR TITLE
Fixing children properties path for ajo-entity-mixins

### DIFF
--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
@@ -1,40 +1,40 @@
 {
   "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaign": {
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaign/campaignID": "9e3c3315-f2ca-42c0-85d2-6d3e83802b18",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaign/campaignVersionID": "f08f3a02-b390-4e24-af16-7fe4a93a05fe",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaign/name": "Marketing Campaign",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaign/description": "Used for sending email/push messages",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaign/campaignActionID": "93rc3315-f2ca-42c0-85d2-6d3e83802b18"
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaignID": "9e3c3315-f2ca-42c0-85d2-6d3e83802b18",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaignVersionID": "f08f3a02-b390-4e24-af16-7fe4a93a05fe",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/name": "Marketing Campaign",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/description": "Used for sending email/push messages",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaignActionID": "93rc3315-f2ca-42c0-85d2-6d3e83802b18"
   },
   "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails": {
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/email": {
-      "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/email/subject": "Hi there, season end sale is here!"
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/email": {
+      "https://ns.adobe.com/experience/customerJourneyManagement/entities/email/subject": "Hi there, season end sale is here!"
     },
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/push": {
-      "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/push/title": "Hi, You've got a coupon"
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/push": {
+      "https://ns.adobe.com/experience/customerJourneyManagement/entities/push/title": "Hi, You've got a coupon"
     },
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/messageID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/baseMessageID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/messagePublicationID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/variantID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/channel": {
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/messageID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/baseMessageID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/messagePublicationID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/variantID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/channel": {
       "@id": "https://ns.adobe.com/xdm/channels/email"
     },
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/template": "Hi {{person.firstName}}",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/messagePublishedAt": "2021-06-25T15:52:25+00:00"
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/template": "Hi {{person.firstName}}",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/messagePublishedAt": "2021-06-25T15:52:25+00:00"
   },
   "https://ns.adobe.com/experience/customerJourneyManagement/entities/experiment": {
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/experiment/treatmentID": "123456",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/experiment/experimentID": "04832ee5-51ff-4706-af8a-a8ff6756sdfd",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/experiment/experimentName": "Hero page experiment",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/experiment/treatmentName": "The first treatment"
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/treatmentID": "123456",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/experimentID": "04832ee5-51ff-4706-af8a-a8ff6756sdfd",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/experimentName": "Hero page experiment",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/treatmentName": "The first treatment"
   },
   "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey": {
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey/journeyVersionID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey/journeyName": "Marketing Test Journey",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey/journeyID": "0879238rf-51ff-4706-af8a-a8ff6756308b",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey/journeyActionName": "Email 100Kb Message",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey/journeyActionID": "04832ee5-51ff-4706-af8a-dsff6756308b",
-    "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey/journeyNameAndVersion": "Email 100Kb Message (1b)"
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyVersionID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyName": "Marketing Test Journey",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyID": "0879238rf-51ff-4706-af8a-a8ff6756308b",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyActionName": "Email 100Kb Message",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyActionID": "04832ee5-51ff-4706-af8a-dsff6756308b",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyNameAndVersion": "Email 100Kb Message (1b)"
   }
 }

--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
@@ -23,27 +23,27 @@
           "type": "object",
           "description": "AJO Campaign Entity Specific Fields",
           "properties": {
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaign/campaignID": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaignID": {
               "title": "AJO Campaign ID",
               "type": "string",
               "description": "AJO Campaign ID. Remains unchanged even after republishing."
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaign/campaignVersionID": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaignVersionID": {
               "title": "AJO Campaign Version ID",
               "type": "string",
               "description": "AJO Campaign Version ID. Changes on republishing. Represents immutable version of campaign."
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaign/name": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/name": {
               "title": "AJO Campaign Name",
               "type": "string",
               "description": "AJO Campaign Name."
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaign/description": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/description": {
               "title": "AJO Campaign Description",
               "type": "string",
               "description": "AJO Campaign Description."
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaign/campaignActionID": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/campaignActionID": {
               "title": "Campaign Action ID",
               "type": "string",
               "description": "Action ID of the Campaign that triggered this message execution."
@@ -55,61 +55,61 @@
           "type": "object",
           "description": "AJO Channel/Message Entity Specific Fields. Denormalized on variantId",
           "properties": {
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/email": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/email": {
               "title": "Email Specific Fields",
               "type": "object",
               "description": "Email Specific Fields",
               "properties": {
-                "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/email/subject": {
+                "https://ns.adobe.com/experience/customerJourneyManagement/entities/subject": {
                   "title": "Email Subject",
                   "type": "string",
                   "description": "Email subject, non-personalized"
                 }
               }
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/push": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/push": {
               "title": "Push Specific Fields",
               "type": "object",
               "description": "Push Specific Fields.",
               "properties": {
-                "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/push/title": {
+                "https://ns.adobe.com/experience/customerJourneyManagement/entities/title": {
                   "title": "Push Title",
                   "type": "string",
                   "description": "Push Title, non-personalized"
                 }
               }
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/messageID": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/messageID": {
               "title": "Message ID",
               "type": "string",
               "description": "Unique ID representing a non-personalized message sent to the end user."
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/baseMessageID": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/baseMessageID": {
               "title": "Base Message ID",
               "type": "string",
               "description": "Represents the base Message ID from which the published message is derived."
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/messagePublicationID": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/messagePublicationID": {
               "title": "Message Publication ID",
               "type": "string",
               "description": "Message Publication ID. Represents a frozen/published version of message."
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/variantID": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/variantID": {
               "title": "Channel's variant ID",
               "type": "string",
               "description": "Is not frozen and might remain same between different versions of message publication."
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/channel": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/channel": {
               "title": "The channel for which this row corresponds.",
               "$ref": "https://ns.adobe.com/xdm/channels/channel",
               "description": "Each specific experience channel defines a constant `@id`."
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/template": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/template": {
               "title": "The json template used in the message",
               "type": "string",
               "description": "The json template used while sending the message"
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelDetails/messagePublishedAt": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/messagePublishedAt": {
               "title": "Message Publication Time",
               "type": "string",
               "format": "date-time",
@@ -122,22 +122,22 @@
           "type": "object",
           "description": "AJO Experiment Entity Specific Fields",
           "properties": {
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/experiment/treatmentID": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/treatmentID": {
               "title": "Treatment ID",
               "type": "string",
               "description": "This along with experimentId has one to one mapping with messageID"
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/experiment/experimentId": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/experimentId": {
               "title": "Experiment ID",
               "type": "string",
               "description": "This along with treatmentId has one to one mapping with messageID"
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/experiment/experimentName": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/experimentName": {
               "title": "Experiment Name",
               "type": "string",
               "description": "Name of the experiment"
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/experiment/treatmentName": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/treatmentName": {
               "title": "Treatment Name",
               "type": "string",
               "description": "Name of the treatment"
@@ -149,32 +149,32 @@
           "type": "object",
           "description": "AJO Journey Entity Specific Fields",
           "properties": {
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey/journeyVersionID": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyVersionID": {
               "title": "Journey Version ID",
               "type": "string",
               "description": "Represents a frozen version of a Journey"
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey/journeyName": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyName": {
               "title": "Journey Name",
               "type": "string",
               "description": "Represents the journey name"
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey/journeyID": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyID": {
               "title": "Journey ID",
               "type": "string",
               "description": "Represents the journey ID"
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey/journeyActionName": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyActionName": {
               "title": "Journey Action Name",
               "type": "string",
               "description": "Represents the Journey Label"
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey/journeyActionID": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyActionID": {
               "title": "Journey Action ID",
               "type": "string",
               "description": "Represents the Journey Action ID"
             },
-            "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey/journeyNameAndVersion": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyNameAndVersion": {
               "title": "Journey Name and Version",
               "type": "string",
               "description": "Represents the concatenated values of Journey Name and Version"

--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
@@ -11,7 +11,7 @@
   "description": "A set of meta-data fields related to various AJO entities which are related to message sent to profile.",
   "type": "object",
   "meta:extensible": true,
-  "meta:abstract": false,
+  "meta:abstract": true,
   "meta:intendedToExtend": [
     "https://ns.adobe.com/experience/customerJourneyManagement/ajoEntity"
   ],


### PR DESCRIPTION
Trying to fix the bug of having root paths introduced multiple times.
![image (3)](https://user-images.githubusercontent.com/14310139/186360213-57c29c11-13da-4c35-9e3c-e4262c8b1c81.png)
