### PR TITLE
[PDCL-11518] - Change sunsetTime type to a date-time formatted string

### DIFF
--- a/components/fieldgroups/shared/current-weather.example.1.json
+++ b/components/fieldgroups/shared/current-weather.example.1.json
@@ -64,7 +64,7 @@
         "xdm:kilometersPerHour": 15,
         "xdm:milesPerHour": 9
       },
-      "xdm:sunsetTime": 1660324163
+      "xdm:sunsetTime": "2022-07-14T02:28:15.000Z"
     }
   }
 }

--- a/components/fieldgroups/shared/current-weather.schema.json
+++ b/components/fieldgroups/shared/current-weather.schema.json
@@ -124,7 +124,8 @@
                   "$ref": "#/definitions/speed"
                 },
                 "xdm:sunsetTime": {
-                  "type": "integer",
+                  "type": "string",
+                  "format": "date-time",
                   "description": "Sunset time in UTC.",
                   "title": "Sunset Time"
                 }


### PR DESCRIPTION
The `sunsetTime` field of the `currentWeather` fieldset must be a date-time formatted string.
