### PR TITLE
[VA-7257] add field group for media scheduled programs

### DIFF
--- a/components/datatypes/mediaevent.schema.json
+++ b/components/datatypes/mediaevent.schema.json
@@ -48,7 +48,8 @@
             "media.error": "Media error",
             "media.sessionComplete": "Media sessionComplete",
             "media.sessionEnd": "Media sessionEnd",
-            "media.statesUpdate": "Media statesUpdate"
+            "media.statesUpdate": "Media statesUpdate",
+            "media.scheduleStart": "Media scheduleStart"
           }
         }
       }

--- a/components/datatypes/mediaprogramdetails.example.1.json
+++ b/components/datatypes/mediaprogramdetails.example.1.json
@@ -1,0 +1,5 @@
+{
+  "xdm:name": "Program Name",
+  "xdm:length": 3600,
+  "xdm:startTimestamp": "2025-01-01T23:30:00Z"
+}

--- a/components/datatypes/mediaprogramdetails.schema.json
+++ b/components/datatypes/mediaprogramdetails.schema.json
@@ -1,0 +1,43 @@
+{
+  "meta:license": [
+    "Copyright 2025 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/datatypes/mediaProgramDetails",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Media Program Details information",
+  "type": "object",
+  "meta:status": "experimental",
+  "meta:extensible": true,
+  "description": "Media Program Details information.",
+  "definitions": {
+    "mediaProgramDetails": {
+      "properties": {
+        "xdm:name": {
+          "title": "Content Name",
+          "type": "string",
+          "description": "This is the “friendly” (human-readable) name of the content. It will be used to create a Media Event of type ScheduleData with this value as friendly name."
+        },
+        "xdm:length": {
+          "title": "Media Content Length",
+          "type": "integer",
+          "description": "Program Length - This is the length (or duration) of the program (in seconds)."
+        },
+        "xdm:startTimestamp": {
+          "title": "Timestamp of the Start of the Program",
+          "type": "string",
+          "format": "date-time",
+          "description": "The time when a program was started."
+        }
+      },
+      "required": ["xdm:name", "xdm:length", "xdm:startTimestamp"]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/mediaProgramDetails"
+    }
+  ]
+}

--- a/components/datatypes/sessiondetails.schema.json
+++ b/components/datatypes/sessiondetails.schema.json
@@ -245,6 +245,11 @@
           "type": "integer",
           "description": "Describes the total amount of time spent by a user on a specific timed media asset, which includes time spent watching ads."
         },
+        "xdm:scheduleTimePlayed": {
+          "title": "Schedule Time Played",
+          "type": "integer",
+          "description": "Sums the event duration (in seconds) for all events of type PLAY on the main content for the scheduled program."
+        },
         "xdm:uniqueTimePlayed": {
           "title": "Unique Time Played",
           "type": "integer",

--- a/components/fieldgroups/tv-schedule/media-analytics-scheduled-program.example.1.json
+++ b/components/fieldgroups/tv-schedule/media-analytics-scheduled-program.example.1.json
@@ -1,0 +1,49 @@
+{
+  "xdm:scheduleDate": "2025-01-02",
+  "xdm:mediaProgramDetails": {
+    "xdm:name": "Program Name",
+    "xdm:length": 3600,
+    "xdm:startTimestamp": "2025-01-01T23:30:00Z"
+  },
+  "xdm:defaultMetadata": {
+    "xdm:show": "Show Name",
+    "xdm:season": "Season 1",
+    "xdm:episode": "Episode 1",
+    "xdm:assetID": "Asset ID",
+    "xdm:genreList": ["comedy", "romance"],
+    "xdm:firstAirDate": "2025-01-01",
+    "xdm:firstDigitalDate": "2025-01-01",
+    "xdm:rating": "TV-PG",
+    "xdm:originator": "Content Creator",
+    "xdm:network": "Network Name",
+    "xdm:showType": "full episode",
+    "xdm:dayPart": "primetime",
+    "xdm:feed": "EAST HD",
+    "xdm:streamFormat": "HD",
+    "xdm:artist": "Artist Name",
+    "xdm:album": "Album Name",
+    "xdm:label": "Record Label",
+    "xdm:author": "Media Author",
+    "xdm:station": "Radio Station Name",
+    "xdm:publisher": "Content Publisher",
+    "xdm:cdn": "Content Delivery Network"
+  },
+  "xdm:customMetadata": [
+    {
+      "xdm:name": "customName",
+      "xdm:value": "test1"
+    },
+    {
+      "xdm:name": "test2",
+      "xdm:value": "customValue"
+    },
+    {
+      "xdm:name": "test3",
+      "xdm:value": "customValue"
+    }
+  ],
+  "xdm:scheduleFilter": {
+    "xdm:filterPath": "xdm.mediaReporting.sessionDetails.channel",
+    "xdm:filterValue": "channel"
+  }
+}

--- a/components/fieldgroups/tv-schedule/media-analytics-scheduled-program.schema.json
+++ b/components/fieldgroups/tv-schedule/media-analytics-scheduled-program.schema.json
@@ -1,0 +1,189 @@
+{
+  "meta:license": [
+    "Copyright 2025 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/mixins/media-analytics-scheduled-program",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "MediaAnalytics Scheduled Program Details ",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:tags": {
+    "industry": ["all"]
+  },
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/data/record"],
+  "description": "Track media scheduled program information.",
+  "definitions": {
+    "mediaAnalyticsScheduledProgram": {
+      "properties": {
+        "xdm:scheduleDate": {
+          "title": "The date of the schedule event",
+          "type": "string",
+          "format": "date",
+          "description": "The date when a program was scheduled."
+        },
+        "xdm:mediaProgramDetails": {
+          "title": "Media Program Details",
+          "$ref": "https://ns.adobe.com/xdm/datatypes/mediaProgramDetails",
+          "description": "Media Program related fields."
+        },
+        "xdm:defaultMetadata": {
+          "title": "The Default Metadata",
+          "type": "object",
+          "properties": {
+            "xdm:show": {
+              "title": "Series Name",
+              "type": "string",
+              "description": "Program/Series Name. Program Name is required only if the show is part of a series."
+            },
+            "xdm:season": {
+              "title": "Season Number",
+              "type": "string",
+              "description": "The season number the show belongs to. Season Series is required only if the show is part of a series."
+            },
+            "xdm:episode": {
+              "title": "Episode Number",
+              "type": "string",
+              "description": "The number of the episode."
+            },
+            "xdm:assetID": {
+              "title": "Asset ID",
+              "type": "string",
+              "description": "This is the unique identifier for the content of the media asset, such as the TV series episode identifier, movie asset identifier, or live event identifier. Typically these IDs are derived from metadata authorities such as EIDR, TMS/Gracenote, or Rovi. These identifiers can also be from other proprietary or in-house systems."
+            },
+            "xdm:genreList": {
+              "title": "Genre List",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Type or grouping of content as defined by content producer. Field represents the comma separated values provided in the genre field."
+            },
+            "xdm:firstAirDate": {
+              "title": "First Air Date",
+              "type": "string",
+              "description": "The date when the content first aired on television. Any date format is acceptable, but Adobe recommends: YYYY-MM-DD."
+            },
+            "xdm:firstDigitalDate": {
+              "title": "First Digital Date",
+              "type": "string",
+              "description": "The date when the content first aired on any digital channel or platform. Any date format is acceptable but Adobe recommends: YYYY-MM-DD."
+            },
+            "xdm:rating": {
+              "title": "Rating Value",
+              "type": "string",
+              "description": "Rating as defined by TV Parental Guidelines."
+            },
+            "xdm:originator": {
+              "title": "Creator Name",
+              "type": "string",
+              "description": "Creator of the content."
+            },
+            "xdm:network": {
+              "title": "Broadcast Network",
+              "type": "string",
+              "description": "The network/channel name."
+            },
+            "xdm:showType": {
+              "title": "Show Type",
+              "type": "string",
+              "description": "The type of content for example, trailer or full episode."
+            },
+            "xdm:dayPart": {
+              "title": "Day Part",
+              "type": "string",
+              "description": "A property that defines the time of the day when the content was broadcast or played. This could have any value set as necessary by customers."
+            },
+            "xdm:feed": {
+              "title": "Feed Type",
+              "type": "string",
+              "description": "The type of feed, which can either represent actual feed-related data such as  EAST HD or SD, or the source of the feed like a URL."
+            },
+            "xdm:streamFormat": {
+              "title": "Stream Format",
+              "type": "string",
+              "description": "Format of the stream (HD, SD)."
+            },
+            "xdm:artist": {
+              "title": "Artist",
+              "type": "string",
+              "description": "The name of the album artist or group performing the music recording or video."
+            },
+            "xdm:album": {
+              "title": "Album",
+              "type": "string",
+              "description": "The name of the album that the music recording or video belongs to."
+            },
+            "xdm:label": {
+              "title": "Record Label",
+              "type": "string",
+              "description": "Name of the record label."
+            },
+            "xdm:author": {
+              "title": "Author",
+              "type": "string",
+              "description": "Name of the media author."
+            },
+            "xdm:station": {
+              "title": "Radio Station",
+              "type": "string",
+              "description": "The radio station name on which the audio is played."
+            },
+            "xdm:publisher": {
+              "title": "Publisher",
+              "type": "string",
+              "description": "Name of the audio content publisher."
+            },
+            "xdm:cdn": {
+              "title": "Content Delivery Network",
+              "type": "string",
+              "description": "The content delivery network of the content played."
+            }
+          },
+          "description": "The scheduled program default metadata that will be used to overwrite the default metadata of the generated media events."
+        },
+        "xdm:customMetadata": {
+          "title": "The Custom Metadata",
+          "type": "array",
+          "items": {
+            "$ref": "https://ns.adobe.com/xdm/datatypes/customMetadataDetails"
+          },
+          "description": "The list of custom metadata."
+        },
+        "xdm:scheduleFilter": {
+          "title": "The Schedule Filter",
+          "type": "object",
+          "description": "The schedule filter is used to filter the media events in order to create schedule events.",
+          "properties": {
+            "xdm:filterPath": {
+              "title": "The filter path",
+              "type": "string",
+              "description": "The xdm path of the property used to filter media events"
+            },
+            "xdm:filterValue": {
+              "title": "The filter value",
+              "type": "string",
+              "description": "The value of the property used to filter media events"
+            }
+          }
+        }
+      },
+      "required": [
+        "xdm:scheduleDate",
+        "xdm:mediaProgramDetails",
+        "xdm:defaultMetadata",
+        "xdm:customMetadata",
+        "xdm:scheduleFilter"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/mediaAnalyticsScheduledProgram"
+    }
+  ],
+  "meta:status": "experimental"
+}


### PR DESCRIPTION
Added a new record schema for tv scheduled programs. 
Added new media event type for schedule program starts.  
Issue  #1984
