### PR TITLE
Added additional fields for support for Adobe Advertising Measurement…

### DIFF
--- a/extensions/adobe/experience/adcloud/conversiondetails.example.1.json
+++ b/extensions/adobe/experience/adcloud/conversiondetails.example.1.json
@@ -1,0 +1,10 @@
+{
+  "xdm:trackingCode": "222222|333333|1",
+  "xdm:matchingIds": "aaaaaaa|bbbbbbb|cccccc|20250809889:s",
+  "xdm:conversionProperties": {
+     {
+         "xdm:id": "7656467",
+         "xdm:data": "purchase"
+     }
+  }
+}

--- a/extensions/adobe/experience/adcloud/conversiondetails.schema.json
+++ b/extensions/adobe/experience/adcloud/conversiondetails.schema.json
@@ -13,6 +13,16 @@
   "definitions": {
     "conversiondetails": {
       "properties": {
+	"xdm:trackingCode": {
+	  "title": "Conversion Tracking Code",
+          "type": "string",
+	  "description": "Campaign and Ad details of a conversion.",
+	},
+	"xdm:trackingIdentities": {
+          "title": "Conversion tracking identity details",
+          "type": "string",
+          "description": "Tracking identity details for a conversion.",
+        },
         "xdm:conversionProperties": {
           "type": "object",
           "description": "List of Conversion Property Map.",


### PR DESCRIPTION
…. The existing field group "Adobe Advertising Cloud ExperienceEvent Full Extension" will be updated with 2 additional fields at _experience->adcloud->conversionDetails . Below are the fields

    1. xdm:trackingCode : stores the Conversion Tracking Code and string type
    2. xdm:trackingIdentities : Conversion tracking identity details

    ARC document : https://wiki.corp.adobe.com/display/EfficientFrontier/Adobe+Advertising+and+Experience+Edge+Integration
    ARC Ticket   : https://jira.corp.adobe.com/browse/DXARB-800

Please link to the issue #… https://jira.corp.adobe.com/browse/AMO-170375
