### PR TITLE
Make Marketo Engage Person Details extension stable.

### DIFF
--- a/extensions/adobe/b2b/marketo/marketo-engage-person-details.schema.json
+++ b/extensions/adobe/b2b/marketo/marketo-engage-person-details.schema.json
@@ -32,5 +32,5 @@
       "$ref": "#/definitions/marketo-engage-person-details"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }


### PR DESCRIPTION
This change is to make the extension added as part of #1795 stable to be available to all customers.
