### PR TITLE
Adding referringSource to channel details for OOTB click-thru tracking

### DIFF
--- a/components/datatypes/channels/channel.schema.json
+++ b/components/datatypes/channels/channel.schema.json
@@ -124,6 +124,11 @@
           },
           "description": "The types of locations (virtual places) that this channel consists of and can deliver content to.",
           "meta:descriptionId": "channel##xdm:locationTypes##description##91781"
+        },
+        "xdm:referringSource": {
+          "title": "Referring Source",
+          "description": "Referring source to this channel",
+          "type": "string"
         }
       }
     }

--- a/components/fieldgroups/experience-event/experienceevent-channel.example.1.json
+++ b/components/fieldgroups/experience-event/experienceevent-channel.example.1.json
@@ -1,6 +1,7 @@
 {
   "xdm:channel": {
     "@id": "https://ns.adobe.com/xdm/channels/apns",
-    "@type": "https://ns.adobe.com/xdm/channel-types/mobile"
+    "@type": "https://ns.adobe.com/xdm/channel-types/mobile",
+    "xdm:referringSource": "source1"
   }
 }


### PR DESCRIPTION
This is for BRANDCON-1985 & AN-397475
We want to create a standard for referring source that we will use for OOTB Brand Concierge click-through tracking.  A WebSDK tag will be added that will automatically grab whatever is in the page URL source query-string param and store it in this location in the ExperienceEvent.