### PR TITLE
CJM-50240: Add domain field in message profile mixin.

### DIFF
--- a/extensions/adobe/experience/customerJourneyManagement/messageprofile.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/messageprofile.example.1.json
@@ -1,5 +1,5 @@
 {
-  "https://ns.adobe.com/experience/customerJourneyManagement/messageProfile/messageProfileID": "4218b775-bef3-46b2-aee2-7caae052cf94",
+  "https://ns.adobe.com/experience/customerJourneyManagement/messageProfile/messageProfileID": "4218b775-bef3-46b2-aee2-7caae052cf95",
   "https://ns.adobe.com/experience/customerJourneyManagement/messageProfile/channel": {
     "@id": "https://ns.adobe.com/xdm/channels/email"
   },

--- a/extensions/adobe/experience/customerJourneyManagement/messageprofile.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/messageprofile.example.1.json
@@ -8,5 +8,6 @@
   "https://ns.adobe.com/experience/customerJourneyManagement/messageProfile/isTestExecution": false,
   "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/address": "user@domain.com",
   "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/namespace": "Email",
-  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/outboundIP": "52.247.77.92"
+  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/outboundIP": "52.247.77.92",
+  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/domain": "domain.com"
 }

--- a/extensions/adobe/experience/customerJourneyManagement/messageprofile.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/messageprofile.schema.json
@@ -69,6 +69,11 @@
           "meta:titleId": "messageprofile##https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/outboundIP##title##99731",
           "meta:descriptionId": "messageprofile##https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/outboundIP##description##75691"
         },
+        "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/domain": {
+          "title": "Domain",
+          "type": "string",
+          "description": "Domain of the recipient's email address."
+        },
         "https://ns.adobe.com/experience/customerJourneyManagement/pushChannelContext/platform": {
           "title": "Push Platform",
           "type": "string",


### PR DESCRIPTION
**JIRA:**

- https://jira.corp.adobe.com/browse/CJM-50240

**Description**
This field is being added to provide a breakdown of open and click events at the domain level, as required for AJO reporting.

More details can be found in this [wiki](https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=CJM&title=Supporting+Device+and+Domain+for+Open+and+Click+Tracking+Events).