### PR TITLE
Add privacyDelete and privacyAccess actions to HygieneOps original PR: #1787

### DIFF
--- a/schemas/hygiene/aep-hygiene-ops-record.schema.json
+++ b/schemas/hygiene/aep-hygiene-ops-record.schema.json
@@ -27,12 +27,19 @@
           "title": "Name of the hygiene operation to be applied by downstream consumers",
           "description": "Name of the hygiene operation to be applied by downstream consumers.",
           "type": "string",
-          "enum": ["deleteIdentity", "updateField"],
+          "enum": [
+            "deleteIdentity",
+            "updateField",
+            "privacyDelete",
+            "privacyAccess"
+          ],
           "meta:titleId": "aep-hygiene-ops##xdm:action##title##96551",
           "meta:descriptionId": "aep-hygiene-ops##xdm:action##description##71821",
           "meta:enum": {
             "deleteIdentity": "Delete Identity",
-            "updateField": "Update Field"
+            "updateField": "Update Field",
+            "privacyDelete": "Identity Delete Request Inititiated by Privacy Service",
+            "privacyAccess": "Data Access Request Inititiated by Privacy Service"
           }
         },
         "xdm:targetDatasetID": {
@@ -75,7 +82,6 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "additionalProperties": false,
                     "properties": {
                       "xdm:namespace": {
                         "title": "The identity namespace",
@@ -122,10 +128,194 @@
               },
               "meta:titleId": "aep-hygiene-ops##xdm:updateField##title##65571",
               "meta:descriptionId": "aep-hygiene-ops##xdm:updateField##description##2691"
+            },
+            "xdm:privacyDelete": {
+              "title": "Privacy Delete Request",
+              "description": "Represents data-subject requests to have their data deleted",
+              "type": "object",
+              "properties": {
+                "xdm:identities": {
+                  "title": "Set of identities",
+                  "description": "Set of identities whose data must be deleted",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "xdm:namespace": {
+                        "title": "The identity namespace",
+                        "description": "The namespace associated with the xdm:id attribute.",
+                        "$ref": "https://ns.adobe.com/xdm/context/namespace"
+                      },
+                      "xdm:ID": {
+                        "title": "Identifier",
+                        "description": "An identifier belonging to the namespace",
+                        "type": "string"
+                      },
+                      "xdm:jobID": {
+                        "title": "Privacy Service Job ID for tracking purposes.",
+                        "description": "An identifier assigned by Privacy Service for the purpose of tracking and reporting of customer requests.",
+                        "type": "string"
+                      },
+                      "xdm:dataSets": {
+                        "title": "Applicable Datasets",
+                        "description": "Datasets that might contain this identity",
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "xdm:datasetId": {
+                              "title": "Dataset ID",
+                              "description": "The ID of a dataset",
+                              "type": "string"
+                            },
+                            "xdm:searchFields": {
+                              "title": "Search Fields",
+                              "description": "Fields of the dataset that store values of the target namespace",
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "xdm:fieldName": {
+                                    "title": "Field Name",
+                                    "description": "A field name of the dataset",
+                                    "type": "string"
+                                  },
+                                  "xdm:values": {
+                                    "title": "Search Values",
+                                    "description": "Values to be sought in this field of the dataset",
+                                    "type": "array",
+                                    "items": {
+                                      "title": "Search Value",
+                                      "description": "A value to be sought in this field of the dataset",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "xdm:sandboxId": {
+                              "title": "Sandbox ID",
+                              "description": "ID of the sandbox containing these datasets",
+                              "type": "string"
+                            },
+                            "xdm:sandboxName": {
+                              "title": "Sandbox Name",
+                              "description": "Name of the sandbox containing these datasets",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "xdm:privacyAccess": {
+              "title": "Privacy Data Access Request",
+              "description": "Represents data-subject requests for data stored about them",
+              "type": "object",
+              "properties": {
+                "xdm:identities": {
+                  "title": "Set of identities",
+                  "description": "Set of identities whose data must be retrieved",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "xdm:namespace": {
+                        "title": "The identity namespace",
+                        "description": "The namespace associated with the xdm:id attribute.",
+                        "$ref": "https://ns.adobe.com/xdm/context/namespace"
+                      },
+                      "xdm:ID": {
+                        "title": "Identifier",
+                        "description": "An identifier belonging to the namespace",
+                        "type": "string"
+                      },
+                      "xdm:jobID": {
+                        "title": "Privacy Service Job ID for tracking purposes.",
+                        "description": "An identifier assigned by Privacy Service for the purpose of tracking and reporting of customer requests.",
+                        "type": "string"
+                      },
+                      "xdm:attachmentInfo": {
+                        "title": "Attachment Information",
+                        "description": "Information about where to upload retrieved user data",
+                        "type": "object",
+                        "properties": {
+                          "xdm:region": {
+                            "title": "Region",
+                            "description": "Datacenter region for data upload",
+                            "type": "string"
+                          },
+                          "xdm:containerName": {
+                            "title": "Container Name",
+                            "description": "Datacenter blob container for data upload",
+                            "type": "string"
+                          },
+                          "xdm:uploadPath": {
+                            "title": "Upload Path",
+                            "description": "Pathname of folder for data upload",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "xdm:dataSets": {
+                        "title": "Applicable Datasets",
+                        "description": "Datasets that might contain this identity",
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "xdm:datasetId": {
+                              "title": "Dataset ID",
+                              "description": "The ID of a dataset",
+                              "type": "string"
+                            },
+                            "xdm:searchFields": {
+                              "title": "Search Fields",
+                              "description": "Fields of the dataset that store values of the target namespace",
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "xdm:fieldName": {
+                                    "title": "Field Name",
+                                    "description": "A field name of the dataset",
+                                    "type": "string"
+                                  },
+                                  "xdm:values": {
+                                    "title": "Search Values",
+                                    "description": "Values to be sought in this field of the dataset",
+                                    "type": "array",
+                                    "items": {
+                                      "title": "Search Value",
+                                      "description": "A value to be sought in this field of the dataset",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "xdm:sandboxId": {
+                              "title": "Sandbox ID",
+                              "description": "ID of the sandbox containing these datasets",
+                              "type": "string"
+                            },
+                            "xdm:sandboxName": {
+                              "title": "Sandbox Name",
+                              "description": "Name of the sandbox containing these datasets",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
-          },
-          "meta:titleId": "aep-hygiene-ops##xdm:operation##title##23961",
-          "meta:descriptionId": "aep-hygiene-ops##xdm:operation##description##80191"
+          }
         }
       }
     }


### PR DESCRIPTION
Add new actions to the HygieneOps dataset to support Privacy Service operations.

https://jira.corp.adobe.com/browse/PLAT-170201 "XDM: Update Hygiene Ops Schema to Support Privacy Access"
https://jira.corp.adobe.com/browse/PLAT-170199 "XDM: Update Hygiene Ops Schema to Support Privacy Delete"