### PR TITLE
[VA-5978] Make mediaReporting fields not required in xdm schema

### DIFF
--- a/components/datatypes/advertisingpoddetails.example.1.json
+++ b/components/datatypes/advertisingpoddetails.example.1.json
@@ -1,5 +1,4 @@
 {
   "xdm:index": 2,
-  "xdm:offset": 123,
-  "xdm:ID": "123"
+  "xdm:offset": 123
 }

--- a/components/datatypes/advertisingpoddetails.schema.json
+++ b/components/datatypes/advertisingpoddetails.schema.json
@@ -36,7 +36,7 @@
           "description": "The offset of the ad break inside the content, in seconds."
         }
       },
-      "required": ["xdm:index", "xdm:offset", "xdm:ID"]
+      "required": ["xdm:index", "xdm:offset"]
     }
   },
   "allOf": [

--- a/components/datatypes/advertisingpoddetails.schema.json
+++ b/components/datatypes/advertisingpoddetails.schema.json
@@ -36,7 +36,7 @@
           "description": "The offset of the ad break inside the content, in seconds."
         }
       },
-      "required": ["xdm:index", "xdm:offset"]
+      "required": ["xdm:offset"]
     }
   },
   "allOf": [

--- a/components/datatypes/chapterdetails.example.1.json
+++ b/components/datatypes/chapterdetails.example.1.json
@@ -1,8 +1,5 @@
 {
   "xdm:length": 100,
   "xdm:offset": 50,
-  "xdm:index": 2,
-  "xdm:isStarted": false,
-  "xdm:isCompleted": false,
-  "xdm:timePlayed": 70
+  "xdm:index": 2
 }

--- a/components/datatypes/chapterdetails.schema.json
+++ b/components/datatypes/chapterdetails.schema.json
@@ -56,14 +56,7 @@
           "description": "The time spent on the chapter, in seconds."
         }
       },
-      "required": [
-        "xdm:length",
-        "xdm:offset",
-        "xdm:index",
-        "xdm:isStarted",
-        "xdm:isCompleted",
-        "xdm:timePlayed"
-      ]
+      "required": ["xdm:length", "xdm:offset", "xdm:index"]
     }
   },
   "allOf": [

--- a/components/datatypes/mediadetails.example.1.json
+++ b/components/datatypes/mediadetails.example.1.json
@@ -1,7 +1,6 @@
 {
   "xdm:playhead": 831,
   "xdm:sessionDetails": {
-    "xdm:ID": "1482236761294786918253",
     "xdm:name": "123456789",
     "xdm:length": 100,
     "xdm:contentType": "VOD",
@@ -12,22 +11,16 @@
     "xdm:name": "123456789",
     "xdm:length": 100,
     "xdm:podPosition": 1,
-    "xdm:playerName": "playerName",
-    "xdm:isCompleted": false,
-    "xdm:isStarted": false
+    "xdm:playerName": "playerName"
   },
   "xdm:advertisingPodDetails": {
     "xdm:index": 2,
-    "xdm:offset": 123,
-    "xdm:ID": "123"
+    "xdm:offset": 123
   },
   "xdm:chapterDetails": {
     "xdm:length": 100,
     "xdm:offset": 50,
-    "xdm:index": 2,
-    "xdm:isStarted": false,
-    "xdm:isCompleted": false,
-    "xdm:timePlayed": 70
+    "xdm:index": 2
   },
   "xdm:errorDetails": {
     "xdm:name": "errorID",

--- a/components/datatypes/mediadetails.schema.json
+++ b/components/datatypes/mediadetails.schema.json
@@ -13,7 +13,7 @@
   "meta:extensible": true,
   "description": "Media details information.",
   "definitions": {
-    "mediaDetailsCollection": {
+    "mediaDetails": {
       "properties": {
         "xdm:playhead": {
           "title": "Playhead",
@@ -28,7 +28,7 @@
         },
         "xdm:sessionDetails": {
           "title": "Session Details",
-          "$ref": "https://ns.adobe.com/xdm/datatypes/sessionDetails#/definitions/sessionDetailsCommon",
+          "$ref": "https://ns.adobe.com/xdm/datatypes/sessionDetails",
           "description": "Session details information related to the experience event."
         },
         "xdm:advertisingDetails": {
@@ -89,101 +89,11 @@
           "description": "The list of custom metadata."
         }
       }
-    },
-    "mediaDetailsReporting-a": {
-      "properties": {
-        "xdm:playhead": {
-          "title": "Playhead",
-          "type": "integer",
-          "minimum": 0,
-          "description": "If the content is live, the playhead must be the current second of the day, 0 <= playhead < 86400. If the content is recorded, the playhead must be the current second of content, 0 <= playhead < content length."
-        },
-        "xdm:sessionID": {
-          "title": "Media Session ID",
-          "type": "string",
-          "description": "Identifies an instance of a content stream unique to an individual playback."
-        },
-        "xdm:sessionDetails": {
-          "title": "Session Details",
-          "description": "Session details information related to the experience event.",
-          "$ref": "https://ns.adobe.com/xdm/datatypes/sessionDetails#/definitions/sessionDetailsCommon"
-        },
-        "xdm:advertisingDetails": {
-          "title": "Advertising Details",
-          "$ref": "https://ns.adobe.com/xdm/datatypes/advertisingDetails",
-          "description": "Advertising details information related to the experience event."
-        },
-        "xdm:advertisingPodDetails": {
-          "title": "Advertising Pod Details",
-          "$ref": "https://ns.adobe.com/xdm/datatypes/advertisingPodDetails",
-          "description": "Advertising pod details information related to the experience event."
-        },
-        "xdm:chapterDetails": {
-          "title": "Chapter Details",
-          "$ref": "https://ns.adobe.com/xdm/datatypes/chapterDetails",
-          "description": "Chapter details information related to the experience event."
-        },
-        "xdm:errorDetails": {
-          "title": "Error Details",
-          "$ref": "https://ns.adobe.com/xdm/datatypes/errorDetails",
-          "description": "Error details information related to the experience event."
-        },
-        "xdm:qoeDataDetails": {
-          "title": "Qoe Data Details",
-          "$ref": "https://ns.adobe.com/xdm/datatypes/qoeDataDetails",
-          "description": "Qoe data details information related to the experience event."
-        },
-        "xdm:statesStart": {
-          "title": "List Of States Start",
-          "type": "array",
-          "items": {
-            "$ref": "https://ns.adobe.com/xdm/datatypes/playerStateData"
-          },
-          "description": "The list of states start."
-        },
-        "xdm:statesEnd": {
-          "title": "List Of States End",
-          "type": "array",
-          "items": {
-            "$ref": "https://ns.adobe.com/xdm/datatypes/playerStateData"
-          },
-          "description": "The list of states end."
-        },
-        "xdm:states": {
-          "title": "List Of States",
-          "type": "array",
-          "items": {
-            "$ref": "https://ns.adobe.com/xdm/datatypes/playerStateData"
-          },
-          "description": "The list of states."
-        },
-        "xdm:customMetadata": {
-          "title": "The Custom Metadata",
-          "type": "array",
-          "items": {
-            "$ref": "https://ns.adobe.com/xdm/datatypes/customMetadataDetails"
-          },
-          "description": "The list of custom metadata."
-        }
-      }
-    },
-    "mediaDetailsReporting-b": {
-      "xdm:sessionDetails": {
-        "title": "Session Details",
-        "description": "Session details information related to the experience event.",
-        "$ref": "https://ns.adobe.com/xdm/datatypes/sessionDetails#/definitions/sessionDetailsReporting"
-      }
     }
   },
   "allOf": [
     {
-      "$ref": "#/definitions/mediaDetailsCollection"
-    },
-    {
-      "$ref": "#/definitions/mediaDetailsReporting-a"
-    },
-    {
-      "$ref": "#/definitions/mediaDetailsReporting-b"
+      "$ref": "#/definitions/mediaDetails"
     }
   ]
 }

--- a/components/datatypes/mediaevent.example.1.json
+++ b/components/datatypes/mediaevent.example.1.json
@@ -4,7 +4,6 @@
   "xdm:mediaCollection": {
     "xdm:playhead": 831,
     "xdm:sessionDetails": {
-      "xdm:ID": "1482236761294786918253",
       "xdm:name": "123456789",
       "xdm:length": 100,
       "xdm:contentType": "VOD",
@@ -15,22 +14,16 @@
       "xdm:name": "123456789",
       "xdm:length": 100,
       "xdm:podPosition": 1,
-      "xdm:playerName": "playerName",
-      "xdm:isCompleted": false,
-      "xdm:isStarted": false
+      "xdm:playerName": "playerName"
     },
     "xdm:advertisingPodDetails": {
       "xdm:index": 2,
-      "xdm:offset": 123,
-      "xdm:ID": "123"
+      "xdm:offset": 123
     },
     "xdm:chapterDetails": {
       "xdm:length": 100,
       "xdm:offset": 50,
-      "xdm:index": 2,
-      "xdm:isStarted": false,
-      "xdm:isCompleted": false,
-      "xdm:timePlayed": 70
+      "xdm:index": 2
     },
     "xdm:errorDetails": {
       "xdm:name": "errorID",

--- a/components/datatypes/mediaevent.schema.json
+++ b/components/datatypes/mediaevent.schema.json
@@ -17,7 +17,7 @@
       "properties": {
         "xdm:mediaCollection": {
           "title": "Media Details",
-          "$ref": "https://ns.adobe.com/xdm/datatypes/mediaDetails#/definitions/mediaDetailsCollection",
+          "$ref": "https://ns.adobe.com/xdm/datatypes/mediaDetails",
           "description": "Media details information related to the experience event."
         },
         "xdm:mediaEventTimestamp": {

--- a/components/datatypes/sessiondetails.example.1.json
+++ b/components/datatypes/sessiondetails.example.1.json
@@ -1,5 +1,4 @@
 {
-  "xdm:ID": "1482236761294786918253",
   "xdm:name": "123456789",
   "xdm:length": 100,
   "xdm:contentType": "VOD",

--- a/components/datatypes/sessiondetails.schema.json
+++ b/components/datatypes/sessiondetails.schema.json
@@ -13,7 +13,7 @@
   "meta:extensible": true,
   "description": "Session details information.",
   "definitions": {
-    "sessionDetailsCommon": {
+    "sessionDetails": {
       "properties": {
         "xdm:ID": {
           "title": "Media Session ID",
@@ -328,6 +328,11 @@
             "audio": "Audio",
             "audioAd": "Audio Ad"
           }
+        },
+        "xdm:pccr": {
+          "title": "Pccr",
+          "type": "boolean",
+          "description": "Indicates that a redirect occurred."
         }
       },
       "required": [
@@ -337,23 +342,11 @@
         "xdm:playerName",
         "xdm:channel"
       ]
-    },
-    "sessionDetailsReporting": {
-      "properties": {
-        "xdm:pccr": {
-          "title": "Pccr",
-          "type": "boolean",
-          "description": "Indicates that a redirect occurred."
-        }
-      }
     }
   },
   "allOf": [
     {
-      "$ref": "#/definitions/sessionDetailsCommon"
-    },
-    {
-      "$ref": "#/definitions/sessionDetailsReporting"
+      "$ref": "#/definitions/sessionDetails"
     }
   ]
 }

--- a/components/datatypes/sessiondetails.schema.json
+++ b/components/datatypes/sessiondetails.schema.json
@@ -331,7 +331,6 @@
         }
       },
       "required": [
-        "xdm:ID",
         "xdm:name",
         "xdm:length",
         "xdm:contentType",

--- a/components/fieldgroups/experience-event/experienceevent-media-analytics.example.1.json
+++ b/components/fieldgroups/experience-event/experienceevent-media-analytics.example.1.json
@@ -2,7 +2,6 @@
   "xdm:mediaCollection": {
     "xdm:playhead": 831,
     "xdm:sessionDetails": {
-      "xdm:ID": "1482236761294786918253",
       "xdm:name": "123456789",
       "xdm:length": 100,
       "xdm:contentType": "VOD",
@@ -17,16 +16,12 @@
     },
     "xdm:advertisingPodDetails": {
       "xdm:index": 2,
-      "xdm:offset": 123,
-      "xdm:ID": "123"
+      "xdm:offset": 123
     },
     "xdm:chapterDetails": {
       "xdm:length": 100,
       "xdm:offset": 50,
-      "xdm:index": 2,
-      "xdm:isStarted": false,
-      "xdm:isCompleted": false,
-      "xdm:timePlayed": 70
+      "xdm:index": 2
     },
     "xdm:errorDetails": {
       "xdm:name": "errorID",
@@ -51,7 +46,6 @@
   },
   "xdm:mediaReporting": {
     "xdm:sessionDetails": {
-      "xdm:ID": "1482236761294786918253",
       "xdm:name": "123456789",
       "xdm:length": 100,
       "xdm:contentType": "VOD",
@@ -97,7 +91,6 @@
       "xdm:mediaCollection": {
         "xdm:playhead": 0,
         "xdm:sessionDetails": {
-          "xdm:ID": "1482236761294786918253",
           "xdm:name": "123456789",
           "xdm:length": 100,
           "xdm:contentType": "VOD",
@@ -128,10 +121,7 @@
           "xdm:friendlyName": "friendlyName",
           "xdm:length": 100,
           "xdm:offset": 50,
-          "xdm:index": 2,
-          "xdm:isStarted": false,
-          "xdm:isCompleted": false,
-          "xdm:timePlayed": 70
+          "xdm:index": 2
         }
       }
     },
@@ -168,8 +158,7 @@
       "xdm:mediaCollection": {
         "xdm:advertisingPodDetails": {
           "xdm:index": 2,
-          "xdm:offset": 123,
-          "xdm:ID": "123"
+          "xdm:offset": 123
         },
         "xdm:playhead": 30
       }

--- a/components/fieldgroups/experience-event/experienceevent-media-analytics.schema.json
+++ b/components/fieldgroups/experience-event/experienceevent-media-analytics.schema.json
@@ -17,16 +17,16 @@
   "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
   "description": "Track interactions with media.",
   "definitions": {
-    "experienceevent-mediaAnalytics-a": {
+    "experienceevent-mediaAnalytics": {
       "properties": {
         "xdm:mediaCollection": {
           "title": "Media Collection Details",
-          "$ref": "https://ns.adobe.com/xdm/datatypes/mediaDetails#/definitions/mediaDetailsCollection",
+          "$ref": "https://ns.adobe.com/xdm/datatypes/mediaDetails",
           "description": "Media Collection related fields."
         },
         "xdm:mediaReporting": {
           "title": "Media Reporting Details",
-          "$ref": "https://ns.adobe.com/xdm/datatypes/mediaDetails#/definitions/mediaDetailsReporting-a",
+          "$ref": "https://ns.adobe.com/xdm/datatypes/mediaDetails",
           "description": "Media Reporting related fields."
         },
         "xdm:mediaDownloadedEvents": {
@@ -38,23 +38,11 @@
           "description": "The list of media collection downloaded content events."
         }
       }
-    },
-    "experienceevent-mediaAnalytics-b": {
-      "properties": {
-        "xdm:mediaReporting": {
-          "title": "Media Reporting Details",
-          "$ref": "https://ns.adobe.com/xdm/datatypes/mediaDetails#/definitions/mediaDetailsReporting-b",
-          "description": "Media Reporting related fields."
-        }
-      }
     }
   },
   "allOf": [
     {
-      "$ref": "#/definitions/experienceevent-mediaAnalytics-a"
-    },
-    {
-      "$ref": "#/definitions/experienceevent-mediaAnalytics-b"
+      "$ref": "#/definitions/experienceevent-mediaAnalytics"
     }
   ],
   "meta:status": "experimental"


### PR DESCRIPTION
https://github.com/adobe/xdm/issues/1550

In the process of preparing for making our media xdm schemas stable we need the following 2 commits:

Context:
Initially we wanted to make a clear separation between mediaCollection and mediaReporting schemas but unfortunately in order to not duplicate fields we need to use the same datatype (mediaDetails) for both.
We documented the Manage related fields usage in the AEP UI in this particular case such that clients know which fields are used for collection and which for reporting (Set up the schema in Adobe Experience Platform https://experienceleague.adobe.com/docs/media-analytics/using/implementation/implementation-edge.html?lang=en) but we would like to give the clients the possibility of using the schemas without a mandatory step of hiding fields, therefore in this PR we remove the required fields which are used on mediaReporting in our schemas, and only required mediaCollection fields remain.

First commit: 
- from sessionDetails remove the required check for ID because this is mediaReporting only field and clients only complete mediaCollection so if they choose not to hide mediaReporting fields from the schema, they should still be able to send us requests 
- from chapterDetails remove the required check for isStarted, isCompleted, timePlayed because these are mediaReporting only fields and clients only complete mediaCollection so if they choose not to hide mediaReporting fields from the schema, they should still be able to send us requests 
- from advertisingPodDetails remove the required check for ID

Second commit: Reverts https://github.com/adobe/xdm/pull/1716 the extraction of pccr field in only mediaReporting as these changes did not work (the AEP schema UI now does not show the pccr field anywhere not in mediaColecton and not in mediaReporting)
 