### PR TITLE
TNT-44351 Create XDM schema for Target Classification datasets

### DIFF
--- a/extensions/adobe/experience/target/classification.schema.json
+++ b/extensions/adobe/experience/target/classification.schema.json
@@ -13,73 +13,73 @@
   "definitions": {
     "classification": {
       "properties": {
-        "xdm:activityName": {
+        "https://ns.adobe.com/experience/target/classification/activityName": {
           "title": "Activity Name",
           "type": "string",
           "description": "The name of the Target activity."
         },
-        "xdm:experienceName": {
+        "https://ns.adobe.com/experience/target/classification/experienceName": {
           "title": "Experience Name",
           "type": "string",
           "description": "The name of the Target experience."
         },
-        "xdm:activityExperience": {
+        "https://ns.adobe.com/experience/target/classification/activityExperience": {
           "title": "Activity Experience",
           "type": "string",
           "description": "Target Activity name concatenated with experience name."
         },
-        "xdm:thirdId": {
+        "https://ns.adobe.com/experience/target/classification/thirdId": {
           "title": "Third Id",
           "type": "string",
           "description": "The third id of the classification record."
         },
-        "xdm:activityId": {
+        "https://ns.adobe.com/experience/target/classification/activityId": {
           "title": "Activity Id",
           "type": "string",
           "description": "The identity of Target activity."
         },
-        "xdm:experienceId": {
+        "https://ns.adobe.com/experience/target/classification/experienceId": {
           "title": "Experience Id",
           "type": "string",
           "description": "The identity of Target experience."
         },
-        "xdm:analyticsReporting": {
+        "https://ns.adobe.com/experience/target/classification/analyticsReporting": {
           "title": "Analytics Reporting",
           "type": "string",
           "description": "The reporting type associated with the Target activity."
         },
-        "xdm:activeDates": {
+        "https://ns.adobe.com/experience/target/classification/activeDates": {
           "title": "Active Dates",
           "type": "string",
           "description": "The date of Target activity activation."
         },
-        "xdm:controlExperience": {
+        "https://ns.adobe.com/experience/target/classification/controlExperience": {
           "title": "Control Experience",
           "type": "string",
           "description": "The experience set as control experience in the Target activity."
         },
-        "xdm:algorithmId": {
+        "https://ns.adobe.com/experience/target/classification/algorithmId": {
           "title": "Algorithm Id",
           "type": "string",
           "description": "The identity of the algorithm used in the Target activity."
         },
-        "xdm:controlvsTargeted": {
+        "https://ns.adobe.com/experience/target/classification/controlvsTargeted": {
           "title": "Control vs Targeted",
           "type": "string",
           "description": "The traffic allocation type for the Target activity."
         },
-        "xdm:trafficTypeId": {
+        "https://ns.adobe.com/experience/target/classification/trafficTypeId": {
           "title": "Traffic Type Id",
           "type": "string",
           "description": "The identity of the traffic type associated with Target activity."
         }
       },
       "required": [
-        "xdm:activityName",
-        "xdm:activityId",
-        "xdm:experienceName",
-        "xdm:experienceId",
-        "xdm:activityExperience"
+        "https://ns.adobe.com/experience/target/classification/activityName",
+        "https://ns.adobe.com/experience/target/classification/activityId",
+        "https://ns.adobe.com/experience/target/classification/experienceName",
+        "https://ns.adobe.com/experience/target/classification/experienceId",
+        "https://ns.adobe.com/experience/target/classification/activityExperience"
       ]
     }
   },

--- a/extensions/adobe/experience/target/classification.schema.json
+++ b/extensions/adobe/experience/target/classification.schema.json
@@ -1,0 +1,96 @@
+{
+  "meta:license": [
+    "Copyright 2023 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/experience/target/classification",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Adobe Target Classification Fields",
+  "type": "object",
+  "description": "A set of meta-data fields that will classify Target activities and experiences.",
+  "definitions": {
+    "classification": {
+      "properties": {
+        "xdm:activityName": {
+          "title": "Activity Name",
+          "type": "string",
+          "description": "The name of the Target activity."
+        },
+        "xdm:experienceName": {
+          "title": "Experience Name",
+          "type": "string",
+          "description": "The name of the Target experience."
+        },
+        "xdm:activityExperience": {
+          "title": "Activity Experience",
+          "type": "string",
+          "description": "Target Activity name concatenated with experience name."
+        },
+        "xdm:thirdId": {
+          "title": "Third Id",
+          "type": "string",
+          "description": "The third id of the classification record."
+        },
+        "xdm:activityId": {
+          "title": "Activity Id",
+          "type": "string",
+          "description": "The identity of Target activity."
+        },
+        "xdm:experienceId": {
+          "title": "Experience Id",
+          "type": "string",
+          "description": "The identity of Target experience."
+        },
+        "xdm:analyticsReporting": {
+          "title": "Analytics Reporting",
+          "type": "string",
+          "description": "The reporting type associated with the Target activity."
+        },
+        "xdm:activeDates": {
+          "title": "Active Dates",
+          "type": "string",
+          "description": "The date of Target activity activation."
+        },
+        "xdm:controlExperience": {
+          "title": "Control Experience",
+          "type": "string",
+          "description": "The experience set as control experience in the Target activity."
+        },
+        "xdm:algorithmId": {
+          "title": "Algorithm Id",
+          "type": "string",
+          "description": "The identity of the algorithm used in the Target activity."
+        },
+        "xdm:controlvsTargeted": {
+          "title": "Control vs Targeted",
+          "type": "string",
+          "description": "The traffic allocation type for the Target activity."
+        },
+        "xdm:trafficTypeId": {
+          "title": "Traffic Type Id",
+          "type": "string",
+          "description": "The identity of the traffic type associated with Target activity."
+        }
+      },
+      "required": [
+        "xdm:activityName",
+        "xdm:activityId",
+        "xdm:experienceName",
+        "xdm:experienceId",
+        "xdm:activityExperience"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/classification"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/data/record"
+    }
+  ],
+  "meta:status": "experimental",
+  "meta:extends": ["https://ns.adobe.com/xdm/data/record"]
+}

--- a/schemas/target/target-classification.example.1.json
+++ b/schemas/target/target-classification.example.1.json
@@ -1,0 +1,8 @@
+{
+  "@id": "123456:2:0:400001",
+  "xdm:activityName": "My Activity A",
+  "xdm:activityId": "123456",
+  "xdm:experienceName": "My Experience 2",
+  "xdm:experienceId": "2",
+  "xdm:activityExperience": "My Activity A > My Experience 2"
+}

--- a/schemas/target/target-classification.example.1.json
+++ b/schemas/target/target-classification.example.1.json
@@ -1,10 +1,11 @@
 {
-  "@id": "123456:2:0:400001",
+  "@id": "14e0bd42-2a48-4f40-a3d0-5e089da31234",
+  "xdm:key": "123456:2:0:400001",
   "xdm:activityName": "My Activity A",
-  "xdm:activityId": "123456",
+  "xdm:activityID": "123456",
   "xdm:experienceName": "My Experience 2",
-  "xdm:experienceId": "2",
+  "xdm:experienceID": "2",
   "xdm:activityExperience": "My Activity A > My Experience 2",
-  "xdm:trafficTypeId": "0",
-  "xdm:algorithmId": "400001"
+  "xdm:trafficTypeID": "0",
+  "xdm:algorithmID": "400001"
 }

--- a/schemas/target/target-classification.example.1.json
+++ b/schemas/target/target-classification.example.1.json
@@ -4,5 +4,7 @@
   "xdm:activityId": "123456",
   "xdm:experienceName": "My Experience 2",
   "xdm:experienceId": "2",
-  "xdm:activityExperience": "My Activity A > My Experience 2"
+  "xdm:activityExperience": "My Activity A > My Experience 2",
+  "xdm:trafficTypeId": "0",
+  "xdm:algorithmId": "400001"
 }

--- a/schemas/target/target-classification.example.2.json
+++ b/schemas/target/target-classification.example.2.json
@@ -1,9 +1,10 @@
 {
-  "@id": "123450:1:1",
+  "@id": "14e0bd42-2a48-4f40-a3d0-5e089da31235",
+  "xdm:key": "123450:1:1",
   "xdm:activityName": "My Activity B",
-  "xdm:activityId": "123450",
+  "xdm:activityID": "123450",
   "xdm:experienceName": "My Experience 1",
-  "xdm:experienceId": "1",
+  "xdm:experienceID": "1",
   "xdm:activityExperience": "My Activity B > My Experience 1",
-  "xdm:trafficTypeId": "1"
+  "xdm:trafficTypeID": "1"
 }

--- a/schemas/target/target-classification.example.2.json
+++ b/schemas/target/target-classification.example.2.json
@@ -1,0 +1,8 @@
+{
+  "@id": "123450:1:400002",
+  "xdm:activityName": "My Activity B",
+  "xdm:activityId": "123450",
+  "xdm:experienceName": "My Experience 1",
+  "xdm:experienceId": "1",
+  "xdm:activityExperience": "My Activity B > My Experience 1"
+}

--- a/schemas/target/target-classification.example.2.json
+++ b/schemas/target/target-classification.example.2.json
@@ -1,8 +1,9 @@
 {
-  "@id": "123450:1:400002",
+  "@id": "123450:1:1",
   "xdm:activityName": "My Activity B",
   "xdm:activityId": "123450",
   "xdm:experienceName": "My Experience 1",
   "xdm:experienceId": "1",
-  "xdm:activityExperience": "My Activity B > My Experience 1"
+  "xdm:activityExperience": "My Activity B > My Experience 1",
+  "xdm:trafficTypeId": "1"
 }

--- a/schemas/target/target-classification.schema.json
+++ b/schemas/target/target-classification.schema.json
@@ -5,92 +5,94 @@
     "you may not use this file except in compliance with the License. You may obtain a copy",
     "of the License at https://creativecommons.org/licenses/by/4.0/"
   ],
-  "$id": "https://ns.adobe.com/experience/target/classification",
+  "$id": "https://ns.adobe.com/xdm/schemas/target-classification",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Adobe Target Classification Fields",
-  "type": "object",
   "description": "A set of meta-data fields that will classify Target activities and experiences.",
+  "type": "object",
+  "meta:extensible": false,
+  "meta:abstract": false,
+  "meta:extends": ["https://ns.adobe.com/xdm/data/record"],
   "definitions": {
-    "classification": {
+    "target": {
       "properties": {
-        "https://ns.adobe.com/experience/target/classification/activityName": {
+        "xdm:activityName": {
           "title": "Activity Name",
           "type": "string",
           "description": "The name of the Target activity."
         },
-        "https://ns.adobe.com/experience/target/classification/experienceName": {
+        "xdm:experienceName": {
           "title": "Experience Name",
           "type": "string",
           "description": "The name of the Target experience."
         },
-        "https://ns.adobe.com/experience/target/classification/activityExperience": {
+        "xdm:activityExperience": {
           "title": "Activity Experience",
           "type": "string",
           "description": "Target Activity name concatenated with experience name."
         },
-        "https://ns.adobe.com/experience/target/classification/thirdId": {
+        "xdm:thirdId": {
           "title": "Third Id",
           "type": "string",
           "description": "The third id of the classification record."
         },
-        "https://ns.adobe.com/experience/target/classification/activityId": {
+        "xdm:activityId": {
           "title": "Activity Id",
           "type": "string",
           "description": "The identity of Target activity."
         },
-        "https://ns.adobe.com/experience/target/classification/experienceId": {
+        "xdm:experienceId": {
           "title": "Experience Id",
           "type": "string",
           "description": "The identity of Target experience."
         },
-        "https://ns.adobe.com/experience/target/classification/analyticsReporting": {
+        "xdm:analyticsReporting": {
           "title": "Analytics Reporting",
           "type": "string",
           "description": "The reporting type associated with the Target activity."
         },
-        "https://ns.adobe.com/experience/target/classification/activeDates": {
+        "xdm:activeDates": {
           "title": "Active Dates",
           "type": "string",
           "description": "The date of Target activity activation."
         },
-        "https://ns.adobe.com/experience/target/classification/controlExperience": {
+        "xdm:controlExperience": {
           "title": "Control Experience",
           "type": "string",
           "description": "The experience set as control experience in the Target activity."
         },
-        "https://ns.adobe.com/experience/target/classification/algorithmId": {
+        "xdm:algorithmId": {
           "title": "Algorithm Id",
           "type": "string",
           "description": "The identity of the algorithm used in the Target activity."
         },
-        "https://ns.adobe.com/experience/target/classification/controlvsTargeted": {
+        "xdm:controlvsTargeted": {
           "title": "Control vs Targeted",
           "type": "string",
           "description": "The traffic allocation type for the Target activity."
         },
-        "https://ns.adobe.com/experience/target/classification/trafficTypeId": {
+        "xdm:trafficTypeId": {
           "title": "Traffic Type Id",
           "type": "string",
           "description": "The identity of the traffic type associated with Target activity."
         }
       },
       "required": [
-        "https://ns.adobe.com/experience/target/classification/activityName",
-        "https://ns.adobe.com/experience/target/classification/activityId",
-        "https://ns.adobe.com/experience/target/classification/experienceName",
-        "https://ns.adobe.com/experience/target/classification/experienceId",
-        "https://ns.adobe.com/experience/target/classification/activityExperience"
+        "xdm:activityName",
+        "xdm:activityId",
+        "xdm:experienceName",
+        "xdm:experienceId",
+        "xdm:activityExperience"
       ]
     }
   },
   "allOf": [
     {
-      "$ref": "#/definitions/classification"
+      "$ref": "https://ns.adobe.com/xdm/data/record"
     },
     {
-      "$ref": "https://ns.adobe.com/xdm/data/record"
+      "$ref": "#/definitions/target"
     }
   ],
-  "meta:status": "experimental",
-  "meta:extends": ["https://ns.adobe.com/xdm/data/record"]
+  "meta:status": "experimental"
 }

--- a/schemas/target/target-classification.schema.json
+++ b/schemas/target/target-classification.schema.json
@@ -14,8 +14,13 @@
   "meta:abstract": false,
   "meta:extends": ["https://ns.adobe.com/xdm/data/record"],
   "definitions": {
-    "target": {
+    "targetClassification": {
       "properties": {
+        "xdm:key": {
+          "title": "Key",
+          "type": "string",
+          "description": "The unique identity of activityId:experienceId:trafficTypeId:algorithmId"
+        },
         "xdm:activityName": {
           "title": "Activity Name",
           "type": "string",
@@ -31,18 +36,18 @@
           "type": "string",
           "description": "Target Activity name concatenated with experience name."
         },
-        "xdm:thirdId": {
-          "title": "Third Id",
+        "xdm:thirdID": {
+          "title": "Third ID",
           "type": "string",
-          "description": "The third id of the classification record."
+          "description": "The third ID of the classification record."
         },
-        "xdm:activityId": {
-          "title": "Activity Id",
+        "xdm:activityID": {
+          "title": "Activity ID",
           "type": "string",
           "description": "The identity of Target activity."
         },
-        "xdm:experienceId": {
-          "title": "Experience Id",
+        "xdm:experienceID": {
+          "title": "Experience ID",
           "type": "string",
           "description": "The identity of Target experience."
         },
@@ -61,27 +66,28 @@
           "type": "string",
           "description": "The experience set as control experience in the Target activity."
         },
-        "xdm:algorithmId": {
-          "title": "Algorithm Id",
+        "xdm:algorithmID": {
+          "title": "Algorithm ID",
           "type": "string",
           "description": "The identity of the algorithm used in the Target activity."
         },
-        "xdm:controlvsTargeted": {
-          "title": "Control vs Targeted",
+        "xdm:controlVsTargeted": {
+          "title": "Control VS Targeted",
           "type": "string",
           "description": "The traffic allocation type for the Target activity."
         },
-        "xdm:trafficTypeId": {
-          "title": "Traffic Type Id",
+        "xdm:trafficTypeID": {
+          "title": "Traffic Type ID",
           "type": "string",
           "description": "The identity of the traffic type associated with Target activity."
         }
       },
       "required": [
+        "xdm:key",
         "xdm:activityName",
-        "xdm:activityId",
+        "xdm:activityID",
         "xdm:experienceName",
-        "xdm:experienceId",
+        "xdm:experienceID",
         "xdm:activityExperience"
       ]
     }
@@ -91,7 +97,7 @@
       "$ref": "https://ns.adobe.com/xdm/data/record"
     },
     {
-      "$ref": "#/definitions/target"
+      "$ref": "#/definitions/targetClassification"
     }
   ],
   "meta:status": "experimental"


### PR DESCRIPTION
Jira:https://jira.corp.adobe.com/browse/TNT-44351
Github Issue: https://github.com/adobe/xdm/issues/1681

Summary:
A new XDM schema for Target Classification datasets containing a set of meta-data fields that will classify Target activities and experiences.