### PR TITLE
[AN-389108] Expand experienceevent-stitching field group applicability to additional schema classes

### DIFF
--- a/components/fieldgroups/experience-event/experienceevent-stitching.schema.json
+++ b/components/fieldgroups/experience-event/experienceevent-stitching.schema.json
@@ -14,7 +14,10 @@
   "meta:tags": {
     "industry": ["all"]
   },
-  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
+  "meta:intendedToExtend": [
+    "https://ns.adobe.com/xdm/context/experienceevent",
+    "https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journeyStepEvent"
+  ],
   "description": "Values computed by the Stitching service, which are meant to provide a more accurate customer journey.",
   "definitions": {
     "experienceevent-stitching": {


### PR DESCRIPTION
This PR updates the experienceevent-stitching field group (https://ns.adobe.com/xdm/context/experienceevent-stitching) to allow its use with additional XDM schema classes.

Supported schema classes:
- https://ns.adobe.com/xdm/context/experienceevent
- https://ns.adobe.com/experience/journeyOrchestration/stepEvents/journeyStepEvent

Solves this issue: #1999 
