### PR TITLE
[Issue #1818] Mark descriptorTimeSeriesGranularity as stable and add optional timezone property

### DIFF
--- a/schemas/descriptors/time-series/descriptorTimeSeriesGranularity.example.1.json
+++ b/schemas/descriptors/time-series/descriptorTimeSeriesGranularity.example.1.json
@@ -2,5 +2,6 @@
   "@type": "xdm:descriptorTimeSeriesGranularity",
   "xdm:sourceSchema": "https://ns.adobe.com/tenant/myIMSid/12343aasd4321",
   "xdm:sourceVersion": 1,
-  "xdm:granularity": "day"
+  "xdm:granularity": "day",
+  "xdm:ianaTimezone": "America/Detroit"
 }

--- a/schemas/descriptors/time-series/descriptorTimeSeriesGranularity.schema.json
+++ b/schemas/descriptors/time-series/descriptorTimeSeriesGranularity.schema.json
@@ -34,6 +34,11 @@
           },
           "meta:titleId": "descriptorTimeSeriesGranularity##xdm:granularity##title##56551",
           "meta:descriptionId": "descriptorTimeSeriesGranularity##xdm:granularity##description##79851"
+        },
+        "xdm:ianaTimezone": {
+          "title": "Iana Timezone",
+          "type": "string",
+          "description": "Timezone of the time-series / summary data as a standard timezone string. https://en.wikipedia.org/wiki/List_of_tz_database_time_zones. The default is UTC."
         }
       },
       "required": ["xdm:granularity"]
@@ -47,7 +52,7 @@
       "$ref": "#/definitions/descriptorTimeSeriesGranularity"
     }
   ],
-  "meta:status": "experimental",
+  "meta:status": "stable",
   "meta:createdDate": "2022-03-28",
   "meta:titleId": "descriptorTimeSeriesGranularity##title##26941",
   "meta:descriptionId": "descriptorTimeSeriesGranularity##description##51361"


### PR DESCRIPTION
This is for issue #1818 

The timezone was added the same way as Place Context that is used in Experience Events:
https://github.com/adobe/xdm/blob/43bf2a1e7e0657621d392307ca9a2a1ce7948665/components/datatypes/placecontext.schema.json#L25
