### PR TITLE
feature-1958 Add decision policy entity details to AJO entity record schema

### DIFF
--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
@@ -33,6 +33,29 @@
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/experimentName": "Hero page experiment",
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/treatmentName": "The first treatment"
   },
+  "https://ns.adobe.com/experience/customerJourneyManagement/entities/DecisionPolicy": [
+    {
+      "https://ns.adobe.com/experience/customerJourneyManagement/entities/decisionPolicyId": "123-456-789-c",
+      "https://ns.adobe.com/experience/customerJourneyManagement/entities/decisionPolicyName": "Decision Policy",
+      "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitions": [
+        {
+          "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionId": "node-67890",
+          "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionName": "US Residents",
+          "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionType": "ELIGIBILITY_RULE"
+        },
+        {
+          "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionId": "node-54321",
+          "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionName": "California Experiment",
+          "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionType": "EXPERIMENTATION"
+        },
+        {
+          "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionId": "node-67890",
+          "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionName": "Treatment B",
+          "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionType": "TREATMENT"
+        }
+      ]
+    }
+  ],
   "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey": {
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyVersionID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyName": "Marketing Test Journey",

--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
@@ -181,17 +181,17 @@
                     "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionId": {
                       "title": "Transition Id",
                       "type": "string",
-                      "description": "Decision Node id"
+                      "description": "Transition Node id"
                     },
                     "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionName": {
                       "title": "Transition Name",
                       "type": "string",
-                      "description": "Decision Node Name"
+                      "description": "Transition Node Name"
                     },
                     "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionType": {
                       "title": "Transition Type",
                       "type": "string",
-                      "description": "Decision Node Type"
+                      "description": "Transition Node Type"
                     }
                   }
                 }

--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
@@ -164,6 +164,51 @@
             }
           }
         },
+        "https://ns.adobe.com/experience/customerJourneyManagement/entities/DecisionPolicy": {
+          "title": "AJO Decision Policy Entity",
+          "type": "array",
+          "description": "AJO Decision Policy Entity Specific Fields",
+          "items": {
+            "type": "object",
+            "properties": {
+              "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitions": {
+                "title": "Transition",
+                "type": "array",
+                "description": "Transition Specific Fields",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionId": {
+                      "title": "Transition Id",
+                      "type": "string",
+                      "description": "Decision Node id"
+                    },
+                    "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionName": {
+                      "title": "Transition Name",
+                      "type": "string",
+                      "description": "Decision Node Name"
+                    },
+                    "https://ns.adobe.com/experience/customerJourneyManagement/entities/transitionType": {
+                      "title": "Transition Type",
+                      "type": "string",
+                      "description": "Decision Node Type"
+                    }
+                  }
+                }
+              },
+              "https://ns.adobe.com/experience/customerJourneyManagement/entities/decisionPolicyId": {
+                "title": "Decision Policy Id",
+                "type": "string",
+                "description": "Decision Policy Id"
+              },
+              "https://ns.adobe.com/experience/customerJourneyManagement/entities/decisionPolicyName": {
+                "title": "Decision Policy Name",
+                "type": "string",
+                "description": "Decision Policy Name"
+              }
+            }
+          }
+        },
         "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey": {
           "title": "AJO Journey Entity",
           "type": "object",


### PR DESCRIPTION
Please link to the issue #1958 
[Add decision policy entity details to AJO entity record](https://github.com/adobe/xdm/issues/1958)