### PR TITLE
feat: add implementation details on experienceeevent-content field group

### DIFF
--- a/components/fieldgroups/experience-event/experienceevent-content.example.1.json
+++ b/components/fieldgroups/experience-event/experienceevent-content.example.1.json
@@ -8,5 +8,10 @@
       "https://domain.com/media/asset1.jpg",
       "https://domain.com/media/asset2.png"
     ]
+  },
+  "xdm:implementationDetails": {
+    "xdm:name": "https://ns.adobe.com/experience/alloy/reactor",
+    "xdm:version": "2.19.2+2.21.4",
+    "xdm:environment": "browser"
   }
 }

--- a/components/fieldgroups/experience-event/experienceevent-content.schema.json
+++ b/components/fieldgroups/experience-event/experienceevent-content.schema.json
@@ -58,6 +58,9 @@
   "allOf": [
     {
       "$ref": "#/definitions/experienceevent-content"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/context/experienceevent-implementation-details"
     }
   ],
   "meta:status": "experimental"


### PR DESCRIPTION
Need for capturing alloy/tags implementations.
