### PR TITLE
[CORE-150798] Mark traitMembership XDM field group as 'stable'

### DIFF
--- a/components/datatypes/traitmembership.schema.json
+++ b/components/datatypes/traitmembership.schema.json
@@ -9,7 +9,7 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Trait Membership Details",
   "type": "object",
-  "meta:status": "experimental",
+  "meta:status": "stable",
   "meta:extensible": true,
   "meta:abstract": true,
   "description": "Details about trait membership for a profile, including qualification time and expiration information.",

--- a/components/fieldgroups/profile/profile-trait-membership.schema.json
+++ b/components/fieldgroups/profile/profile-trait-membership.schema.json
@@ -41,5 +41,5 @@
       "$ref": "#/definitions/profile-trait-membership"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }


### PR DESCRIPTION
This PR resolves #2108.
Internal JIRA task: https://jira.corp.adobe.com/browse/CORE-150798.

## Overview

This PR marks the XDM field group for trait membership as 'stable'.

## Changes made
Changed `meta:status` from `experimental` to `stable`.