### PR TITLE
CJM-120557 Add business rule details in message-delivery-feedback schema

### DIFF
--- a/extensions/adobe/experience/customerJourneyManagement/message-delivery-feedback.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/message-delivery-feedback.schema.json
@@ -68,15 +68,19 @@
             "type": "object",
             "description": "Ruleset information for message exclusion.",
             "properties": {
-              "https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/ID": {
-                "title": "ID",
+              "https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/rulesetID": {
+                "title": "Ruleset ID",
                 "type": "string",
-                "description": "Ruleset ID."
+                "description": "Unique identifier of the ruleset.",
+                "meta:titleId": "message-delivery-feedback##https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/rulesetID##title##12345",
+                "meta:descriptionId": "message-delivery-feedback##https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/rulesetID##description##67890"
               },
-              "https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/name": {
-                "title": "Name",
+              "https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/rulesetName": {
+                "title": "Ruleset Name",
                 "type": "string",
-                "description": "Ruleset name."
+                "description": "Name of the ruleset.",
+                "meta:titleId": "message-delivery-feedback##https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/rulesetName##title##23456",
+                "meta:descriptionId": "message-delivery-feedback##https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/rulesetName##description##78901"
               },
               "https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/rules": {
                 "title": "Rules",
@@ -85,20 +89,27 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/ID": {
-                      "title": "ID",
+                    "https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/ruleID": {
+                      "title": "Rule ID",
                       "type": "string",
-                      "description": "Rule ID."
+                      "description": "Unique identifier of the rule.",
+                      "meta:titleId": "message-delivery-feedback##https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/ruleID##title##34567",
+                      "meta:descriptionId": "message-delivery-feedback##https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/ruleID##description##89012"
                     },
-                    "https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/name": {
-                      "title": "Name",
+                    "https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/ruleName": {
+                      "title": "Rule Name",
                       "type": "string",
-                      "description": "Rule name."
+                      "description": "Name of the rule.",
+                      "meta:titleId": "message-delivery-feedback##https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/ruleName##title##45678",
+                      "meta:descriptionId": "message-delivery-feedback##https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/ruleName##description##90123"
                     }
                   }
                 }
               }
             },
+            "meta:titleId": "message-delivery-feedback##https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/ruleset##title##56789",
+            "meta:descriptionId": "message-delivery-feedback##https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/ruleset##description##12340"
+          },
           "meta:titleId": "message-delivery-feedback##https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/messageExclusion##title##32491"
         },
         "https://ns.adobe.com/experience/customerJourneyManagement/messageDeliveryfeedback/messageFailure": {


### PR DESCRIPTION
Add Business Rules details in message-delivery-feedback event. When an exclusion happens due to a rule, we need to capture its details and propagate it to be used in reporting.

Jira: https://jira.corp.adobe.com/browse/CJM-120557
Wiki: https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=CJM&title=Reporting+Improvement+For+Business+Rules

**Fields Added**
1. Rule Set - It contains ruleset id, name and the details of the rules
2. Rue - It contains id and name of the rules which caused the exclusion