### PR TITLE
Adding min & max for ProcessingTimeMS

### DIFF
--- a/extensions/adobe/experience/journeyOrchestration/stepEvents/journeyStepEventCommonFieldsMixin.schema.json
+++ b/extensions/adobe/experience/journeyOrchestration/stepEvents/journeyStepEventCommonFieldsMixin.schema.json
@@ -218,7 +218,9 @@
               "type": "integer",
               "meta:xdmType": "long",
               "meta:titleId": "journeyStepEventCommonFields##https://ns.adobe.com/experience/journeyOrchestration/processingTime##title##30461",
-              "meta:descriptionId": "journeyStepEventCommonFields##https://ns.adobe.com/experience/journeyOrchestration/processingTime##description##73591"
+              "meta:descriptionId": "journeyStepEventCommonFields##https://ns.adobe.com/experience/journeyOrchestration/processingTime##description##73591",
+              "maximum": 9223372036854775807,
+              "minimum": -9223372036854775808
             },
             "https://ns.adobe.com/experience/journeyOrchestration/instanceType": {
               "title": "instanceType",


### PR DESCRIPTION
ProcessingTimeMS is of type int and meta:xdmType as long. Since it does not have minimum and maximum defined, it uses int type's min and max. In order for it to have min and max of Long, it have to be explicitly added.  Reference - https://experienceleague.adobe.com/docs/experience-platform/xdm/schema/field-constraints.html?lang=en

Please link to the issue #…
