### PR TITLE
AN-447042 Add /ready slash-command workflow for PR review-ready labeling

### DIFF
--- a/.github/workflows/pr-ready-label.yml
+++ b/.github/workflows/pr-ready-label.yml
@@ -1,0 +1,85 @@
+name: PR review-ready label
+
+# Applies or removes the `needs review` label on a PR based on /ready and /wip
+# slash commands posted by the PR author (or any commenter with triage+ access).
+#
+# This exists because external contributors on fork PRs cannot add labels
+# directly — only users with write access to adobe/xdm can. This workflow
+# runs in the base-repo context with GITHUB_TOKEN, which has the needed scopes.
+#
+# See issue #2150 and parent proposal #2148 for design discussion.
+
+on:
+  pull_request_target:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  onboarding-comment:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                "👋 Thanks for opening a PR.",
+                "",
+                "When this change is ready for review, please post `/ready` as a new comment on this PR.",
+                "That will add the `needs review` label, which is how reviewers filter the open-PR list.",
+                "",
+                "If you need to mark the PR not-ready again later, post `/wip` to remove the label.",
+                "",
+                "You can re-run these commands as many times as needed."
+              ].join("\n")
+            });
+
+  slash-command:
+    if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body || "";
+            const isReady = /^\s*\/ready\b/m.test(body);
+            const isWip = /^\s*\/wip\b/m.test(body);
+            if (!isReady && !isWip) return;
+            if (isReady && isWip) {
+              core.info("Both /ready and /wip present in the same comment — ignoring.");
+              return;
+            }
+
+            const args = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            };
+            const commentId = context.payload.comment.id;
+
+            if (isReady) {
+              await github.rest.issues.addLabels({ ...args, labels: ["needs review"] });
+              await github.rest.reactions.createForIssueComment({
+                ...args, comment_id: commentId, content: "+1",
+              });
+              core.info(`Added 'needs review' label to PR #${context.issue.number}.`);
+            } else {
+              try {
+                await github.rest.issues.removeLabel({ ...args, name: "needs review" });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+              await github.rest.reactions.createForIssueComment({
+                ...args, comment_id: commentId, content: "eyes",
+              });
+              core.info(`Removed 'needs review' label from PR #${context.issue.number}.`);
+            }


### PR DESCRIPTION
## Summary

Closes #2150 · Parent proposal: #2148 · Related: #2149 · Jira: [AN-447042](https://jira.corp.adobe.com/browse/AN-447042)

Adds a single GitHub Actions workflow at `.github/workflows/pr-ready-label.yml` that owns the `needs review` label on contributors' behalf. External contributors on fork PRs cannot add labels directly (admin-only on `adobe/xdm`), so the workflow applies/removes the label in response to `/ready` and `/wip` comments posted by the PR author.

**Non-breaking, additive.** No schema changes, no CircleCI changes, no secret configuration required.

## Motivation

Surfaced during review of #2149 — the existing README/CLAUDE.md guidance "add the `needs review` label when ready" was not actionable for external contributors. Rather than remove the label convention (reviewers rely on it to filter the open-PR queue), give contributors a path that doesn't require repo-write access.

## Behavior

| Event | What happens |
|---|---|
| `pull_request_target.opened` | Bot posts a one-time onboarding comment explaining `/ready` and `/wip`. |
| `issue_comment.created` containing `/ready` on its own line | Adds the `needs review` label; reacts 👍 on the triggering comment. |
| `issue_comment.created` containing `/wip` on its own line | Removes the `needs review` label; reacts 👀 on the triggering comment. |
| Comment containing both `/ready` and `/wip` | Ignored (logged). |
| Comment containing neither | Ignored (silently). |

Commands are idempotent and reversible. Contributors who mis-fire can correct with the inverse command.

## Why `pull_request_target` (and why it's safe here)

Fork PRs under the standard `pull_request` trigger receive a read-only `GITHUB_TOKEN`. That means a workflow running on fork PRs cannot post comments or apply labels. `pull_request_target` runs the workflow in the base-repo context against the base-repo `GITHUB_TOKEN`, which has the `pull-requests: write` and `issues: write` scopes required.

`pull_request_target` is [well-known to be risky](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) when combined with `actions/checkout` + execution of fork-supplied code. **This workflow does neither.** It uses only `actions/github-script@v7` with a string-literal comment body and parses the triggering comment text with a regex. No code from the fork is checked out or executed.

## Changes

- `.github/workflows/pr-ready-label.yml` — new, 85 lines.

## Validation

- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('…'))"`).
- `npm run lint` — clean (workflow file is outside the prettier glob, no schemas changed).
- `npm test` — not run; no schema or example files changed.
- Live smoke test will happen on the next PR against `adobe/xdm:master` once this workflow is merged.

## Prerequisites for this to work

GitHub Actions must be enabled on `adobe/xdm` repo settings. If it's currently disabled (the repo uses CircleCI for CI today), maintainers will need to enable Actions for this workflow to run. No Actions secrets are required.

## Non-goals

- Auto-labeling any PR without an explicit command. Reviewers who want to see unlabelled open PRs can always fall back to the unfiltered list.
- Broader slash-command system (Prow-style `/lgtm`, `/approve`, `/hold`, etc.) — out of scope; can follow separately if there's appetite.
- Rewriting README / CLAUDE.md text that references the label workflow — covered by a separate follow-up PR.