### PR TITLE
Commerce scoping cleanup

### DIFF
--- a/components/datatypes/commercescope.example.1.json
+++ b/components/datatypes/commercescope.example.1.json
@@ -1,4 +1,6 @@
 {
   "xdm:environmentID": "27a15179-5545-4d23-e654-1b4ac0b42bd3",
-  "xdm:websiteCode": "base"
+  "xdm:websiteCode": "base",
+  "xdm:storeCode": "main_website_store",
+  "xdm:storeViewCode": "default"
 }

--- a/components/datatypes/commercescope.schema.json
+++ b/components/datatypes/commercescope.schema.json
@@ -42,5 +42,5 @@
       "$ref": "#/definitions/commerce-scope"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/datatypes/marketing/commerce.example.1.json
+++ b/components/datatypes/marketing/commerce.example.1.json
@@ -1,5 +1,5 @@
 {
-  "xdm:order": {
+    "xdm:order": {
     "xdm:purchaseID": "a8g784hjq1mnp3",
     "xdm:purchaseOrderNumber": "123456",
     "xdm:payments": [
@@ -25,5 +25,11 @@
   "xdm:shipping": {
     "xdm:shippingAmount": 20.0,
     "xdm:shippingMethod": "standard ground"
+  },
+  "xdm:commerceScope": {
+    "xdm:environment": "27a15179-5545-4d23-e654-1b4ac0b42bd3",
+    "xdm:website": "base",
+    "xdm:store": "main_website_store",
+    "xdm:storeView": "default"
   }
 }

--- a/components/datatypes/marketing/commerce.example.1.json
+++ b/components/datatypes/marketing/commerce.example.1.json
@@ -1,5 +1,5 @@
 {
-    "xdm:order": {
+  "xdm:order": {
     "xdm:purchaseID": "a8g784hjq1mnp3",
     "xdm:purchaseOrderNumber": "123456",
     "xdm:payments": [


### PR DESCRIPTION
Adding example fields back in from when [previous PR](https://github.com/adobe/xdm/pull/1738) required [workaround](https://github.com/adobe/xdm/pull/1747); stabilizing
