### PR TITLE
[CORE-130800] Define XDM mixin for trait membership

### DIFF
--- a/components/datatypes/traitmembership.example.1.json
+++ b/components/datatypes/traitmembership.example.1.json
@@ -1,0 +1,4 @@
+{
+  "xdm:lastQualificationTime": "2024-06-11T23:53:43.000Z",
+  "xdm:validUntil": "2024-07-11"
+}

--- a/components/datatypes/traitmembership.schema.json
+++ b/components/datatypes/traitmembership.schema.json
@@ -1,0 +1,40 @@
+{
+  "meta:license": [
+    "Copyright 2025 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/datatypes/traitMembership",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Trait Membership Details",
+  "type": "object",
+  "meta:status": "experimental",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "description": "Details about trait membership for a profile, including qualification time and expiration information.",
+  "definitions": {
+    "traitMembership": {
+      "properties": {
+        "xdm:lastQualificationTime": {
+          "title": "Last Qualification Time",
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp when the profile last qualified for this trait."
+        },
+        "xdm:validUntil": {
+          "title": "Valid Until Date",
+          "type": "string",
+          "format": "date",
+          "description": "The date until which the trait membership is valid. Used for expiration tracking with day-level granularity."
+        }
+      },
+      "required": ["xdm:lastQualificationTime", "xdm:validUntil"]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/traitMembership"
+    }
+  ]
+}

--- a/components/fieldgroups/profile/profile-trait-membership.example.1.json
+++ b/components/fieldgroups/profile/profile-trait-membership.example.1.json
@@ -1,0 +1,17 @@
+{
+  "xdm:traitMembership": {
+    "ed2de91d-07de-4f39-bc8a-6cd2cd615c20": {
+      "xdm:lastQualificationTime": "2024-06-11T23:53:43.000Z",
+      "xdm:validUntil": "2024-07-11"
+    },
+    "f47ac10b-58cc-4372-a567-0e02b2c3d479": {
+      "xdm:lastQualificationTime": "2024-06-10T15:30:00.000Z",
+      "xdm:validUntil": "2024-07-10"
+    },
+    "eb7578c0-e53f-4696-821d-ce8be32a6ea4": {
+      "xdm:lastQualificationTime": "2024-06-12T08:45:12.000Z",
+      "xdm:validUntil": "2024-07-12"
+    }
+  },
+  "xdm:__system__traitMembership": "AQADZwZ-wwADAAIAAAADAAAAAACBgYAAAAAAAPfe8Q=="
+}

--- a/components/fieldgroups/profile/profile-trait-membership.schema.json
+++ b/components/fieldgroups/profile/profile-trait-membership.schema.json
@@ -1,0 +1,45 @@
+{
+  "meta:license": [
+    "Copyright 2025 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/context/profile-trait-membership",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Profile Trait Membership",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/profile"],
+  "description": "Trait membership information such as including which active traits the profile belongs to, the last qualification time, and when the membership is valid until.",
+  "definitions": {
+    "profile-trait-membership": {
+      "properties": {
+        "xdm:traitMembership": {
+          "title": "Trait Membership",
+          "type": "object",
+          "meta:xdmType": "map",
+          "description": "Map of trait IDs to their membership details. Each key is a trait ID, and the value contains qualification and expiration information.",
+          "additionalProperties": {
+            "$ref": "https://ns.adobe.com/xdm/datatypes/traitMembership"
+          }
+        },
+        "xdm:__system__traitMembership": {
+          "title": "System Trait Membership",
+          "type": "string",
+          "description": "Binary encoded system representation of trait membership for optimized storage and processing. This field is managed by the system and contains compressed trait membership data."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "#/definitions/profile-trait-membership"
+    }
+  ],
+  "meta:status": "experimental"
+}


### PR DESCRIPTION
This PR resolves #1990.
Internal JIRA task: https://jira.corp.adobe.com/browse/CORE-130800.

## Overview

This PR adds a new XDM field group for trait membership functionality.

## Changes Made

### New Schema Files Added:

1. **`components/datatypes/traitmembership.schema.json`**
   - Defines the trait membership datatype with required qualification time and expiration date
   - Includes `xdm:lastQualificationTime` and `xdm:validUntil` fields (both required)

2. **`components/datatypes/traitmembership.example.1.json`**
   - Provides example usage of the trait membership datatype
   - Demonstrates both qualification time and expiration date

3. **`components/fieldgroups/profile/profile-trait-membership.schema.json`**
   - Extends XDM Profile with trait membership capabilities
   - Includes `xdm:traitMembership` map for human-readable trait membership
   - Includes `xdm:__system__traitMembership` binary field for system optimization

4. **`components/fieldgroups/profile/profile-trait-membership.example.1.json`**
   - Demonstrates usage with multiple traits
   - Shows real-world examples with qualification and expiration dates
