### PR TITLE
Adding more fields to Loyalty Profile field group (CJM-115123)

### DIFF
--- a/components/fieldgroups/profile/profile-loyalty-details.example.2.json
+++ b/components/fieldgroups/profile/profile-loyalty-details.example.2.json
@@ -6,7 +6,7 @@
     "xdm:status": "active",
     "xdm:tier": "silver",
     "xdm:tierExpiryDate": "2025-12-31T23:59:59Z",
-    "xdm:upgradeDate": "2022-07-01T10:00:00Z",
+    "xdm:tierUpgradeDate": "2022-07-01T10:00:00Z",
     "xdm:points": 8974,
     "xdm:pointsRedeemed": 5148,
     "xdm:adjustedPoints": 50,

--- a/components/fieldgroups/profile/profile-loyalty-details.example.3.json
+++ b/components/fieldgroups/profile/profile-loyalty-details.example.3.json
@@ -1,0 +1,108 @@
+{
+  "xdm:loyalty": {
+    "xdm:joinDate": "2019-03-12T14:22:00Z",
+    "xdm:loyaltyID": ["NRD-LOY-7K2M9P"],
+    "xdm:program": "Nordhaven Rewards",
+    "xdm:status": "active",
+    "xdm:tier": "Gold",
+    "xdm:nextTier": "Platinum",
+    "xdm:pointsToNextTier": 4200,
+    "xdm:tierUpgradeDate": "2024-11-02T09:15:30Z",
+    "xdm:tierExpiryDate": "2026-12-31T23:59:59Z",
+    "xdm:points": 15800,
+    "xdm:pointsRedeemed": 6200,
+    "xdm:adjustedPoints": -150,
+    "xdm:expiredPoints": 400,
+    "xdm:lifetimePoints": 28550,
+    "xdm:lifetimePurchases": 12430.67,
+    "xdm:promisedPoints": 500,
+    "xdm:returnedPoints": 75,
+    "xdm:pointsExpiration": [
+      {
+        "xdm:pointsExpiring": 1200,
+        "xdm:pointsExpirationDate": "2026-06-30T23:59:59Z"
+      }
+    ],
+    "xdm:cardsDetails": [
+      {
+        "xdm:number": "4532-8810-0044-9921",
+        "xdm:series": "2024 physical card",
+        "xdm:status": "active"
+      }
+    ],
+    "xdm:challenges": [
+      {
+        "xdm:id": "ch_winter_browse_2026",
+        "xdm:name": "Winter Browse Streak",
+        "xdm:description": "Visit the app or site on 5 separate days before the campaign ends.",
+        "xdm:series": "seasonal_engagement",
+        "xdm:frequencyType": "daily",
+        "xdm:startDate": "2026-01-01T00:00:00Z",
+        "xdm:endDate": "2026-01-31T23:59:59Z",
+        "xdm:state": "active",
+        "xdm:tasks": [
+          {
+            "xdm:name": "Log a qualifying session",
+            "xdm:type": "digital_visit",
+            "xdm:entity": "mobile_app",
+            "xdm:goal": 5,
+            "xdm:progress": 2,
+            "xdm:startDate": "2026-01-01T00:00:00Z",
+            "xdm:endDate": "2026-01-31T23:59:59Z",
+            "xdm:state": "inProgress"
+          }
+        ]
+      }
+    ],
+    "xdm:rewards": {
+      "xdm:badges": [
+        {
+          "xdm:id": "bdg_early_adopter",
+          "xdm:name": "Early Adopter",
+          "xdm:series": "founders",
+          "xdm:startDate": "2019-03-12T14:22:00Z",
+          "xdm:endDate": "2029-12-31T23:59:59Z",
+          "xdm:state": "active"
+        }
+      ],
+      "xdm:coupons": [
+        {
+          "xdm:id": "cpn_gold_double_2026q1",
+          "xdm:name": "Gold member double points weekend",
+          "xdm:series": "tier_perks",
+          "xdm:discountValue": 0,
+          "xdm:startDate": "2026-02-14T00:00:00Z",
+          "xdm:endDate": "2026-02-16T23:59:59Z",
+          "xdm:state": "active",
+          "xdm:redemptionCount": 0,
+          "xdm:redemptionLimit": 1,
+          "xdm:storeName": "Nordhaven Online"
+        }
+      ],
+      "xdm:giveaways": [
+        {
+          "xdm:id": "gw_ski_weekend_2026",
+          "xdm:name": "Ski weekend for two",
+          "xdm:series": "travel_partner_q1",
+          "xdm:type": "sweepstakes",
+          "xdm:partnerId": "PRT-AlpineEscapes",
+          "xdm:partnerName": "Alpine Escapes Ltd.",
+          "xdm:startDate": "2026-01-05T00:00:00Z",
+          "xdm:endDate": "2026-02-28T23:59:59Z",
+          "xdm:state": "active"
+        }
+      ],
+      "xdm:referrals": [
+        {
+          "xdm:id": "ref_8f3c21a",
+          "xdm:name": "Refer-a-friend bonus",
+          "xdm:series": "member_get_member",
+          "xdm:recipient": "sam.lee@example.com",
+          "xdm:startDate": "2025-11-01T00:00:00Z",
+          "xdm:endDate": "2026-05-01T23:59:59Z",
+          "xdm:state": "completed"
+        }
+      ]
+    }
+  }
+}

--- a/components/fieldgroups/profile/profile-loyalty-details.schema.json
+++ b/components/fieldgroups/profile/profile-loyalty-details.schema.json
@@ -98,8 +98,17 @@
               "title": "Upgrade Date",
               "type": "string",
               "description": "Date which the customer was upgraded to the next tier level.",
+              "meta:status": "deprecated",
               "meta:titleId": "profile-loyalty-details##xdm:upgradeDate##title##76171",
               "meta:descriptionId": "profile-loyalty-details##xdm:upgradeDate##description##59701"
+            },
+            "xdm:tierUpgradeDate": {
+              "title": "Tier Upgrade Date",
+              "type": "string",
+              "format": "date-time",
+              "description": "Date and time when the customer was upgraded to the next loyalty tier level.",
+              "meta:titleId": "profile-loyalty-details##xdm:tierUpgradeDate##title##77005",
+              "meta:descriptionId": "profile-loyalty-details##xdm:tierUpgradeDate##description##77006"
             },
             "xdm:status": {
               "title": "Status",
@@ -114,6 +123,20 @@
               "description": "Captures the loyalty progam tier in which a visitor is enrolled.",
               "meta:titleId": "profile-loyalty-details##xdm:tier##title##75921",
               "meta:descriptionId": "profile-loyalty-details##xdm:tier##description##54761"
+            },
+            "xdm:nextTier": {
+              "title": "Next Tier",
+              "type": "string",
+              "description": "The next loyalty tier the person can obtain, typically the tier above their current tier when they are not yet at the program's highest level.",
+              "meta:titleId": "profile-loyalty-details##xdm:nextTier##title##77001",
+              "meta:descriptionId": "profile-loyalty-details##xdm:nextTier##description##77002"
+            },
+            "xdm:pointsToNextTier": {
+              "title": "Points To Next Tier",
+              "type": "number",
+              "description": "Number of loyalty points the person still needs to accrue before qualifying for upgrade to the next loyalty tier.",
+              "meta:titleId": "profile-loyalty-details##xdm:pointsToNextTier##title##77003",
+              "meta:descriptionId": "profile-loyalty-details##xdm:pointsToNextTier##description##77004"
             },
             "xdm:tierExpiryDate": {
               "title": "Tier Expiry Date",
@@ -155,6 +178,112 @@
               "meta:titleId": "profile-loyalty-details##xdm:cardsDetails##title##11111",
               "meta:descriptionId": "profile-loyalty-details##xdm:cardsDetails##description##22222"
             },
+            "xdm:challenges": {
+              "title": "Loyalty Challenges",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "xdm:description": {
+                    "title": "Challenge Description",
+                    "type": "string",
+                    "description": "Detailed description of the loyalty challenge or campaign."
+                  },
+                  "xdm:endDate": {
+                    "title": "Challenge End Date",
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "End date and time of the loyalty challenge."
+                  },
+                  "xdm:frequencyType": {
+                    "title": "Frequency Type",
+                    "type": "string",
+                    "description": "Type of frequency for the challenge (daily, weekly, monthly, etc.)."
+                  },
+                  "xdm:id": {
+                    "title": "Challenge ID",
+                    "type": "string",
+                    "description": "Unique identifier for the loyalty challenge."
+                  },
+                  "xdm:name": {
+                    "title": "Challenge Name",
+                    "type": "string",
+                    "description": "Name or title of the loyalty challenge."
+                  },
+                  "xdm:series": {
+                    "title": "Challenge Series",
+                    "type": "string",
+                    "description": "Series or collection the challenge belongs to."
+                  },
+                  "xdm:startDate": {
+                    "title": "Challenge Start Date",
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Start date and time of the loyalty challenge."
+                  },
+                  "xdm:state": {
+                    "title": "Challenge State",
+                    "type": "string",
+                    "description": "Current state of the challenge (active, completed, expired, etc.)."
+                  },
+                  "xdm:tasks": {
+                    "title": "Challenge Tasks",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "xdm:endDate": {
+                          "title": "Task End Date",
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "End date and time for the challenge task."
+                        },
+                        "xdm:entity": {
+                          "title": "Task Entity",
+                          "type": "string",
+                          "description": "Entity or object the task is related to."
+                        },
+                        "xdm:goal": {
+                          "title": "Task Goal",
+                          "type": "number",
+                          "description": "Target goal value for the challenge task."
+                        },
+                        "xdm:name": {
+                          "title": "Task Name",
+                          "type": "string",
+                          "description": "Name or description of the specific task."
+                        },
+                        "xdm:progress": {
+                          "title": "Task Progress",
+                          "type": "number",
+                          "description": "Current progress value toward the task goal."
+                        },
+                        "xdm:startDate": {
+                          "title": "Task Start Date",
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Start date and time for the challenge task."
+                        },
+                        "xdm:state": {
+                          "title": "Task State",
+                          "type": "string",
+                          "description": "Current state of the task (in progress, completed, failed, etc.)."
+                        },
+                        "xdm:type": {
+                          "title": "Task Type",
+                          "type": "string",
+                          "description": "Type or category of the challenge task."
+                        }
+                      }
+                    },
+                    "description": "Tasks within the loyalty challenge, each object describing one task."
+                  }
+                }
+              },
+              "description": "Loyalty challenges the user is participating in.",
+              "meta:titleId": "profile-loyalty-details##xdm:challenges##title##33333",
+              "meta:descriptionId": "profile-loyalty-details##xdm:challenges##description##44444"
+            },
             "xdm:expiredPoints": {
               "title": "Expired Points",
               "type": "number",
@@ -189,6 +318,223 @@
               "description": "Points that have been returned to the customer's account due to refunds or adjustments.",
               "meta:titleId": "profile-loyalty-details##xdm:returnedPoints##title##33334",
               "meta:descriptionId": "profile-loyalty-details##xdm:returnedPoints##description##44445"
+            },
+            "xdm:rewards": {
+              "title": "Loyalty Rewards",
+              "type": "object",
+              "description": "Various types of rewards available to the customer through the loyalty program.",
+              "properties": {
+                "xdm:badges": {
+                  "title": "Achievement Badges",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "xdm:endDate": {
+                        "title": "Badge End Date",
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date when the badge expires or becomes invalid."
+                      },
+                      "xdm:id": {
+                        "title": "Badge ID",
+                        "type": "string",
+                        "description": "Unique identifier for the achievement badge."
+                      },
+                      "xdm:name": {
+                        "title": "Badge Name",
+                        "type": "string",
+                        "description": "Name or title of the achievement badge."
+                      },
+                      "xdm:series": {
+                        "title": "Badge Series",
+                        "type": "string",
+                        "description": "Series or collection the badge belongs to."
+                      },
+                      "xdm:startDate": {
+                        "title": "Badge Start Date",
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date when the badge was awarded or became active."
+                      },
+                      "xdm:state": {
+                        "title": "Badge State",
+                        "type": "string",
+                        "description": "Current state of the badge (active, expired, revoked, etc.)."
+                      }
+                    }
+                  },
+                  "description": "Achievement badges earned by the customer through various activities."
+                },
+                "xdm:coupons": {
+                  "title": "Loyalty Coupons",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "xdm:discountValue": {
+                        "title": "Discount Value",
+                        "type": "number",
+                        "description": "Monetary value of the discount provided by the coupon."
+                      },
+                      "xdm:endDate": {
+                        "title": "Coupon End Date",
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Expiration date of the coupon."
+                      },
+                      "xdm:id": {
+                        "title": "Coupon ID",
+                        "type": "string",
+                        "description": "Unique identifier for the loyalty coupon."
+                      },
+                      "xdm:name": {
+                        "title": "Coupon Name",
+                        "type": "string",
+                        "description": "Name or description of the coupon offer."
+                      },
+                      "xdm:redemptionCount": {
+                        "title": "Redemption Count",
+                        "type": "integer",
+                        "description": "Number of times this coupon has been redeemed."
+                      },
+                      "xdm:redemptionLimit": {
+                        "title": "Redemption Limit",
+                        "type": "integer",
+                        "description": "Maximum number of times this coupon can be redeemed."
+                      },
+                      "xdm:series": {
+                        "title": "Coupon Series",
+                        "type": "string",
+                        "description": "Series or campaign the coupon belongs to."
+                      },
+                      "xdm:startDate": {
+                        "title": "Coupon Start Date",
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date when the coupon becomes valid for use."
+                      },
+                      "xdm:state": {
+                        "title": "Coupon State",
+                        "type": "string",
+                        "description": "Current state of the coupon (active, expired, redeemed, etc.)."
+                      },
+                      "xdm:storeName": {
+                        "title": "Store Name",
+                        "type": "string",
+                        "description": "Name of the store where the coupon can be used."
+                      }
+                    }
+                  },
+                  "description": "Discount coupons available to the customer through the loyalty program."
+                },
+                "xdm:giveaways": {
+                  "title": "Loyalty Giveaways",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "xdm:endDate": {
+                        "title": "Giveaway End Date",
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "End date of the giveaway promotion."
+                      },
+                      "xdm:id": {
+                        "title": "Giveaway ID",
+                        "type": "string",
+                        "description": "Unique identifier for the giveaway promotion."
+                      },
+                      "xdm:name": {
+                        "title": "Giveaway Name",
+                        "type": "string",
+                        "description": "Name or description of the giveaway promotion."
+                      },
+                      "xdm:partnerId": {
+                        "title": "Partner ID",
+                        "type": "string",
+                        "description": "Identifier for the partner offering the giveaway."
+                      },
+                      "xdm:partnerName": {
+                        "title": "Partner Name",
+                        "type": "string",
+                        "description": "Name of the partner offering the giveaway."
+                      },
+                      "xdm:series": {
+                        "title": "Giveaway Series",
+                        "type": "string",
+                        "description": "Series or campaign the giveaway belongs to."
+                      },
+                      "xdm:startDate": {
+                        "title": "Giveaway Start Date",
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Start date of the giveaway promotion."
+                      },
+                      "xdm:state": {
+                        "title": "Giveaway State",
+                        "type": "string",
+                        "description": "Current state of the giveaway (active, ended, won, etc.)."
+                      },
+                      "xdm:type": {
+                        "title": "Giveaway Type",
+                        "type": "string",
+                        "description": "Type or category of the giveaway promotion."
+                      }
+                    }
+                  },
+                  "description": "Giveaway promotions available to the customer through the loyalty program."
+                },
+                "xdm:referrals": {
+                  "title": "Referral Rewards",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "xdm:endDate": {
+                        "title": "Referral End Date",
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "End date of the referral reward period."
+                      },
+                      "xdm:id": {
+                        "title": "Referral ID",
+                        "type": "string",
+                        "description": "Unique identifier for the referral reward."
+                      },
+                      "xdm:name": {
+                        "title": "Referral Name",
+                        "type": "string",
+                        "description": "Name or description of the referral reward."
+                      },
+                      "xdm:recipient": {
+                        "title": "Referral Recipient",
+                        "type": "string",
+                        "description": "Name or identifier of the person who was referred."
+                      },
+                      "xdm:series": {
+                        "title": "Referral Series",
+                        "type": "string",
+                        "description": "Series or campaign the referral belongs to."
+                      },
+                      "xdm:startDate": {
+                        "title": "Referral Start Date",
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Start date of the referral reward period."
+                      },
+                      "xdm:state": {
+                        "title": "Referral State",
+                        "type": "string",
+                        "description": "Current state of the referral (pending, completed, expired, etc.)."
+                      }
+                    }
+                  },
+                  "description": "Referral rewards earned by the customer for referring others to the loyalty program."
+                }
+              },
+              "meta:titleId": "profile-loyalty-details##xdm:rewards##title##55556",
+              "meta:descriptionId": "profile-loyalty-details##xdm:rewards##description##66667"
             }
           },
           "meta:descriptionId": "profile-loyalty-details##xdm:loyalty##description##85311"


### PR DESCRIPTION
Add more fields to loyalty profile schema to support more loyalty use cases around challenges and rewards, as requested. Also fix tier upgradeDate to be of type date-time.

### Challenges
A loyalty challenge is a time bound challenge that usually has tasks for the user to finish with a reward for finishing on time. A typical example would be spend more than $20 over the next week to receive 100 extra loyalty points.

This PR adds a "challenges" field that lists such loyalty challenges that the user has signed up for and tracks their progress in them.

### Rewards
This PR also adds a rewards section that tracks different reward channels for the user:

- Coupons: Tracks coupons that has been assigned to the user. these are usually time bound and has some kind of redemption limit. 
- Badges: achievement badges earned by the user through various activities.
- Giveaways: These are very much like coupons but to be redeemed against a partner.
- Referrals: Referral rewards earned by the user for referring others to the loyalty program