### PR TITLE
Soft-deprecate single-object xdm:radius in favor of array xdm:radii

### DIFF
--- a/components/datatypes/paid-media/paid-media-targeting.example.2.json
+++ b/components/datatypes/paid-media/paid-media-targeting.example.2.json
@@ -1,11 +1,18 @@
 {
   "xdm:geoTargeting": {
     "xdm:countries": ["US"],
-    "xdm:radius": {
-      "xdm:latitude": 37.7749,
-      "xdm:longitude": -122.4194,
-      "xdm:radiusKm": 25
-    }
+    "xdm:radii": [
+      {
+        "xdm:latitude": 37.7749,
+        "xdm:longitude": -122.4194,
+        "xdm:radiusKm": 25
+      },
+      {
+        "xdm:latitude": 40.7128,
+        "xdm:longitude": -74.006,
+        "xdm:radiusKm": 15
+      }
+    ]
   },
   "xdm:demographicTargeting": {
     "xdm:ageRanges": [

--- a/components/datatypes/paid-media/paid-media-targeting.schema.json
+++ b/components/datatypes/paid-media/paid-media-targeting.schema.json
@@ -67,23 +67,26 @@
                 "type": "integer"
               }
             },
-            "xdm:radius": {
-              "type": "object",
+            "xdm:radii": {
+              "type": "array",
               "title": "Radius Targeting",
-              "description": "Location radius targeting",
-              "properties": {
-                "xdm:latitude": {
-                  "type": "number",
-                  "title": "Latitude"
-                },
-                "xdm:longitude": {
-                  "type": "number",
-                  "title": "Longitude"
-                },
-                "xdm:radiusKm": {
-                  "type": "number",
-                  "title": "Radius (km)",
-                  "description": "Radius in kilometers"
+              "description": "Location radius (proximity) targets. Modeled as an array because source networks support multiple radius circles per ad set/campaign: Meta `geo_locations.custom_locations` is an array of `{latitude, longitude, radius, distance_unit}`; Google Ads `ProximityInfo` is one criterion per location with multiple criteria allowed per campaign. Ingestion pipelines SHOULD normalize the source radius to kilometers (Meta `distance_unit=mile` → multiply by 1.609344) before populating `xdm:radiusKm`, consistent with the country/region ISO normalization elsewhere in this datatype.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "xdm:latitude": {
+                    "type": "number",
+                    "title": "Latitude"
+                  },
+                  "xdm:longitude": {
+                    "type": "number",
+                    "title": "Longitude"
+                  },
+                  "xdm:radiusKm": {
+                    "type": "number",
+                    "title": "Radius (km)",
+                    "description": "Radius in kilometers"
+                  }
                 }
               }
             }

--- a/components/datatypes/paid-media/paid-media-targeting.schema.json
+++ b/components/datatypes/paid-media/paid-media-targeting.schema.json
@@ -67,10 +67,30 @@
                 "type": "integer"
               }
             },
+            "xdm:radius": {
+              "type": "object",
+              "title": "Radius Targeting (deprecated)",
+              "description": "Single-target location radius. **Deprecated** — use `xdm:radii` instead, which is an array and matches the multi-target shape of source networks (Meta `geo_locations.custom_locations`, Google Ads `ProximityInfo`). Retained for backwards compatibility with existing downstream consumers; new integrations SHOULD populate `xdm:radii`. When both are present, `xdm:radii` takes precedence.",
+              "properties": {
+                "xdm:latitude": {
+                  "type": "number",
+                  "title": "Latitude"
+                },
+                "xdm:longitude": {
+                  "type": "number",
+                  "title": "Longitude"
+                },
+                "xdm:radiusKm": {
+                  "type": "number",
+                  "title": "Radius (km)",
+                  "description": "Radius in kilometers"
+                }
+              }
+            },
             "xdm:radii": {
               "type": "array",
               "title": "Radius Targeting",
-              "description": "Location radius (proximity) targets. Modeled as an array because source networks support multiple radius circles per ad set/campaign: Meta `geo_locations.custom_locations` is an array of `{latitude, longitude, radius, distance_unit}`; Google Ads `ProximityInfo` is one criterion per location with multiple criteria allowed per campaign. Ingestion pipelines SHOULD normalize the source radius to kilometers (Meta `distance_unit=mile` → multiply by 1.609344) before populating `xdm:radiusKm`, consistent with the country/region ISO normalization elsewhere in this datatype.",
+              "description": "Location radius (proximity) targets. Modeled as an array because source networks support multiple radius circles per ad set/campaign: Meta `geo_locations.custom_locations` is an array of `{latitude, longitude, radius, distance_unit}`; Google Ads `ProximityInfo` is one criterion per location with multiple criteria allowed per campaign. Ingestion pipelines SHOULD normalize the source radius to kilometers (Meta `distance_unit=mile` → multiply by 1.609344) before populating `xdm:radiusKm`, consistent with the country/region ISO normalization elsewhere in this datatype. Supersedes the deprecated single-object `xdm:radius` field.",
               "items": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
## What this changes
- Source networks model paid-media radius (proximity) targeting as a list of circles per ad set/campaign — Meta `geo_locations.custom_locations` is an array of `{latitude, longitude, radius, distance_unit}`, Google Ads `ProximityInfo` allows multiple proximity criteria per campaign. The current single-object `xdm:radius` shape silently drops all but one target on ingest.
- Adds `xdm:radii` as the new array-shaped field on `paid-media-targeting`.
- Soft-deprecates `xdm:radius` (single object) — retained for backwards compatibility with downstream consumers already emitting it; description now flags it deprecated and points to `xdm:radii`. Existing emitters continue to validate.
- Description on `xdm:radii` reminds ingestion pipelines to normalize source radius to kilometers (Meta `distance_unit=mile` → ×1.609344) before populating `xdm:radiusKm`, consistent with the country/region ISO normalization soft-deprecation already in this datatype.
- Updates `paid-media-targeting.example.2.json` to demonstrate the array form with two radii.

## Breaking changes
None. Additive change plus soft-deprecation. Existing emitters of `xdm:radius` continue to validate; new integrations populate `xdm:radii`.

## Tracking
- Closes #2154
- Internal Jira: [AN-448142](https://jira.corp.adobe.com/browse/AN-448142) (epic [AN-444787](https://jira.corp.adobe.com/browse/AN-444787))

## References
- [Meta Marketing API — Basic Targeting](https://developers.facebook.com/docs/marketing-api/audiences/reference/basic-targeting/) — `custom_locations` array with `{latitude, longitude, radius}` plus `distance_unit` at the `geo_locations` level.
- Google Ads API `ProximityInfo` criterion — multiple proximity criteria allowed per campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)