### PR TITLE
Soft-deprecate paid-media xdm:entityIDs and other GenStudio migration aids

### DIFF
--- a/components/classes/paid-media.example.1.json
+++ b/components/classes/paid-media.example.1.json
@@ -1,13 +1,10 @@
 {
   "xdm:entityType": "campaign",
-  "xdm:entityIDs": {
-    "xdm:account": {
-      "xdm:accountGUID": "urn:paidmedia:account:550e8400-e29b-41d4-a716-446655440000",
-      "xdm:accountID": "act_987654321"
-    },
-    "xdm:campaign": {
-      "xdm:campaignGUID": "urn:paidmedia:campaign:660e8400-e29b-41d4-a716-446655440001",
-      "xdm:campaignID": "camp_12345"
-    }
+  "xdm:paidMedia": {
+    "xdm:adNetwork": "meta",
+    "xdm:accountGUID": "urn:paidmedia:account:550e8400-e29b-41d4-a716-446655440000",
+    "xdm:accountID": "act_987654321",
+    "xdm:campaignGUID": "urn:paidmedia:campaign:660e8400-e29b-41d4-a716-446655440001",
+    "xdm:campaignID": "camp_12345"
   }
 }

--- a/components/classes/paid-media.schema.json
+++ b/components/classes/paid-media.schema.json
@@ -39,8 +39,8 @@
         },
         "xdm:entityIDs": {
           "type": "object",
-          "title": "Entity IDs",
-          "description": "Nested platform entity identifiers to ease migration from GenStudio templates",
+          "title": "Entity IDs (deprecated)",
+          "description": "Nested platform entity identifiers grouped by entity type. **Deprecated** — use the flat top-level `xdm:accountID`/`xdm:accountGUID`/`xdm:campaignID`/`xdm:campaignGUID`/`xdm:adGroupID`/`xdm:adGroupGUID`/`xdm:adID`/`xdm:adGUID`/`xdm:experienceID`/`xdm:experienceGUID`/`xdm:assetID`/`xdm:assetGUID` fields from the `core-paid-media-identifiers` field group instead, which fully cover the same identifiers without nesting. Originally added to ease migration from GenStudio templates; that migration is no longer planned. Retained for backwards compatibility with existing downstream consumers; new integrations SHOULD populate the flat identifier fields. When both shapes are present, the flat identifier fields take precedence.",
           "properties": {
             "xdm:account": {
               "type": "object",

--- a/components/fieldgroups/paid-media/core-paid-media-account-details.example.1.json
+++ b/components/fieldgroups/paid-media/core-paid-media-account-details.example.1.json
@@ -3,7 +3,6 @@
     "xdm:accountDetails": {
       "xdm:accountName": "Acme Corp - Meta Business Account",
       "xdm:currency": "USD",
-      "xdm:currencyCode": "USD",
       "xdm:timezone": "America/Los_Angeles",
       "xdm:accountType": "business",
       "xdm:businessName": "Acme Corporation",

--- a/components/fieldgroups/paid-media/core-paid-media-account-details.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-account-details.schema.json
@@ -36,8 +36,8 @@
                 },
                 "xdm:currencyCode": {
                   "type": "string",
-                  "title": "Currency Code",
-                  "description": "Alias of currency (ISO 4217) for migration from GenStudio templates"
+                  "title": "Currency Code (deprecated)",
+                  "description": "Alias of `xdm:currency` (ISO 4217). **Deprecated** — use `xdm:currency` instead. Originally added to ease migration from GenStudio templates; that migration is no longer planned. Retained for backwards compatibility with existing downstream consumers; new integrations SHOULD populate `xdm:currency`. When both are present, `xdm:currency` takes precedence."
                 },
                 "xdm:timezone": {
                   "type": "string",

--- a/components/fieldgroups/paid-media/core-paid-media-dimensional-breakdowns.example.1.json
+++ b/components/fieldgroups/paid-media/core-paid-media-dimensional-breakdowns.example.1.json
@@ -1,12 +1,10 @@
 {
   "xdm:paidMedia": {
-    "xdm:breakdownType": "device_platform_demographic",
     "xdm:dimensionalBreakdowns": {
       "xdm:deviceType": "mobile",
       "xdm:platform": "instagram",
       "xdm:placement": "instagram_feed",
       "xdm:ageGroup": "25-34",
-      "xdm:age": "25-34",
       "xdm:gender": "female",
       "xdm:country": "US",
       "xdm:region": "California",
@@ -19,7 +17,6 @@
       "xdm:optimizationGoal": "link_clicks",
       "xdm:creativeFormat": "single_image",
       "xdm:adPosition": "feed",
-      "xdm:position": "feed",
       "xdm:timeOfDay": "afternoon",
       "xdm:dayOfWeek": "Tuesday"
     }

--- a/components/fieldgroups/paid-media/core-paid-media-dimensional-breakdowns.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-dimensional-breakdowns.schema.json
@@ -21,8 +21,8 @@
           "properties": {
             "xdm:breakdownType": {
               "type": "string",
-              "title": "Breakdown Type",
-              "description": "Indicates which dimension this metrics row is broken down by (GenStudio migration aid)"
+              "title": "Breakdown Type (deprecated)",
+              "description": "Indicates which dimension this metrics row is broken down by. **Deprecated** — originally added to ease migration from GenStudio templates; that migration is no longer planned. Retained for backwards compatibility with existing downstream consumers; new integrations SHOULD infer the breakdown dimension from the populated fields under `xdm:dimensionalBreakdowns` directly."
             },
             "xdm:dimensionalBreakdowns": {
               "type": "object",
@@ -54,8 +54,8 @@
                 },
                 "xdm:age": {
                   "type": "string",
-                  "title": "Age",
-                  "description": "Alias of ageGroup for migration"
+                  "title": "Age (deprecated)",
+                  "description": "Alias of `xdm:ageGroup`. **Deprecated** — use `xdm:ageGroup` instead. Originally added to ease migration from GenStudio templates; that migration is no longer planned. Retained for backwards compatibility with existing downstream consumers; new integrations SHOULD populate `xdm:ageGroup`. When both are present, `xdm:ageGroup` takes precedence."
                 },
                 "xdm:gender": {
                   "type": "string",
@@ -126,8 +126,8 @@
                 },
                 "xdm:position": {
                   "type": "string",
-                  "title": "Position",
-                  "description": "Alias of adPosition for migration"
+                  "title": "Position (deprecated)",
+                  "description": "Alias of `xdm:adPosition`. **Deprecated** — use `xdm:adPosition` instead. Originally added to ease migration from GenStudio templates; that migration is no longer planned. Retained for backwards compatibility with existing downstream consumers; new integrations SHOULD populate `xdm:adPosition`. When both are present, `xdm:adPosition` takes precedence."
                 },
                 "xdm:platform": {
                   "type": "string",

--- a/components/fieldgroups/paid-media/core-paid-media-extended-metrics.example.1.json
+++ b/components/fieldgroups/paid-media/core-paid-media-extended-metrics.example.1.json
@@ -20,7 +20,6 @@
       "xdm:follows": 234,
       "xdm:profileVisits": 1890,
       "xdm:websiteVisits": 4250,
-      "xdm:averageDwellTime": 34.5,
       "xdm:appInstalls": 156,
       "xdm:appOpens": 420,
       "xdm:leadSubmissions": 245,

--- a/components/fieldgroups/paid-media/core-paid-media-extended-metrics.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-extended-metrics.schema.json
@@ -141,8 +141,8 @@
                 },
                 "xdm:averageDwellTime": {
                   "type": "number",
-                  "title": "Average Dwell Time",
-                  "description": "Average dwell time (seconds) (alias for qualityMetrics.dwellTime to ease migration)",
+                  "title": "Average Dwell Time (deprecated)",
+                  "description": "Average dwell time (seconds). **Deprecated** — use `xdm:qualityMetrics.xdm:dwellTime` from the `core-paid-media-quality-metrics` field group instead. Originally added as an alias to ease migration from GenStudio templates; that migration is no longer planned. Retained for backwards compatibility with existing downstream consumers; new integrations SHOULD populate `xdm:qualityMetrics.xdm:dwellTime`. When both are present, `xdm:qualityMetrics.xdm:dwellTime` takes precedence.",
                   "minimum": 0
                 },
                 "xdm:appInstalls": {

--- a/components/fieldgroups/paid-media/core-paid-media-identifiers.example.1.json
+++ b/components/fieldgroups/paid-media/core-paid-media-identifiers.example.1.json
@@ -1,7 +1,6 @@
 {
   "xdm:paidMedia": {
     "xdm:adNetwork": "meta",
-    "xdm:network": "meta",
     "xdm:accountID": "act_123456789012345",
     "xdm:accountGUID": "meta_act_123456789012345",
     "xdm:campaignID": "23851234567890789",

--- a/components/fieldgroups/paid-media/core-paid-media-identifiers.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-identifiers.schema.json
@@ -54,8 +54,8 @@
             },
             "xdm:network": {
               "type": "string",
-              "title": "Network",
-              "description": "Alias of adNetwork for migration from GenStudio templates"
+              "title": "Network (deprecated)",
+              "description": "Alias of `xdm:adNetwork`. **Deprecated** — use `xdm:adNetwork` instead. Originally added to ease migration from GenStudio templates; that migration is no longer planned. Retained for backwards compatibility with existing downstream consumers; new integrations SHOULD populate `xdm:adNetwork`. When both are present, `xdm:adNetwork` takes precedence."
             },
             "xdm:accountID": {
               "type": "string",


### PR DESCRIPTION
## Summary

Soft-deprecates paid-media XDM fields that were originally added to ease migration from GenStudio templates. GenStudio migration is no longer planned, and these fields duplicate the canonical identifiers/aliases that already exist on the paid-media class and field groups.

This follows the soft-deprecate pattern established in #2153 (single-object `xdm:radius` → array `xdm:radii`): the field stays in place for backwards compatibility with existing downstream consumers, but the `title` gets a `(deprecated)` suffix and the `description` is updated to point new integrations at the canonical replacement. When both shapes are present, the canonical field takes precedence.

## Fields soft-deprecated

| Schema | Field | Replacement |
|---|---|---|
| `components/classes/paid-media.schema.json` | `xdm:entityIDs` (whole nested object) | Flat top-level `xdm:accountID`/`xdm:accountGUID`/`xdm:campaignID`/`xdm:campaignGUID`/`xdm:adGroupID`/`xdm:adGroupGUID`/`xdm:adID`/`xdm:adGUID`/`xdm:experienceID`/`xdm:experienceGUID`/`xdm:assetID`/`xdm:assetGUID` fields from `core-paid-media-identifiers` |
| `components/fieldgroups/paid-media/core-paid-media-identifiers.schema.json` | `xdm:network` | `xdm:adNetwork` |
| `components/fieldgroups/paid-media/core-paid-media-account-details.schema.json` | `xdm:currencyCode` | `xdm:currency` |
| `components/fieldgroups/paid-media/core-paid-media-extended-metrics.schema.json` | `xdm:averageDwellTime` | `xdm:qualityMetrics.xdm:dwellTime` from `core-paid-media-quality-metrics` |
| `components/fieldgroups/paid-media/core-paid-media-dimensional-breakdowns.schema.json` | `xdm:breakdownType` | Inferable from populated `xdm:dimensionalBreakdowns` fields |
| `components/fieldgroups/paid-media/core-paid-media-dimensional-breakdowns.schema.json` | `xdm:age` | `xdm:ageGroup` |
| `components/fieldgroups/paid-media/core-paid-media-dimensional-breakdowns.schema.json` | `xdm:position` | `xdm:adPosition` |

Example files are also updated to drop the deprecated aliases and demonstrate the canonical replacement (mirrors the example update from #2153).

## Breaking changes

None — soft-deprecate only; the fields remain valid in the schema.

## Related

- Closes #2168
- Internal tracking: [AN-450895](https://jira.corp.adobe.com/browse/AN-450895)
- Pattern reference: #2153

🤖 Generated with [Claude Code](https://claude.com/claude-code)