### PR TITLE
Use long integer min/max constraints for paid-media micro-currency fields

### DIFF
--- a/components/fieldgroups/paid-media/core-paid-media-adgroup-details.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-adgroup-details.schema.json
@@ -126,12 +126,16 @@
                     "xdm:budgetInMicroCurrency": {
                       "type": "integer",
                       "title": "Budget (Micro Currency)",
-                      "description": "Budget amount in micro currency units"
+                      "description": "Budget amount in micro currency units",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
                     },
                     "xdm:bidInMicroCurrency": {
                       "type": "integer",
                       "title": "Bid (Micro Currency)",
-                      "description": "Bid amount in micro currency units"
+                      "description": "Bid amount in micro currency units",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
                     },
                     "xdm:bidStrategyType": {
                       "type": "string",

--- a/components/fieldgroups/paid-media/core-paid-media-cost-metrics.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-cost-metrics.schema.json
@@ -27,9 +27,9 @@
                 "xdm:spendInMicroCurrency": {
                   "type": "integer",
                   "title": "Spend (Micro Currency)",
-                  "description": "Amount spent in micro currency units (spend * 1,000,000). Use a 64-bit long to avoid overflow for large spend values.",
+                  "description": "Amount spent in micro currency units (spend * 1,000,000).",
                   "minimum": 0,
-                  "meta:xdmType": "long"
+                  "maximum": 9007199254740991
                 },
                 "xdm:averageCpm": {
                   "type": "number",
@@ -76,9 +76,9 @@
                 "xdm:bidAmountMicro": {
                   "type": "integer",
                   "title": "Bid Amount (Micro Currency)",
-                  "description": "Bid amount in micro currency units (bid * 1,000,000). Use a 64-bit long to avoid overflow for large bid values.",
+                  "description": "Bid amount in micro currency units (bid * 1,000,000).",
                   "minimum": 0,
-                  "meta:xdmType": "long"
+                  "maximum": 9007199254740991
                 },
                 "xdm:maxBid": {
                   "type": "number",


### PR DESCRIPTION
## What this changes

Replaces `meta:xdmType: "long"` annotations with explicit JSON Schema `minimum`/`maximum` bounds on paid-media micro-currency integer fields.

Per XDM team guidance, the correct pattern for a 64-bit integer field is:
```json
{
  "type": "integer",
  "minimum": -9007199254740991,
  "maximum": 9007199254740991
}
```
This lets the system auto-generate `meta:xdmType` rather than requiring manual annotation. Both `int` and `long` use `"type": "integer"` in JSON Schema, so the constraints are what distinguish them.

## Fields updated

- `xdm:spendInMicroCurrency` in `core-paid-media-cost-metrics` fieldgroup — remove `meta:xdmType: "long"`, add `maximum`
- `xdm:bidAmountMicro` in `core-paid-media-cost-metrics` fieldgroup — remove `meta:xdmType: "long"`, add `maximum`
- `xdm:budgetInMicroCurrency` in `core-paid-media-adgroup-details` fieldgroup — add `minimum: 0`, `maximum`
- `xdm:bidInMicroCurrency` in `core-paid-media-adgroup-details` fieldgroup — add `minimum: 0`, `maximum`

## No breaking changes

All fields remain `"type": "integer"`. The resolved `meta:xdmType` is unchanged (`long`). This is a schema source correction, not a behavioral change.

Fixes #2155
Jira: [AN-448665](https://jira.corp.adobe.com/browse/AN-448665)