### PR TITLE
AN-449314 Soft-deprecate adGroupDetails.childAdType in favor of per-ad adType

### DIFF
--- a/components/fieldgroups/paid-media/core-paid-media-adgroup-details.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-adgroup-details.schema.json
@@ -74,7 +74,8 @@
                 "xdm:childAdType": {
                   "type": "string",
                   "title": "Child Ad Type",
-                  "description": "Type of ads contained in this ad group"
+                  "description": "Deprecated: Use adDetails.adType on each individual ad in the Ad Lookup instead. A single ad group can contain mixed ad types, making this field inaccurate for heterogeneous groups.",
+                  "meta:status": "deprecated"
                 },
                 "xdm:promotedObject": {
                   "type": "object",


### PR DESCRIPTION
## What this change does

Soft-deprecates `xdm:childAdType` on `adGroupDetails` by updating its description and adding `"meta:status": "deprecated"`.

## Why

`childAdType` is both redundant and inaccurate:

- **Redundant**: `adDetails.adType` already exists on each individual ad in the Ad Lookup schema with a rich enum of 35+ values.
- **Inaccurate**: `childAdType` is a single `string` — it cannot represent ad groups containing mixed ad types (common on Meta, TikTok, and other platforms). For heterogeneous groups, the field must be left blank or set to `"other"`, making it useless.

Consumers should use `adDetails.adType` on each individual ad record in the Ad Lookup, which handles mixed-type ad groups correctly.

## References

- GitHub issue: #2157
- Jira: [AN-449314](https://jira.corp.adobe.com/browse/AN-449314)

## Breaking changes

None — this is a soft deprecation. The field remains in the schema and existing data is unaffected.

## Checklist

- [x] `npm test` validates all example files
- [x] No new example files required (no new fields added)