### PR TITLE
Additional fields to support dynamic capping threshold

### DIFF
--- a/extensions/adobe/experience/decisioning/offerItem.example.3.json
+++ b/extensions/adobe/experience/decisioning/offerItem.example.3.json
@@ -1,0 +1,25 @@
+{
+  "https://ns.adobe.com/experience/decisioning/offeritem/lifecycleStatus": "draft",
+  "https://ns.adobe.com/experience/decisioning/offeritem/frequencyCappingConstraints": [
+    {
+      "xdm:scope": "global",
+      "xdm:events": ["decisioning"],
+      "xdm:repeat": {
+        "xdm:enabled": true,
+        "xdm:unit": "week",
+        "xdm:unitCount": 2
+      },
+      "xdm:dynamicCappingThresholdEnabled": true,
+      "xdm:dynamicCappingThresholdQuery": "elsData.`ds-id`.cappingThreshold"
+    }
+  ],
+  "xdm:contentReferences": {
+    "xdm:contentReferencesMap": {
+      "mobile": {
+        "xdm:id": "fragment_12345",
+        "xdm:source": "ajo",
+        "xdm:type": "HTML"
+      }
+    }
+  }
+}

--- a/extensions/adobe/experience/decisioning/offerItem.schema.json
+++ b/extensions/adobe/experience/decisioning/offerItem.schema.json
@@ -114,6 +114,17 @@
                     "default": 1
                   }
                 }
+              },
+              "xdm:dynamicCappingThresholdEnabled": {
+                "title": "Toggle for Static or Dynamic Capping Threshold",
+                "description": "If set to true, PQL query will be used to determine the capping threshold. The UI will not show limit field when this is enabled and will show a text box to enter PQL query.",
+                "type": "boolean",
+                "default": false
+              },
+              "xdm:dynamicCappingThresholdQuery": {
+                "title": "PQL Query for Dynamic Capping Threshold",
+                "description": "PQL query to determine the capping threshold.",
+                "type": "string"
               }
             },
             "required": ["xdm:limit", "xdm:scope"]


### PR DESCRIPTION
We currently support frequency capping using a static threshold to limit offers. However, there is a new requirement to support a dynamic capping threshold that utilizes a PQL rule to determine its value. This request comes from Universal Studios, which wants to leverage ELS to provide the dynamic threshold capping value from a specified dataset.

This PR introduced new fields to support dynamic capping threshold for Offeritem.
JIRA : https://jira.corp.adobe.com/browse/CJM-102540
