### PR TITLE
CJM-40731 Remove uri-reference validation from 2 fields in content-component-details

### DIFF
--- a/docs/reference/adobe/experience/decisioning/content-component-details.schema.json
+++ b/docs/reference/adobe/experience/decisioning/content-component-details.schema.json
@@ -88,20 +88,20 @@
                 },
                 "xdm:deliveryURL": {
                     "type": "string",
-                    "format": "uri-reference",
                     "meta:usereditable": false,
                     "description": "An optional unique resource locator to obtain the asset from a content delivery network or service endpoint. This URL is used to access the asset publicly by a user agent.",
                     "examples": [
-                        "https://cdn.adobe.io/content/projectx/fragment/prod/static/1232324wd32.jpeg"
+                        "https://cdn.adobe.io/content/projectx/fragment/prod/static/1232324wd32.jpeg",
+                        "https://cdn.adobe.io/content/projectx/fragment/prod/static/{{imageName}}"
                     ],
                     "meta:descriptionId": "content-component-details##xdm:deliveryURL##description##82731"
                 },
                 "xdm:linkURL": {
                     "type": "string",
-                    "format": "uri-reference",
                     "description": "An optional unique resource locator for user interactions. This URL is used to refer the end user to in a user agent and can be tracked.",
                     "examples": [
-                        "https://cdn.adobe.io/tracker?code=23432&redirect=/content/projectx/fragment/prod/static/1232324wd32.jpeg"
+                        "https://cdn.adobe.io/tracker?code=23432&redirect=/content/projectx/fragment/prod/static/1232324wd32.jpeg",
+                        "https://cdn.adobe.io/tracker?code={{code}}&redirect={{redirectPath}}"
                     ],
                     "meta:descriptionId": "content-component-details##xdm:linkURL##description##5581"
                 }

--- a/docs/reference/adobe/experience/decisioning/content-component-details.schema.md
+++ b/docs/reference/adobe/experience/decisioning/content-component-details.schema.md
@@ -271,19 +271,11 @@ An optional unique resource locator to obtain the asset from a content delivery 
 * type: `string`
 * defined in this schema
 
-### xdm:deliveryURL Type
-
-
-`string`
-* format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
-
-
-
-
 ### xdm:deliveryURL Example
 
-```json
+```
 "https://cdn.adobe.io/content/projectx/fragment/prod/static/1232324wd32.jpeg"
+"https://cdn.adobe.io/content/projectx/fragment/prod/static/{{imageName}}"
 ```
 
 
@@ -296,18 +288,10 @@ An optional unique resource locator for user interactions. This URL is used to r
 * type: `string`
 * defined in this schema
 
-### xdm:linkURL Type
-
-
-`string`
-* format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
-
-
-
-
 ### xdm:linkURL Example
 
-```json
+```
 "https://cdn.adobe.io/tracker?code=23432&redirect=/content/projectx/fragment/prod/static/1232324wd32.jpeg"
+"https://cdn.adobe.io/tracker?code={{code}}&redirect={{redirectPath}}"
 ```
 

--- a/extensions/adobe/experience/decisioning/content-component-details.schema.json
+++ b/extensions/adobe/experience/decisioning/content-component-details.schema.json
@@ -76,20 +76,20 @@
         },
         "xdm:deliveryURL": {
           "type": "string",
-          "format": "uri-reference",
           "meta:usereditable": false,
           "description": "An optional unique resource locator to obtain the asset from a content delivery network or service endpoint. This URL is used to access the asset publicly by a user agent.",
           "examples": [
-            "https://cdn.adobe.io/content/projectx/fragment/prod/static/1232324wd32.jpeg"
+            "https://cdn.adobe.io/content/projectx/fragment/prod/static/1232324wd32.jpeg",
+            "https://cdn.adobe.io/content/projectx/fragment/prod/static/{{imageName}}"
           ],
           "meta:descriptionId": "content-component-details##xdm:deliveryURL##description##82731"
         },
         "xdm:linkURL": {
           "type": "string",
-          "format": "uri-reference",
           "description": "An optional unique resource locator for user interactions. This URL is used to refer the end user to in a user agent and can be tracked.",
           "examples": [
-            "https://cdn.adobe.io/tracker?code=23432&redirect=/content/projectx/fragment/prod/static/1232324wd32.jpeg"
+            "https://cdn.adobe.io/tracker?code=23432&redirect=/content/projectx/fragment/prod/static/1232324wd32.jpeg",
+            "https://cdn.adobe.io/tracker?code={{code}}&redirect={{redirectPath}}"
           ],
           "meta:descriptionId": "content-component-details##xdm:linkURL##description##5581"
         }


### PR DESCRIPTION
**Issue** 
https://github.com/adobe/xdm/issues/1673

**Changes**
- Remove uri-reference validation from `xdm:deliveryURL` and `xdm:linkURL` in `content-component-details`
- Update field examples and doc for `content-component-details`