### PR TITLE
Product-specific identity deletes for Data Hygiene

### DIFF
--- a/schemas/hygiene/aep-hygiene-ops-record.schema.json
+++ b/schemas/hygiene/aep-hygiene-ops-record.schema.json
@@ -49,13 +49,13 @@
           "meta:titleId": "aep-hygiene-ops##xdm:workorderID##title##7131",
           "meta:descriptionId": "aep-hygiene-ops##xdm:workorderID##description##50431"
         },
-        "xdm:targetProducts": {
-          "title": "Products that should process this request.",
-          "description": "Array of products to which these requests apply. If this field is absent, all products should process these requests.",
+        "xdm:targetServices": {
+          "title": "Services that should process this request.",
+          "description": "Array of service names indicating to whom these requests apply. If this field is absent, all services should process these requests.",
           "type": "array",
           "items": {
-            "title": "Product Name",
-            "description": "A product name, such as \"datalake\", \"identity\", or \"profile\".",
+            "title": "Service Name",
+            "description": "A service name, such as \"datalake\", \"identity\", or \"profile\".",
             "type": "string"
           }
         },

--- a/schemas/hygiene/aep-hygiene-ops-record.schema.json
+++ b/schemas/hygiene/aep-hygiene-ops-record.schema.json
@@ -56,12 +56,8 @@
           "items": {
             "title": "Product Name",
             "description": "A product name, such as \"datalake\", \"identity\", or \"profile\".",
-            "type": "string",
-            "meta:titleId": "TBD",
-            "meta:descriptionId": "TBD"
-          },
-          "meta:titleId": "TBD",
-          "meta:descriptionId": "TBD"
+            "type": "string"
+          }
         },
         "xdm:operation": {
           "title": "Payload of the hygiene op request",

--- a/schemas/hygiene/aep-hygiene-ops-record.schema.json
+++ b/schemas/hygiene/aep-hygiene-ops-record.schema.json
@@ -36,8 +36,8 @@
           }
         },
         "xdm:targetDatasetID": {
-          "title": "Target Dataset ID specified by the user to apply hygiene operations",
-          "description": "May be \"*\", but only if operationType = \"deleteIdentity\". Otherwise a valid value is required.",
+          "title": "ID(s) of the dataset(s) to which the hygiene operations apply",
+          "description": "May be \"ALL\", but only if operationType = \"deleteIdentity\". Otherwise, a comma-separated list of datasetID's is required.",
           "type": "string",
           "meta:titleId": "aep-hygiene-ops##xdm:targetDatasetID##title##10841",
           "meta:descriptionId": "aep-hygiene-ops##xdm:targetDatasetID##description##86781"
@@ -48,6 +48,20 @@
           "type": "string",
           "meta:titleId": "aep-hygiene-ops##xdm:workorderID##title##7131",
           "meta:descriptionId": "aep-hygiene-ops##xdm:workorderID##description##50431"
+        },
+        "xdm:targetProducts": {
+          "title": "Products that should process this request.",
+          "description": "Array of products to which these requests apply. If this field is absent, all products should process these requests.",
+          "type": "array",
+          "items": {
+            "title": "Product Name",
+            "description": "A product name, such as \"datalake\", \"identity\", or \"profile\".",
+            "type": "string",
+            "meta:titleId": "TBD",
+            "meta:descriptionId": "TBD"
+          },
+          "meta:titleId": "TBD",
+          "meta:descriptionId": "TBD"
         },
         "xdm:operation": {
           "title": "Payload of the hygiene op request",


### PR DESCRIPTION
[PLAT-151491](https://jira.corp.adobe.com/browse/PLAT-151491)

Add a new field, `targetProducts`, which is an array of strings intended to contain some subset of `["datalake", "identity", "profile"]`. Products that consume the HygieneOps dataset should ignore batches that contain a `targetProducts` array unless their product name appears in the list.

The contents of the array are represented as a strings, and are not constrained by an enumeration. This will allow new products to be supported later without modifying the XDM.