### PR TITLE
Add dc:language field to Application

### DIFF
--- a/components/datatypes/application.schema.json
+++ b/components/datatypes/application.schema.json
@@ -168,6 +168,18 @@
           "meta:titleId": "application##xdm:userPerspective##title##35971"
         }
       }
+    },
+    "language": {
+      "properties": {
+        "dc:language": {
+          "meta:usereditable": false,
+          "title": "Language",
+          "type": "string",
+          "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
+          "description": "The language of the application to represent the user's linguistic, geographical, or cultural preferences for data presentation.\nLanguages are specified in language code as defined in [IETF RFC 3066](https://www.ietf.org/rfc/rfc3066.txt), which is part of BCP 47, which is used elsewhere in XDM.",
+          "examples": ["en-US", "pt-BR", "es-ES"]
+        }
+      }
     }
   },
   "allOf": [
@@ -203,6 +215,9 @@
     },
     {
       "$ref": "#/definitions/userperspective"
+    },
+    {
+      "$ref": "#/definitions/language"
     }
   ],
   "meta:status": "stable",


### PR DESCRIPTION
Resolves #1725 

Mobile devices can specify a system/device locale preference and a separate application locale preference. Currently the XDM Environment schema captures the system locale preference under environment/_dc/language, however a new field is needed to capture the application locale preference.

This PR adds the field "language" to the Application schema which may be populated with the application's locale preference.
