### PR TITLE
CJM-104481 Add email attachment metadata fields to messageprofile schema

### DIFF
--- a/extensions/adobe/experience/customerJourneyManagement/messageProfile.example.3.json
+++ b/extensions/adobe/experience/customerJourneyManagement/messageProfile.example.3.json
@@ -1,0 +1,16 @@
+{
+  "https://ns.adobe.com/experience/customerJourneyManagement/messageProfile/messageProfileID": "4218b775-bef3-46b2-aee2-7caae052cf95",
+  "https://ns.adobe.com/experience/customerJourneyManagement/messageProfile/messageProfileTrackingID": "3218b775-bef3-46b2-aee2-7caae052cf96",
+  "https://ns.adobe.com/experience/customerJourneyManagement/messageProfile/channel": {
+    "@id": "https://ns.adobe.com/xdm/channels/email"
+  },
+  "https://ns.adobe.com/experience/customerJourneyManagement/messageProfile/variant": "A",
+  "https://ns.adobe.com/experience/customerJourneyManagement/messageProfile/isSendTimeOptimized": true,
+  "https://ns.adobe.com/experience/customerJourneyManagement/messageProfile/isTestExecution": false,
+  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/address": "user@domain.com",
+  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/namespace": "Email",
+  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/outboundIP": "52.247.77.92",
+  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/domain": "domain.com",
+  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/attachmentCount": 1,
+  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/totalAttachmentSize": 1048576
+}

--- a/extensions/adobe/experience/customerJourneyManagement/messageprofile.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/messageprofile.schema.json
@@ -81,6 +81,17 @@
           "type": "string",
           "description": "Domain of the recipient's email address."
         },
+        "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/attachmentCount": {
+          "title": "Attachment Count",
+          "type": "integer",
+          "description": "Number of attachments in the email message.",
+          "minimum": 0
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/totalAttachmentSize": {
+          "title": "Total Attachment Size",
+          "type": "integer",
+          "description": "Total size of all attachments in bytes."
+        },
         "https://ns.adobe.com/experience/customerJourneyManagement/pushChannelContext/platform": {
           "title": "Push Platform",
           "type": "string",


### PR DESCRIPTION
## Summary
Add email attachment metadata tracking fields to the messageprofile XDM schema to enable monitoring of email attachments in Customer Journey Management.

## Changes Made
- **Added `attachmentCount` field** to `emailChannelContext`
  - Type: `integer` with `minimum: 0`
  - Tracks the number of attachments in an email message
  
- **Added `totalAttachmentSize` field** to `emailChannelContext`
  - Type: `integer` 
  - Tracks total size of all attachments in bytes

- **Added example file** (`messageprofile.example.3.json`)
  - Demonstrates usage of attachment fields
  - Shows email with 1 attachments totaling 1MB

## Design Decisions
- **Direct Integration**: Fields added directly to `emailChannelContext` following existing schema patterns
- **Optional Fields**: Both fields are optional to maintain backward compatibility

## Testing
- ✅ XDM schema validation passes
- ✅ All existing tests continue to pass
- ✅ New example validates correctly
- ✅ Backward compatibility maintained

## Examples
**Without attachments (existing behavior):**
```json
{
  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/address": "user@domain.com",
  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/domain": "domain.com"
}
```

**With attachments (new capability):**
```json
{
  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/address": "user@domain.com",
  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/domain": "domain.com",
  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/attachmentCount": 1,
  "https://ns.adobe.com/experience/customerJourneyManagement/emailChannelContext/totalAttachmentSize": 1048576
}
```
