### PR TITLE
CJM-124288: add support for accumulators

### DIFF
--- a/extensions/adobe/experience/ajo/loyalty/loyalty.challenge.accumulatorItemEntry.schema.json
+++ b/extensions/adobe/experience/ajo/loyalty/loyalty.challenge.accumulatorItemEntry.schema.json
@@ -1,0 +1,101 @@
+{
+  "meta:license": [
+    "Copyright 2025 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/experience/ajo/loyalty/challenge/accumulatorItemEntry",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Loyalty Challenge Accumulator Item Entry",
+  "description": "A single item-level contribution in an accumulators items list for a loyalty challenge task or completion, including item details, identifiers, and timestamps.",
+  "type": "object",
+  "meta:extensible": true,
+  "definitions": {
+    "accumulatorItemEntry": {
+      "type": "object",
+      "properties": {
+        "xdm:item": {
+          "title": "Item",
+          "type": "object",
+          "description": "Item details for this accumulator entry.",
+          "properties": {
+            "xdm:itemSet": {
+              "title": "Item Set",
+              "type": "array",
+              "description": "Properties or tags of the item.",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "xdm:itemName": {
+              "title": "Item Name",
+              "type": "string",
+              "description": "Name of the item."
+            },
+            "xdm:qty": {
+              "title": "Quantity",
+              "type": "number",
+              "description": "Quantity of the item."
+            },
+            "xdm:unitPrice": {
+              "title": "Unit Price",
+              "type": "number",
+              "description": "Price per unit of the item."
+            },
+            "xdm:subTotal": {
+              "title": "Subtotal",
+              "type": "number",
+              "description": "Subtotal for this line (for example quantity multiplied by unit price)."
+            }
+          }
+        },
+        "xdm:id": {
+          "title": "Identifier",
+          "type": "string",
+          "description": "Unique identifier for this accumulator list entry.",
+          "minLength": 1
+        },
+        "xdm:timestamp": {
+          "title": "Timestamp",
+          "type": "string",
+          "format": "date-time",
+          "description": "When the contributing event occurred."
+        },
+        "xdm:timestampApplied": {
+          "title": "Timestamp Applied",
+          "type": "string",
+          "format": "date-time",
+          "description": "When this entry was applied to accumulators."
+        },
+        "xdm:utcOffset": {
+          "title": "UTC Offset",
+          "type": "string",
+          "description": "Local UTC offset for the contributing event (for example -08:00)."
+        },
+        "xdm:locationId": {
+          "title": "Location ID",
+          "type": "string",
+          "description": "Identifier for the location where the contributing transaction occurred."
+        },
+        "xdm:transactionId": {
+          "title": "Transaction ID",
+          "type": "string",
+          "description": "Transaction associated with this accumulator entry.",
+          "minLength": 1
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "#/definitions/accumulatorItemEntry"
+    }
+  ],
+  "meta:status": "experimental"
+}

--- a/extensions/adobe/experience/ajo/loyalty/loyalty.challenge.task.example.1.json
+++ b/extensions/adobe/experience/ajo/loyalty/loyalty.challenge.task.example.1.json
@@ -22,7 +22,30 @@
     },
     "singleTrans": false,
     "spendMin": 0,
-    "qtyMin": 1,
+    "qtyMin": 3,
     "maxTrans": 0
+  },
+  "accumulators": {
+    "qty": 1,
+    "spend": 6,
+    "days": 1,
+    "items": [
+      {
+        "item": {
+          "itemSet": [
+            "FRAP"
+          ],
+          "itemName": "Frozen Caramel Latte",
+          "qty": 1,
+          "unitPrice": 6,
+          "subTotal": 6
+        },
+        "id": "16e46e10-eff6-4e8d-8c9d-a635d9d89c17",
+        "timestamp": "2026-03-03T00:44:00.000+00:00",
+        "timestampApplied": "2026-04-01T19:52:55.626+00:00",
+        "utcOffset": "-08:00",
+        "transactionId": "f2b19a13-02ec-41ab-9b85-2a24d8b05c7c"
+      }
+    ]
   }
 }

--- a/extensions/adobe/experience/ajo/loyalty/loyalty.challenge.task.schema.json
+++ b/extensions/adobe/experience/ajo/loyalty/loyalty.challenge.task.schema.json
@@ -8,7 +8,7 @@
   "$id": "https://ns.adobe.com/experience/ajo/loyalty/challenge/task",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Loyalty Challenge Task",
-  "description": "Details about a task within a loyalty challenge, including state, dates, variables, and completion tracking.",
+  "description": "Details about a task within a loyalty challenge, including state, dates, variables, accumulators, and completion tracking.",
   "type": "object",
   "meta:extensible": true,
   "definitions": {
@@ -196,6 +196,38 @@
                     "minLength": 1
                   }
                 }
+              },
+              "meta:xdmType": "array"
+            }
+          }
+        },
+        "xdm:accumulators": {
+          "title": "Accumulators",
+          "type": "object",
+          "description": "Accumulated quantity, spend, qualified days, and item-level entries toward this task.",
+          "properties": {
+            "xdm:qty": {
+              "title": "Quantity",
+              "type": "number",
+              "description": "Total quantity accumulated."
+            },
+            "xdm:spend": {
+              "title": "Spend",
+              "type": "number",
+              "description": "Total spend accumulated."
+            },
+            "xdm:days": {
+              "title": "Days",
+              "type": "integer",
+              "description": "Number of qualified days accumulated.",
+              "meta:xdmType": "int"
+            },
+            "xdm:items": {
+              "title": "Items",
+              "type": "array",
+              "description": "Item-level contributions that counted toward this task.",
+              "items": {
+                "$ref": "https://ns.adobe.com/experience/ajo/loyalty/challenge/accumulatorItemEntry"
               },
               "meta:xdmType": "array"
             }

--- a/extensions/adobe/experience/ajo/loyalty/loyalty.challenge.taskCompletion.example.1.json
+++ b/extensions/adobe/experience/ajo/loyalty/loyalty.challenge.taskCompletion.example.1.json
@@ -1,7 +1,26 @@
 {
-  "completionDate": "2025-09-03T00:00:00.000+00:00",
+  "completionDate": "2026-04-01T19:52:55.626+00:00",
   "accumulators": {
-    "qty": 3,
-    "spend": 40
+    "qty": 1,
+    "spend": 6,
+    "days": 1,
+    "items": [
+      {
+        "item": {
+          "itemSet": [
+            "FRAP"
+          ],
+          "itemName": "Frozen Caramel Latte",
+          "qty": 1,
+          "unitPrice": 6,
+          "subTotal": 6
+        },
+        "id": "16e46e10-eff6-4e8d-8c9d-a635d9d89c17",
+        "timestamp": "2026-03-03T00:44:00.000+00:00",
+        "timestampApplied": "2026-04-01T19:52:55.626+00:00",
+        "utcOffset": "-08:00",
+        "transactionId": "f2b19a13-02ec-41ab-9b85-2a24d8b05c7c"
+      }
+    ]
   }
 }

--- a/extensions/adobe/experience/ajo/loyalty/loyalty.challenge.taskCompletion.schema.json
+++ b/extensions/adobe/experience/ajo/loyalty/loyalty.challenge.taskCompletion.schema.json
@@ -23,7 +23,7 @@
         "xdm:accumulators": {
           "title": "Accumulators",
           "type": "object",
-          "description": "Accumulated quantity and spend for this task completion.",
+          "description": "Accumulated quantity, spend, days, and item-level entries for this task completion.",
           "properties": {
             "xdm:qty": {
               "title": "Quantity",
@@ -34,6 +34,20 @@
               "title": "Spend",
               "type": "number",
               "description": "Total spend accumulated."
+            },
+            "xdm:days": {
+              "title": "Days",
+              "type": "integer",
+              "description": "Number of qualified days accumulated."
+            },
+            "xdm:items": {
+              "title": "Items",
+              "type": "array",
+              "description": "Item-level contributions that counted toward this task completion.",
+              "items": {
+                "$ref": "https://ns.adobe.com/experience/ajo/loyalty/challenge/accumulatorItemEntry"
+              },
+              "meta:xdmType": "array"
             }
           }
         },


### PR DESCRIPTION
Add accumulators object to task definitions, and add more details in task completion's accumulators object.
In task definition it tracks the user's current progress toward completing the task. 
Add more detailed information about the "items" that contributed towards completing the task. 

### `accumulatorItemEntry`
**`loyalty.challenge.accumulatorItemEntry`** (`https://ns.adobe.com/experience/ajo/loyalty/challenge/accumulatorItemEntry`) is the XDM type for a **single row** in **`xdm:accumulators` → `xdm:items`** on a loyalty challenge **task** or **task completion**. It records one qualifying line contribution toward rolled-up totals, with enough merchandising and transaction context to support auditing and reconciliation. Tasks and completions reuse this type so item-level structure stays consistent.
**Member fields**
- **`xdm:id`** — Unique id for this **list entry** (the row in `items`), not the catalog product id.
- **`xdm:timestamp`** — When the contributing event occurred (`date-time`).
- **`xdm:timestampApplied`** — When this row was applied to accumulators (`date-time`).
- **`xdm:utcOffset`** — Local offset from UTC for the event (for example `-08:00`).
- **`xdm:locationId`** — Location where the contributing transaction happened.
- **`xdm:transactionId`** — Transaction this row belongs to.
- **`xdm:item`** — Nested line payload:
  - **`xdm:itemSet`** — Tags or properties that describe the item (unique strings).
  - **`xdm:itemName`** — Display or catalog name of the item.
  - **`xdm:qty`** — Quantity for this line.
  - **`xdm:unitPrice`** — Price per unit.
  - **`xdm:subTotal`** — Line subtotal (for example qty × unit price).