### PR TITLE
add trackedURL in decisioningAsset for ExD decision item

### DIFF
--- a/extensions/adobe/experience/decisioning/decisioning-asset.example.2.json
+++ b/extensions/adobe/experience/decisioning/decisioning-asset.example.2.json
@@ -1,0 +1,7 @@
+{
+  "xdm:repository": "aem",
+  "xdm:type": "image",
+  "xdm:sourceURL": "http://cdn.com/myimage.png",
+  "xdm:destinationURL": "http://ecommerce.com/product",
+  "xdm:trackedURL": "http://tracker-host/?tuid=1234"
+}

--- a/extensions/adobe/experience/decisioning/decisioning-asset.schema.json
+++ b/extensions/adobe/experience/decisioning/decisioning-asset.schema.json
@@ -44,6 +44,11 @@
           "title": "destinationURL",
           "type": "string",
           "description": "certain assets like images can have a destination, when clicked upon. eg) http://ecommerce.com/product"
+        },
+        "xdm:trackedURL": {
+          "title": "trackedURL",
+          "type": "string",
+          "description": "tracked URL of destination URL. This field would be set by the decisioning system to track click on destination URL."
         }
       }
     }


### PR DESCRIPTION
JIRA

https://jira.corp.adobe.com/browse/CJM-84815

Description
This change is to add trackedURL in decisioningAsset field for decision item schema.

Wiki Reference

https://wiki.corp.adobe.com/pages/viewpage.action?pageId=3127593930#ExDemaildeliveryinAJO-Instrumentation/Reportingsupport