### PR TITLE
ACSS-53716 adding exitCriteriaID and exitCriteriaName fields 

### DIFF
--- a/extensions/adobe/experience/journeyOrchestration/stepEvents/journeyStepEventCommonFieldsMixin.schema.json
+++ b/extensions/adobe/experience/journeyOrchestration/stepEvents/journeyStepEventCommonFieldsMixin.schema.json
@@ -50,6 +50,16 @@
               "description": "If the journey is a read segment journey, the current step event indicates that the the segment export process has been initiated.",
               "type": "boolean"
             },
+            "https://ns.adobe.com/experience/journeyOrchestration/exitCriteriaID": {
+              "title": "exitCriteriaID",
+              "description": "ID of exit criteria",
+              "type": "string"
+            },
+            "https://ns.adobe.com/experience/journeyOrchestration/exitCriteriaName": {
+              "title": "exitCriteriaName",
+              "description": "Name of exit criteria",
+              "type": "string"
+            },
             "https://ns.adobe.com/experience/journeyOrchestration/origSegmentQualificationStatus": {
               "title": "origSegmentQualificationStatus",
               "description": "Indicates original Segment Qualification Status. Possible values can be: existing, realized, exited",


### PR DESCRIPTION
Adding exitCriteriaID and exitCriteriaName to step events schema

Please link to the issue #…
[#1835](https://github.com/adobe/xdm/issues/1835)

