### PR TITLE
[VA-7404] Relax Media Analytics XDM required fields

### DIFF
--- a/components/datatypes/advertisingdetails.schema.json
+++ b/components/datatypes/advertisingdetails.schema.json
@@ -89,12 +89,7 @@
           "description": "The total amount of time, in seconds, spent watching the ad (i.e., the number of seconds played)."
         }
       },
-      "required": [
-        "xdm:name",
-        "xdm:length",
-        "xdm:podPosition",
-        "xdm:playerName"
-      ]
+      "required": ["xdm:name", "xdm:length", "xdm:podPosition"]
     }
   },
   "allOf": [

--- a/components/datatypes/sessiondetails.schema.json
+++ b/components/datatypes/sessiondetails.schema.json
@@ -348,13 +348,7 @@
           "description": "Indicates that a redirect occurred."
         }
       },
-      "required": [
-        "xdm:name",
-        "xdm:length",
-        "xdm:contentType",
-        "xdm:playerName",
-        "xdm:channel"
-      ]
+      "required": ["xdm:name", "xdm:length", "xdm:contentType"]
     }
   },
   "allOf": [


### PR DESCRIPTION
Issue [VA-7404](https://jira.corp.adobe.com/browse/VA-7404)

Currently, Media Analytics requires the following XDM fields for sessiondetails:

xdm:name
xdm:length
xdm:contentType
xdm:playerName
xdm:channel
And for advertisingdetails:

xdm:name
xdm:length
xdm:podPosition
xdm:playerName
However, since clients use Adobe Data Collection (ADC) to transfer data from Adobe Analytics to Adobe Experience Platform (AEP), not all of these fields are required in Adobe Analytics. As a result, some events are being dropped due to missing required fields.

After analyzing Splunk logs, we identified that the following fields are frequently missing in client implementations:

sessiondetails.playerName
sessiondetails.channel
advertisingdetails.playerName
You can view the full Splunk results here: https://adobe.sharepoint.com/:x:/r/sites/MediaAnalyticsADCmigration/Shared%20Documents/Missing%20XDM%20required%20fields.xlsx?d=w5455bb7ddd15463882a1fefeccdba5ee&csf=1&web=1&e=wRxdvU

To improve compatibility and reduce dropped events, we propose relaxing the requirement for the following fields:

sessiondetails.playerName
sessiondetails.channel
advertisingdetails.playerName
The following fields will remain required, as they are essential for accurate analytics:

sessiondetails.length
advertisingdetails.podPosition
advertisingdetails.length
Additionally, the following fields were consistently populated in our analysis and will not be removed:

sessiondetails.contentType
sessiondetails.name
advertisingdetails.name