### PR TITLE
Add "tokens" string array to _experience.decisioning.propositionAction object

### DIFF
--- a/extensions/adobe/experience/decisioning/proposition-action.schema.json
+++ b/extensions/adobe/experience/decisioning/proposition-action.schema.json
@@ -26,6 +26,14 @@
           "title": "label",
           "description": "The customer generated display name of the element with which the end-user interacted.",
           "type": "string"
+        },
+        "xdm:tokens": {
+          "title": "tokens",
+          "type": "array",
+          "description": "Application-generated metadata associated with the element with which the end-user interacted.",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }


### PR DESCRIPTION

Please link to the issue #1826 

The tokens are required for AJO Inbound decision item tracking.
