### PR TITLE
Delete implementationDetails and endUserIDs from mediaDetails

### DIFF
--- a/components/datatypes/mediadetails.example.1.json
+++ b/components/datatypes/mediadetails.example.1.json
@@ -80,8 +80,5 @@
         "xdm:code": "AVID"
       }
     }
-  },
-  "xdm:implementationDetails": {
-    "xdm:version": "2.7.0"
   }
 }

--- a/components/datatypes/mediadetails.example.1.json
+++ b/components/datatypes/mediadetails.example.1.json
@@ -66,19 +66,5 @@
       "xdm:name": "test2",
       "xdm:value": "customValue"
     }
-  ],
-  "xdm:endUserIDs": {
-    "https://ns.adobe.com/experience/mcid": {
-      "@id": "https://data.adobe.io/entities/identity/92312748749128",
-      "xdm:namespace": {
-        "xdm:code": "ECID"
-      }
-    },
-    "https://ns.adobe.com/experience/aaid": {
-      "@id": "https://data.adobe.io/entities/identity/2394509340-30453470347",
-      "xdm:namespace": {
-        "xdm:code": "AVID"
-      }
-    }
-  }
+  ]
 }

--- a/components/datatypes/mediadetails.schema.json
+++ b/components/datatypes/mediadetails.schema.json
@@ -92,11 +92,6 @@
           "title": "End User IDs",
           "$ref": "https://ns.adobe.com/xdm/context/enduserids",
           "description": "Condensed, normalized encapsulation of all end user identifiers. At least one of the fields is required."
-        },
-        "xdm:implementationDetails": {
-          "title": "Implementation Details",
-          "$ref": "https://ns.adobe.com/xdm/context/implementationdetails",
-          "description": "Details about the SDK, library, or service used in an application or web page implementation of a service."
         }
       }
     }

--- a/components/datatypes/mediadetails.schema.json
+++ b/components/datatypes/mediadetails.schema.json
@@ -87,11 +87,6 @@
             "$ref": "https://ns.adobe.com/xdm/datatypes/customMetadataDetails"
           },
           "description": "The list of custom metadata."
-        },
-        "xdm:endUserIDs": {
-          "title": "End User IDs",
-          "$ref": "https://ns.adobe.com/xdm/context/enduserids",
-          "description": "Condensed, normalized encapsulation of all end user identifiers. At least one of the fields is required."
         }
       }
     }

--- a/components/datatypes/mediaevent.example.1.json
+++ b/components/datatypes/mediaevent.example.1.json
@@ -65,9 +65,6 @@
           "xdm:code": "AVID"
         }
       }
-    },
-    "xdm:implementationDetails": {
-      "xdm:version": "2.7.0"
     }
   }
 }

--- a/components/datatypes/mediaevent.example.1.json
+++ b/components/datatypes/mediaevent.example.1.json
@@ -51,20 +51,6 @@
       {
         "xdm:name": "fullScreen"
       }
-    ],
-    "xdm:endUserIDs": {
-      "https://ns.adobe.com/experience/mcid": {
-        "@id": "https://data.adobe.io/entities/identity/92312748749128",
-        "xdm:namespace": {
-          "xdm:code": "ECID"
-        }
-      },
-      "https://ns.adobe.com/experience/aaid": {
-        "@id": "https://data.adobe.io/entities/identity/2394509340-30453470347",
-        "xdm:namespace": {
-          "xdm:code": "AVID"
-        }
-      }
-    }
+    ]
   }
 }

--- a/components/fieldgroups/experience-event/experienceevent-media-analytics.example.1.json
+++ b/components/fieldgroups/experience-event/experienceevent-media-analytics.example.1.json
@@ -47,15 +47,7 @@
       {
         "xdm:name": "fullScreen"
       }
-    ],
-    "xdm:endUserIDs": {
-      "https://ns.adobe.com/experience/aacustomid": {
-        "@id": "https://data.adobe.io/entities/identity/92312748749128"
-      },
-      "https://ns.adobe.com/experience/aaid": {
-        "@id": "https://data.adobe.io/entities/identity/2394509340-30453470347"
-      }
-    }
+    ]
   },
   "xdm:mediaReporting": {
     "xdm:sessionDetails": {
@@ -113,14 +105,6 @@
         },
         "xdm:qoeDataDetails": {
           "xdm:bitrate": 100
-        },
-        "xdm:endUserIDs": {
-          "https://ns.adobe.com/experience/aacustomid": {
-            "@id": "https://data.adobe.io/entities/identity/92312748749128"
-          },
-          "https://ns.adobe.com/experience/aaid": {
-            "@id": "https://data.adobe.io/entities/identity/2394509340-30453470347"
-          }
         }
       }
     },

--- a/components/fieldgroups/experience-event/experienceevent-media-analytics.example.1.json
+++ b/components/fieldgroups/experience-event/experienceevent-media-analytics.example.1.json
@@ -55,9 +55,6 @@
       "https://ns.adobe.com/experience/aaid": {
         "@id": "https://data.adobe.io/entities/identity/2394509340-30453470347"
       }
-    },
-    "xdm:implementationDetails": {
-      "xdm:version": "2.7.0"
     }
   },
   "xdm:mediaReporting": {
@@ -98,10 +95,7 @@
         "xdm:count": 2,
         "xdm:time": 100
       }
-    ],
-    "xdm:implementationDetails": {
-      "xdm:version": "2.7.0"
-    }
+    ]
   },
   "xdm:mediaDownloadedEvents": [
     {
@@ -127,9 +121,6 @@
           "https://ns.adobe.com/experience/aaid": {
             "@id": "https://data.adobe.io/entities/identity/2394509340-30453470347"
           }
-        },
-        "xdm:implementationDetails": {
-          "xdm:version": "2.7.0"
         }
       }
     },


### PR DESCRIPTION
Issue https://github.com/adobe/xdm/issues/1550
This PR deletes the implementationDetails and endUserIDs datatypes from mediaDetails because we decided to use the implementationDetails fieldgroup and AdobeAnalytics Experience event template directly.
