### PR TITLE
[MINOR] Delete unused media event types from meta enum

### DIFF
--- a/components/behaviors/time-series.schema.json
+++ b/components/behaviors/time-series.schema.json
@@ -120,11 +120,6 @@
             "media.sessionEnd": "Media sessionEnd",
             "media.statesUpdate": "Media statesUpdate",
             "media.downloaded": "Media downloaded content",
-            "media.reporting.sessionStart": "Media reporting sessionStart",
-            "media.reporting.sessionClose": "Media reporting sessionClose",
-            "media.reporting.adStart": "Media reporting adStart",
-            "media.reporting.adClose": "Media reporting adClose",
-            "media.reporting.chapterClose": "Media reporting chapterClose",
             "location.entry": "Location entry",
             "location.exit": "Location exit"
           },


### PR DESCRIPTION
Issue link: https://github.com/adobe/xdm/issues/1550

This is just a cleanup PR for meta:enum values in the eventType field that we do not use. Please review and merge whenever possible.
