### PR TITLE
feat: Add lifecycle event tracking to live chat schema

### DIFF
--- a/components/fieldgroups/experience-event/events/engaged-with-representative-in-concierge.example.1.json
+++ b/components/fieldgroups/experience-event/events/engaged-with-representative-in-concierge.example.1.json
@@ -1,30 +1,14 @@
 {
+  "xdm:eventType": "engagement.business.representative.concierge",
+  "@id": "event-abc123-initiated",
+  "xdm:timestamp": "2025-01-15T10:00:00Z",
   "xdm:engagement": {
     "xdm:businessRepresentativeInConcierge": {
-      "xdm:businessRepresentativeDetails": {
-        "xdm:businessRepresentativeID": "rep-789",
-        "xdm:businessRepresentativeEmail": "rep.jane.doe@example.com",
-        "xdm:businessRepresentativeName": "Jane Doe"
-      },
       "xdm:conciergeConversationDetails": {
-        "xdm:status": "Completed",
-        "xdm:summary": "Client discussed enterprise pricing options.",
-        "xdm:transcript": "Client: Can I get pricing for 500+, Yes, let me send a quote.",
-        "xdm:discussedTopics": [
-          "Enterprise Pricing",
-          "Bulk Licensing"
-        ]
-      },
-      "xdm:conciergeDetails": {
-        "xdm:conciergeID": "concierge-1234",
-        "xdm:conciergeName": "Enterprise Sales Concierge",
-        "xdm:pageURL": "https://example.com/contact/concierge"
-      },
-      "xdm:conciergeKey": {
-        "xdm:sourceType": "SalesPortal",
-        "xdm:sourceInstanceID": "portal-instance-01",
-        "xdm:sourceID": "source-9988",
-        "xdm:sourceKey": "SalesPortal|portal-instance-01|source-9988"
+        "xdm:sessionID": "session-abc123",
+        "xdm:status": "INITIATED",
+        "xdm:initiatedAt": "2025-01-15T10:00:00Z",
+        "xdm:notifiedAgents": ["agent1@adobe.com", "agent2@adobe.com"]
       }
     }
   }

--- a/components/fieldgroups/experience-event/events/engaged-with-representative-in-concierge.example.2.json
+++ b/components/fieldgroups/experience-event/events/engaged-with-representative-in-concierge.example.2.json
@@ -1,0 +1,22 @@
+{
+  "xdm:eventType": "engagement.business.representative.concierge",
+  "@id": "event-abc123-accepted",
+  "xdm:timestamp": "2025-01-15T10:00:45Z",
+  "xdm:engagement": {
+    "xdm:businessRepresentativeInConcierge": {
+      "xdm:businessRepresentativeDetails": {
+        "xdm:businessRepresentativeID": "agent1@adobe.com",
+        "xdm:businessRepresentativeName": "John Doe",
+        "xdm:businessRepresentativeEmail": "agent1@adobe.com"
+      },
+      "xdm:conciergeConversationDetails": {
+        "xdm:sessionID": "session-abc123",
+        "xdm:status": "ACCEPTED",
+        "xdm:initiatedAt": "2025-01-15T10:00:00Z",
+        "xdm:notifiedAgents": ["agent1@adobe.com", "agent2@adobe.com"],
+        "xdm:acceptedAt": "2025-01-15T10:00:45Z"
+      }
+    }
+  }
+}
+

--- a/components/fieldgroups/experience-event/events/engaged-with-representative-in-concierge.example.3.json
+++ b/components/fieldgroups/experience-event/events/engaged-with-representative-in-concierge.example.3.json
@@ -1,0 +1,27 @@
+{
+  "xdm:eventType": "engagement.business.representative.concierge",
+  "@id": "event-abc123-completed",
+  "xdm:timestamp": "2025-01-15T10:15:30Z",
+  "xdm:engagement": {
+    "xdm:businessRepresentativeInConcierge": {
+      "xdm:businessRepresentativeDetails": {
+        "xdm:businessRepresentativeID": "agent1@adobe.com",
+        "xdm:businessRepresentativeName": "John Doe",
+        "xdm:businessRepresentativeEmail": "agent1@adobe.com"
+      },
+      "xdm:conciergeConversationDetails": {
+        "xdm:sessionID": "session-abc123",
+        "xdm:status": "COMPLETED_BY_AGENT",
+        "xdm:initiatedAt": "2025-01-15T10:00:00Z",
+        "xdm:notifiedAgents": ["agent1@adobe.com", "agent2@adobe.com"],
+        "xdm:acceptedAt": "2025-01-15T10:00:45Z",
+        "xdm:completedAt": "2025-01-15T10:15:30Z",
+        "xdm:completedBy": "AGENT",
+        "xdm:summary": "Customer inquired about product pricing and features",
+        "xdm:transcriptURL": "https://experience.adobe.com/transcript/session-abc123",
+        "xdm:discussedTopics": ["Pricing", "Features", "Integration"]
+      }
+    }
+  }
+}
+

--- a/components/fieldgroups/experience-event/events/engaged-with-representative-in-concierge.schema.json
+++ b/components/fieldgroups/experience-event/events/engaged-with-representative-in-concierge.schema.json
@@ -17,7 +17,7 @@
   "meta:intendedToExtend": [
     "https://ns.adobe.com/xdm/context/experienceevent"
   ],
-  "description": "Engaged with a business representative through Concierge in the Conversation.",
+  "description": "Engaged with a business representative through Concierge in the Conversation. Supports lifecycle tracking with multiple events per session (INITIATED, ACCEPTED, COMPLETED, MISSED).",
   "definitions": {
     "engagewithbusinessrepresentativeinconcierge": {
       "properties": {
@@ -54,10 +54,74 @@
                   "title": "Concierge Session Details",
                   "type": "object",
                   "properties": {
+                    "xdm:sessionID": {
+                      "title": "Session ID",
+                      "type": "string",
+                      "description": "Unique identifier for the session. Used to link lifecycle events (INITIATED → ACCEPTED → COMPLETED/MISSED)."
+                    },
                     "xdm:status": {
                       "title": "Status",
                       "type": "string",
-                      "description": "The status of the Concierge session"
+                      "description": "Current lifecycle status of the session.",
+                      "enum": [
+                        "INITIATED",
+                        "ACCEPTED",
+                        "COMPLETED_BY_AGENT",
+                        "COMPLETED_BY_VISITOR",
+                        "MISSED",
+                        "EXPIRED"
+                      ],
+                      "meta:enum": {
+                        "INITIATED": "Visitor requested chat, agents notified",
+                        "ACCEPTED": "Agent accepted the request",
+                        "COMPLETED_BY_AGENT": "Agent ended the chat",
+                        "COMPLETED_BY_VISITOR": "Visitor ended the chat",
+                        "MISSED": "No agent accepted within timeout",
+                        "EXPIRED": "Session timed out due to inactivity"
+                      }
+                    },
+                    "xdm:initiatedAt": {
+                      "title": "Initiated At",
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "ISO 8601 timestamp when the session was initiated by the visitor."
+                    },
+                    "xdm:notifiedAgents": {
+                      "title": "Notified Agents",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "List of business representative IDs who were notified about this session."
+                    },
+                    "xdm:acceptedAt": {
+                      "title": "Accepted At",
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "ISO 8601 timestamp when an agent accepted the session. Used to calculate response time."
+                    },
+                    "xdm:completedAt": {
+                      "title": "Completed At",
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "ISO 8601 timestamp when the session was completed or marked as missed."
+                    },
+                    "xdm:completedBy": {
+                      "title": "Completed By",
+                      "type": "string",
+                      "description": "Entity that ended the session.",
+                      "enum": ["AGENT", "VISITOR", "SYSTEM"],
+                      "meta:enum": {
+                        "AGENT": "Session ended by the agent",
+                        "VISITOR": "Session ended by the visitor",
+                        "SYSTEM": "Session ended automatically (timeout/error)"
+                      }
+                    },
+                    "xdm:transcriptURL": {
+                      "title": "Transcript URL",
+                      "type": "string",
+                      "format": "uri",
+                      "description": "URL to access the full session transcript."
                     },
                     "xdm:summary": {
                       "title": "Summary",


### PR DESCRIPTION
- Added sessionID field to link multiple events per session
- Enhanced status field with enum values (INITIATED, ACCEPTED, COMPLETED, MISSED)
- Added timestamp fields: initiatedAt, acceptedAt, completedAt
- Added notifiedAgents array for agent attribution
- Added completedBy enum to track who ended the session
- Added transcriptURL for external transcript storage

Enables agent performance analytics as per BRANDCON-1420

Fixes #2055

Please link to the issue # https://github.com/adobe/xdm/issues/2055 
