### PR TITLE
Add URL field to messageInteraction mixin

### DIFF
--- a/extensions/adobe/experience/customerJourneyManagement/message-interaction.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/message-interaction.example.1.json
@@ -1,6 +1,7 @@
 {
   "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/interactionType": "click",
   "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/urlID": "123",
+  "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/url": "https://www.adobe.com/",
   "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/messageInteraction/trackingType": "offer",
   "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/tags": [
     "marketing",

--- a/extensions/adobe/experience/customerJourneyManagement/message-interaction.example.3.json
+++ b/extensions/adobe/experience/customerJourneyManagement/message-interaction.example.3.json
@@ -1,6 +1,7 @@
 {
   "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/interactionType": "submit",
   "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/urlID": "123",
+  "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/url": "https://www.adobe.com/",
   "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/messageInteraction/trackingType": "tracked",
   "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/messageInteraction/entityType": "landing_page",
   "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/label": "adobe.com",

--- a/extensions/adobe/experience/customerJourneyManagement/message-interaction.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/message-interaction.schema.json
@@ -58,6 +58,11 @@
           "meta:titleId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/urlID##title##17241",
           "meta:descriptionId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/urlID##description##9381"
         },
+        "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/url": {
+          "title": "Tracker URL",
+          "type": "string",
+          "description": "The URL clicked by the user."
+        },
         "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/trackingType": {
           "title": "URL Tracking Type",
           "type": "string",


### PR DESCRIPTION
**JIRA:** 
1. https://jira.corp.adobe.com/browse/CJM-40662
2. https://jira.corp.adobe.com/browse/PLATIR-23106

**Description:**
AJO Reporting requires to show actual URLs in breakdowns in the SMS Click Reports.
Since, only URL Id is present in the experience events, we need to have a way to enrich these URL Ids along with actual URLs in messageInteraction.

**Wiki Reference:** 
1. https://wiki.corp.adobe.com/display/CJM/Tracked+URL+Lookup+Dataset+Requirements+For+AJO+Reporting
2. https://wiki.corp.adobe.com/display/CJM/Addition+of+url+field+in+AJO+Email+Tracking+Experience+Event+Schema
