### PR TITLE
[VA-7501] Add XDM field to identify ingestion source for Media Analytics data

### DIFF
--- a/components/datatypes/sessiondetails.schema.json
+++ b/components/datatypes/sessiondetails.schema.json
@@ -346,6 +346,11 @@
           "title": "Pccr",
           "type": "boolean",
           "description": "Indicates that a redirect occurred."
+        },
+        "xdm:dataIngestionSource": {
+          "title": "Data Ingestion Source",
+          "type": "string",
+          "description": "Indicates the method or channel through which the data was ingested into Adobe Experience Platform."
         }
       },
       "required": ["xdm:name", "xdm:length", "xdm:contentType"]


### PR DESCRIPTION

Context:
In Customer Journey Analytics (CJA), all events include a timestamp that reflects when the event actually occurred. The Concurrent Viewers panel relies on this timestamp to generate accurate reports.

In contrast, Adobe Analytics does not timestamp all hits at the moment they occur. Instead, the timestamp is assigned by the Analytics collection layer when the hit is received. To correct for this delay, the SSLC parameter is used. This parameter represents the number of seconds between when the media event occurred and when it was received by Analytics. The value of SSLC ranges from 0 to 600 seconds (10 minutes), with 600 indicating a session timeout. 

Problem:
When data is pushed from Analytics to CJA via Adobe Data Connector (ADC), the timestamp used on the experience events is the one set by the Analytics collection layer—not the actual event time. Since CJA does not apply the SSLC correction, the Concurrent Viewers panel displays inaccurate data for these events.

Solution:
We will introduce a new XDM field under the mediaReporting path to indicate the source of the ingested row. (Example: mediaReporting.sessiondetails. dataIngestionSource = ADC)