### PR TITLE
Adding Direct Mail channel support to Consent schema

### DIFF
--- a/components/datatypes/consent/consent-preferences.schema.json
+++ b/components/datatypes/consent/consent-preferences.schema.json
@@ -315,9 +315,7 @@
         "xdm:directMail": {
           "title": "Receive Direct Mail",
           "description": "User agrees to receive Direct Mail",
-          "$ref": "#/definitions/marketing-field",
-          "meta:titleId": "consents-and-preferences##xdm:sms##title##14821",
-          "meta:descriptionId": "consents-and-preferences##xdm:sms##description##10841"
+          "$ref": "#/definitions/marketing-field"
         }
       },
       "meta:titleId": "consents-and-preferences##base-marketing##title##34441",
@@ -398,9 +396,7 @@
         "xdm:directMail": {
           "title": "Receive Direct Mail",
           "description": "User agrees to receive Direct Mail",
-          "$ref": "#/definitions/marketing-with-subscriptions",
-          "meta:titleId": "consents-and-preferences##xdm:sms##title##68521",
-          "meta:descriptionId": "consents-and-preferences##xdm:sms##description##45961"
+          "$ref": "#/definitions/marketing-with-subscriptions"
         },
         "xdm:call": {
           "title": "Receive calls",
@@ -455,9 +451,7 @@
         "xdm:directMail": {
           "title": "Receive Direct Mail",
           "description": "User agrees to receive Direct Mail",
-          "$ref": "#/definitions/marketing-field",
-          "meta:titleId": "consents-and-preferences##xdm:sms##title##12131",
-          "meta:descriptionId": "consents-and-preferences##xdm:sms##description##16821"
+          "$ref": "#/definitions/marketing-field"
         }
       },
       "meta:titleId": "consents-and-preferences##idSpecific-marketing##title##57411",

--- a/components/datatypes/consent/consent-preferences.schema.json
+++ b/components/datatypes/consent/consent-preferences.schema.json
@@ -232,6 +232,7 @@
             "inHome",
             "iot",
             "social",
+            "directMail",
             "other",
             "none",
             "unknown"

--- a/components/datatypes/consent/consent-preferences.schema.json
+++ b/components/datatypes/consent/consent-preferences.schema.json
@@ -247,6 +247,7 @@
             "inHome": "In-home Messages",
             "iot": "IoT Messages",
             "social": "Social Media",
+            "directMail": "Direct Mail",
             "other": "Other",
             "none": "No Preferred Channel",
             "unknown": "Unknown"
@@ -309,6 +310,13 @@
           "$ref": "#/definitions/marketing-field",
           "meta:titleId": "consents-and-preferences##xdm:sms##title##14821",
           "meta:descriptionId": "consents-and-preferences##xdm:sms##description##10841"
+        },
+        "xdm:directMail": {
+          "title": "Receive Direct Mail",
+          "description": "User agrees to receive Direct Mail",
+          "$ref": "#/definitions/marketing-field",
+          "meta:titleId": "consents-and-preferences##xdm:sms##title##14821",
+          "meta:descriptionId": "consents-and-preferences##xdm:sms##description##10841"
         }
       },
       "meta:titleId": "consents-and-preferences##base-marketing##title##34441",
@@ -334,6 +342,7 @@
             "inHome",
             "iot",
             "social",
+            "directMail",
             "other",
             "none",
             "unknown"
@@ -349,6 +358,7 @@
             "inHome": "In-home Messages",
             "iot": "IoT Messages",
             "social": "Social Media",
+            "directMail": "Direct Mail",
             "other": "Other",
             "none": "No Preferred Channel",
             "unknown": "Unknown"
@@ -380,6 +390,13 @@
         "xdm:sms": {
           "title": "Receive SMS",
           "description": "User agrees to receive text messages",
+          "$ref": "#/definitions/marketing-with-subscriptions",
+          "meta:titleId": "consents-and-preferences##xdm:sms##title##68521",
+          "meta:descriptionId": "consents-and-preferences##xdm:sms##description##45961"
+        },
+        "xdm:directMail": {
+          "title": "Receive Direct Mail",
+          "description": "User agrees to receive Direct Mail",
           "$ref": "#/definitions/marketing-with-subscriptions",
           "meta:titleId": "consents-and-preferences##xdm:sms##title##68521",
           "meta:descriptionId": "consents-and-preferences##xdm:sms##description##45961"
@@ -430,6 +447,13 @@
         "xdm:sms": {
           "title": "Receive SMS",
           "description": "User agrees to receive text messages",
+          "$ref": "#/definitions/marketing-field",
+          "meta:titleId": "consents-and-preferences##xdm:sms##title##12131",
+          "meta:descriptionId": "consents-and-preferences##xdm:sms##description##16821"
+        },
+        "xdm:directMail": {
+          "title": "Receive Direct Mail",
+          "description": "User agrees to receive Direct Mail",
           "$ref": "#/definitions/marketing-field",
           "meta:titleId": "consents-and-preferences##xdm:sms##title##12131",
           "meta:descriptionId": "consents-and-preferences##xdm:sms##description##16821"

--- a/docs/reference/datatypes/consent-preferences.schema.json
+++ b/docs/reference/datatypes/consent-preferences.schema.json
@@ -144,9 +144,10 @@
                                 "inHome",
                                 "iot",
                                 "social",
+                                "directMail",
                                 "other",
                                 "none",
-                                "unknown"
+                                "unknown",
                             ],
                             "meta:enum": {
                                 "email": "email",
@@ -159,6 +160,7 @@
                                 "inHome": "In-home Messages",
                                 "iot": "IoT Messages",
                                 "social": "Social Media",
+                                "directMail": "Direct Mail",
                                 "other": "Other",
                                 "none": "No Preferred Channel",
                                 "unknown": "Unknown"
@@ -182,6 +184,11 @@
                         "xdm:sms": {
                             "title": "Receive SMS",
                             "description": "User agrees to receive text messages",
+                            "$ref": "#/definitions/marketing-fields"
+                        },
+                        "xdm:directMail": {
+                            "title": "Receive Direct Mail",
+                            "description": "User agrees to receive direct mail",
                             "$ref": "#/definitions/marketing-fields"
                         }
                     }

--- a/docs/reference/datatypes/consent-preferences.schema.json
+++ b/docs/reference/datatypes/consent-preferences.schema.json
@@ -147,7 +147,7 @@
                                 "directMail",
                                 "other",
                                 "none",
-                                "unknown",
+                                "unknown"
                             ],
                             "meta:enum": {
                                 "email": "email",

--- a/docs/reference/datatypes/consent-preferences.schema.md
+++ b/docs/reference/datatypes/consent-preferences.schema.md
@@ -160,7 +160,7 @@ User's Direct Marketing Preferences
 | `xdm:preferred`| string | Optional |
 | `xdm:push`|  | Optional |
 | `xdm:sms`|  | Optional |
-
+| `xdm:directMail`|  | Optional |
 
 
 #### xdm:any
@@ -227,6 +227,7 @@ The value of this property **must** be equal to one of the [known values below](
 | `inHome` | In-home Messages |
 | `iot` | IoT Messages |
 | `social` | Social Media |
+| `directMail` | Direct Mail |
 | `other` | Other |
 | `none` | No Preferred Channel |
 | `unknown` | Unknown |
@@ -272,6 +273,22 @@ User agrees to receive text messages
 
 
 
+
+
+
+#### xdm:directMail
+##### Receive Direct Mail
+
+User permits receiving Direct Mail
+
+`xdm:directMail`
+* is optional
+* type: reference
+
+##### xdm:directMail Type
+
+
+* []() – `#/definitions/marketing-fields`
 
 
 

--- a/docs/reference/datatypes/consent/consent-preferences.schema.json
+++ b/docs/reference/datatypes/consent/consent-preferences.schema.json
@@ -257,6 +257,7 @@
                         "inHome",
                         "iot",
                         "social",
+                        "directMail",
                         "other",
                         "none",
                         "unknown"
@@ -272,6 +273,7 @@
                         "inHome": "In-home Messages",
                         "iot": "IoT Messages",
                         "social": "Social Media",
+                        "directMail": "Direct Mail",
                         "other": "Other",
                         "none": "No Preferred Channel",
                         "unknown": "Unknown"
@@ -334,6 +336,11 @@
                     "$ref": "#/definitions/marketing-field",
                     "meta:titleId": "consents-and-preferences##xdm:sms##title##14821",
                     "meta:descriptionId": "consents-and-preferences##xdm:sms##description##10841"
+                },
+                "xdm:directMail": {
+                    "title": "Receive Direct Mail",
+                    "description": "User agrees to receive Direct Mail",
+                    "$ref": "#/definitions/marketing-field"
                 }
             },
             "meta:titleId": "consents-and-preferences##base-marketing##title##34441",
@@ -359,6 +366,7 @@
                         "inHome",
                         "iot",
                         "social",
+                        "directMail",
                         "other",
                         "none",
                         "unknown"
@@ -374,6 +382,7 @@
                         "inHome": "In-home Messages",
                         "iot": "IoT Messages",
                         "social": "Social Media",
+                        "directMail": "Direct Mail",
                         "other": "Other",
                         "none": "No Preferred Channel",
                         "unknown": "Unknown"
@@ -428,7 +437,12 @@
                     "title": "Receive postal mail",
                     "description": "User permits receiving postal mail",
                     "$ref": "#/definitions/marketing-field"
-                }
+                },
+                "xdm:sms": {
+                    "title": "Receive Direct Mail",
+                    "description": "User agrees to receive text messages",
+                    "$ref": "#/definitions/marketing-with-subscriptions",
+                },
             },
             "meta:titleId": "consents-and-preferences##base-marketing-with-subscriptions##title##25111",
             "meta:descriptionId": "consents-and-preferences##base-marketing-with-subscriptions##description##58371"
@@ -458,6 +472,11 @@
                     "$ref": "#/definitions/marketing-field",
                     "meta:titleId": "consents-and-preferences##xdm:sms##title##12131",
                     "meta:descriptionId": "consents-and-preferences##xdm:sms##description##16821"
+                },
+                "xdm:directMail": {
+                    "title": "Receive Direct Mail",
+                    "description": "User agrees to receive Direct Mail",
+                    "$ref": "#/definitions/marketing-field"
                 }
             },
             "meta:titleId": "consents-and-preferences##idSpecific-marketing##title##57411",

--- a/docs/reference/datatypes/consent/consent-preferences.schema.json
+++ b/docs/reference/datatypes/consent/consent-preferences.schema.json
@@ -438,7 +438,7 @@
                     "description": "User permits receiving postal mail",
                     "$ref": "#/definitions/marketing-field"
                 },
-                "xdm:sms": {
+                "xdm:directMail": {
                     "title": "Receive Direct Mail",
                     "description": "User agrees to receive text messages",
                     "$ref": "#/definitions/marketing-with-subscriptions",

--- a/docs/reference/datatypes/consent/consent-preferences.schema.md
+++ b/docs/reference/datatypes/consent/consent-preferences.schema.md
@@ -221,6 +221,7 @@ Sharing of user's data with 2nd or 3rd parties is permitted
 | [xdm:push](#xdmpush) | reference | `https://ns.adobe.com/xdm/datatypes/consents-and-preferences#/definitions/idSpecific-marketing` |
 | [xdm:reason](#xdmreason) | reference | `https://ns.adobe.com/xdm/datatypes/consents-and-preferences#/definitions/marketing-with-subscriptions` |
 | [xdm:sms](#xdmsms) | reference | `https://ns.adobe.com/xdm/datatypes/consents-and-preferences#/definitions/idSpecific-marketing` |
+| [xdm:sms](#xdmdirectMail) | reference | `https://ns.adobe.com/xdm/datatypes/consents-and-preferences#/definitions/idSpecific-marketing` |
 | [xdm:subscriptions](#xdmsubscriptions) | reference | `https://ns.adobe.com/xdm/datatypes/consents-and-preferences#/definitions/marketing-with-subscriptions` |
 | [xdm:time](#xdmtime) | `string` | `https://ns.adobe.com/xdm/datatypes/consents-and-preferences#/definitions/metadata` |
 | [xdm:val](#xdmval) | reference | `https://ns.adobe.com/xdm/datatypes/consents-and-preferences#/definitions/marketing-with-subscriptions` |
@@ -379,6 +380,28 @@ User permits receiving postal mail
 
 
 
+
+
+
+## xdm:directMail
+### Receive Direct Mail
+
+User permits receiving Direct Mail
+
+`xdm:directMail`
+* is optional
+* type: reference
+* defined in this schema
+
+### xdm:directMail Type
+
+
+* []() – `#/definitions/marketing-field`
+
+
+
+
+
 ## xdm:preferred
 ### Preferred Channel
 
@@ -404,6 +427,7 @@ The value of this property **must** be equal to one of the [known values below](
 | `inHome` | In-home Messages |
 | `iot` | IoT Messages |
 | `social` | Social Media |
+| `directMail` | Direct Mail |
 | `other` | Other |
 | `none` | No Preferred Channel |
 | `unknown` | Unknown |


### PR DESCRIPTION
Please link to the issue #…
Adding Direct Mail channel support to Consent schema #1751
[XDM-1751  Adding Direct Mail channel support to Consent schema
](https://github.com/adobe/xdm/issues/1751)
