### PR TITLE
AN-451008 paid-media: add missing title on nested leaf properties

### DIFF
--- a/components/fieldgroups/paid-media/core-paid-media-attribution-metrics.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-attribution-metrics.schema.json
@@ -150,17 +150,24 @@
                     "xdm:devicePathBreakdown": {
                       "type": "object",
                       "title": "Device Path Breakdown",
+                      "description": "Conversion counts grouped by the device transition path leading up to the conversion",
                       "properties": {
                         "xdm:mobileToDesktop": {
                           "type": "number",
+                          "title": "Mobile to Desktop Conversions",
+                          "description": "Conversions where the user transitioned from a mobile device to a desktop device along the conversion path",
                           "minimum": 0
                         },
                         "xdm:desktopToMobile": {
                           "type": "number",
+                          "title": "Desktop to Mobile Conversions",
+                          "description": "Conversions where the user transitioned from a desktop device to a mobile device along the conversion path",
                           "minimum": 0
                         },
                         "xdm:mobileToMobileApp": {
                           "type": "number",
+                          "title": "Mobile Web to Mobile App Conversions",
+                          "description": "Conversions where the user transitioned from a mobile web experience to a mobile app along the conversion path",
                           "minimum": 0
                         }
                       }
@@ -297,13 +304,19 @@
                         "type": "object",
                         "properties": {
                           "xdm:channel": {
-                            "type": "string"
+                            "type": "string",
+                            "title": "Channel",
+                            "description": "Marketing channel for this step in the conversion path"
                           },
                           "xdm:position": {
-                            "type": "integer"
+                            "type": "integer",
+                            "title": "Position",
+                            "description": "Ordered position of this channel within the conversion path (1-based)"
                           },
                           "xdm:weight": {
-                            "type": "number"
+                            "type": "number",
+                            "title": "Weight",
+                            "description": "Attribution weight assigned to this channel within the conversion path"
                           }
                         }
                       }

--- a/components/fieldgroups/paid-media/core-paid-media-campaign-details.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-campaign-details.schema.json
@@ -332,11 +332,14 @@
                         "xdm:schedule": {
                           "type": "array",
                           "title": "Schedule",
+                          "description": "Day-of-week and time-of-day windows during which the campaign is eligible to serve",
                           "items": {
                             "type": "object",
                             "properties": {
                               "xdm:dayOfWeek": {
                                 "type": "string",
+                                "title": "Day of Week",
+                                "description": "Day of the week this schedule entry applies to",
                                 "enum": [
                                   "monday",
                                   "tuesday",
@@ -358,11 +361,15 @@
                               },
                               "xdm:startHour": {
                                 "type": "integer",
+                                "title": "Start Hour",
+                                "description": "Hour of the day the schedule window opens, expressed in 24-hour format (0-23)",
                                 "minimum": 0,
                                 "maximum": 23
                               },
                               "xdm:endHour": {
                                 "type": "integer",
+                                "title": "End Hour",
+                                "description": "Hour of the day the schedule window closes, expressed in 24-hour format (0-23)",
                                 "minimum": 0,
                                 "maximum": 23
                               }


### PR DESCRIPTION
## Summary

Several nested-object leaf properties in the paid-media fieldgroup
schemas were missing the `title` keyword (and `description` in most
cases). Downstream consumers (CJA Workspace, schema editors, docs) were
falling back to the full dot-notation `schemaPath` as the display name
— surfacing raw paths like
`paidMedia.attributionMetrics.crossDeviceAttribution.devicePathBreakdown.mobileToMobileApp`
in the UI instead of a human-readable label.

Sibling properties at the same nesting level all have `title` set, so
this was an oversight in three inline object definitions, not an
intentional pattern.

## Affected fields

`components/fieldgroups/paid-media/core-paid-media-attribution-metrics.schema.json`
  - `xdm:devicePathBreakdown` leaves: `mobileToDesktop`, `desktopToMobile`, `mobileToMobileApp`
  - `xdm:channelSequence.items`: `channel`, `position`, `weight`

`components/fieldgroups/paid-media/core-paid-media-campaign-details.schema.json`
  - `xdm:dayParting.schedule.items`: `dayOfWeek`, `startHour`, `endHour`

## Backwards compatibility

No breaking changes. Only `title` and `description` metadata are added;
property names, types, and constraints are unchanged.

`npm test` and `npm run validate components/fieldgroups/paid-media` both
pass on this branch.

Issue: #2170
Jira: AN-451008

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
