### PR TITLE
Add locale variants to paid-media-creative datatype

### DIFF
--- a/components/datatypes/paid-media/paid-media-creative.example.4.json
+++ b/components/datatypes/paid-media/paid-media-creative.example.4.json
@@ -1,0 +1,90 @@
+{
+  "xdm:paidMediaCreative": {
+    "xdm:creativeID": "creative-multilang-001",
+    "xdm:creativeType": "image",
+    "xdm:title": "Discover Our New Collection",
+    "xdm:body": "Shop the latest arrivals and find your next favorite piece.",
+    "xdm:callToAction": "Shop Now",
+    "xdm:destinationURL": "https://example.com/collection?adid=creative-multilang-001&campaignid=fall2025",
+    "xdm:displayURL": "https://example.com/collection",
+    "xdm:assets": [
+      {
+        "xdm:assetID": "asset-multilang-default",
+        "xdm:assetType": "image",
+        "xdm:name": "collection-hero-default.jpg",
+        "xdm:url": "https://cdn.example.com/images/collection-hero-default.jpg",
+        "xdm:dimensions": {
+          "xdm:width": 1200,
+          "xdm:height": 628
+        },
+        "xdm:fileSize": 245760,
+        "xdm:hash": "default0123456789abcdef0123456789"
+      }
+    ],
+    "xdm:localeVariants": [
+      {
+        "xdm:language": "en-US",
+        "xdm:title": "Discover Our New Collection",
+        "xdm:body": "Shop the latest arrivals and find your next favorite piece.",
+        "xdm:callToAction": "Shop Now",
+        "xdm:destinationURL": "https://example.com/collection?adid=creative-multilang-001&campaignid=fall2025&lang=en-US",
+        "xdm:assets": [
+          {
+            "xdm:assetID": "asset-multilang-en",
+            "xdm:assetType": "image",
+            "xdm:name": "collection-hero-en.jpg",
+            "xdm:url": "https://cdn.example.com/images/collection-hero-en.jpg",
+            "xdm:dimensions": {
+              "xdm:width": 1200,
+              "xdm:height": 628
+            },
+            "xdm:fileSize": 245760,
+            "xdm:hash": "en0000000000000000000000000000ab"
+          }
+        ]
+      },
+      {
+        "xdm:language": "ar-AR",
+        "xdm:title": "اكتشف مجموعتنا الجديدة",
+        "xdm:body": "تسوق أحدث وصولاتنا وابحث عن قطعتك المفضلة التالية.",
+        "xdm:callToAction": "تسوق الآن",
+        "xdm:destinationURL": "https://example.com/collection?adid=creative-multilang-001&campaignid=fall2025&lang=ar-AR",
+        "xdm:assets": [
+          {
+            "xdm:assetID": "asset-multilang-ar",
+            "xdm:assetType": "image",
+            "xdm:name": "collection-hero-ar.jpg",
+            "xdm:url": "https://cdn.example.com/images/collection-hero-ar.jpg",
+            "xdm:dimensions": {
+              "xdm:width": 1200,
+              "xdm:height": 628
+            },
+            "xdm:fileSize": 251904,
+            "xdm:hash": "ar0000000000000000000000000000cd"
+          }
+        ]
+      },
+      {
+        "xdm:language": "fr-FR",
+        "xdm:title": "Découvrez notre nouvelle collection",
+        "xdm:body": "Achetez les dernières nouveautés et trouvez votre prochaine pièce préférée.",
+        "xdm:callToAction": "Achetez maintenant",
+        "xdm:destinationURL": "https://example.com/collection?adid=creative-multilang-001&campaignid=fall2025&lang=fr-FR",
+        "xdm:assets": [
+          {
+            "xdm:assetID": "asset-multilang-fr",
+            "xdm:assetType": "image",
+            "xdm:name": "collection-hero-fr.jpg",
+            "xdm:url": "https://cdn.example.com/images/collection-hero-fr.jpg",
+            "xdm:dimensions": {
+              "xdm:width": 1200,
+              "xdm:height": 628
+            },
+            "xdm:fileSize": 248832,
+            "xdm:hash": "fr0000000000000000000000000000ef"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/components/datatypes/paid-media/paid-media-creative.schema.json
+++ b/components/datatypes/paid-media/paid-media-creative.schema.json
@@ -11,6 +11,155 @@
   "type": "object",
   "description": "Data type representing creative assets and content for paid media ads",
   "definitions": {
+    "creativeAsset": {
+      "type": "object",
+      "description": "A single media asset associated with a paid media creative",
+      "properties": {
+        "xdm:assetID": {
+          "type": "string",
+          "title": "Asset ID",
+          "description": "Unique identifier for the asset"
+        },
+        "xdm:assetType": {
+          "type": "string",
+          "title": "Asset Type",
+          "description": "Type of media asset",
+          "enum": ["image", "video", "audio", "document", "other"],
+          "meta:enum": {
+            "image": "Image",
+            "video": "Video",
+            "audio": "Audio",
+            "document": "Document",
+            "other": "Other Asset Type"
+          }
+        },
+        "xdm:name": {
+          "type": "string",
+          "title": "Asset Name",
+          "description": "Name or title of the asset"
+        },
+        "xdm:url": {
+          "type": "string",
+          "format": "uri",
+          "title": "Asset URL",
+          "description": "URL where the asset can be accessed"
+        },
+        "xdm:thumbnailURL": {
+          "type": "string",
+          "format": "uri",
+          "title": "Thumbnail URL",
+          "description": "URL for asset thumbnail"
+        },
+        "xdm:dimensions": {
+          "type": "object",
+          "title": "Asset Dimensions",
+          "description": "Dimensions of the asset",
+          "properties": {
+            "xdm:width": {
+              "type": "integer",
+              "title": "Width",
+              "description": "Width in pixels",
+              "minimum": 0
+            },
+            "xdm:height": {
+              "type": "integer",
+              "title": "Height",
+              "description": "Height in pixels",
+              "minimum": 0
+            }
+          }
+        },
+        "xdm:fileSize": {
+          "type": "integer",
+          "title": "File Size",
+          "description": "File size in bytes",
+          "minimum": 0
+        },
+        "xdm:duration": {
+          "type": "number",
+          "title": "Duration",
+          "description": "Duration in seconds (for video/audio assets)"
+        },
+        "xdm:hash": {
+          "type": "string",
+          "title": "Asset Hash",
+          "description": "Unique hash identifier for the asset content"
+        }
+      }
+    },
+    "creativeTrackingURL": {
+      "type": "object",
+      "description": "A third-party tracking URL associated with a paid media creative",
+      "properties": {
+        "xdm:eventType": {
+          "type": "string",
+          "title": "Event Type",
+          "description": "Type of event being tracked (click, impression, conversion)"
+        },
+        "xdm:url": {
+          "type": "string",
+          "format": "uri",
+          "title": "Tracking URL",
+          "description": "The tracking URL"
+        }
+      }
+    },
+    "creativeLocaleVariant": {
+      "type": "object",
+      "description": "A locale-specific variant of creative content. When the creative is delivered to a user matching this variant's language, the variant's fields override the creative's top-level fields. Modeled after Meta Marketing API asset_feed_spec language_label customization (see https://developers.facebook.com/docs/marketing-api/multi-language-ads/) and is also intended to capture equivalent localization concepts from other ad networks such as Google Ads, TikTok, and Snapchat.",
+      "properties": {
+        "xdm:language": {
+          "type": "string",
+          "title": "Language",
+          "description": "BCP 47 language tag identifying the locale this variant targets. Languages are specified in language code as defined in [IETF BCP 47](https://tools.ietf.org/html/bcp47).",
+          "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$",
+          "examples": ["en-US", "ar-AR", "fr-FR", "ja-JP", "es-ES"]
+        },
+        "xdm:title": {
+          "type": "string",
+          "title": "Title",
+          "description": "Localized creative title or headline. Overrides the creative-level title for this locale."
+        },
+        "xdm:body": {
+          "type": "string",
+          "title": "Body Text",
+          "description": "Localized body text or description. Overrides the creative-level body for this locale."
+        },
+        "xdm:callToAction": {
+          "type": "string",
+          "title": "Call to Action",
+          "description": "Localized call to action text or type. Overrides the creative-level call to action for this locale."
+        },
+        "xdm:destinationURL": {
+          "type": "string",
+          "format": "uri",
+          "title": "Destination URL",
+          "description": "Localized landing page URL where users in this locale are directed. Overrides the creative-level destination URL for this locale."
+        },
+        "xdm:displayURL": {
+          "type": "string",
+          "format": "uri",
+          "title": "Display URL",
+          "description": "Localized URL displayed in the ad for this locale. Overrides the creative-level display URL for this locale."
+        },
+        "xdm:trackingURLs": {
+          "type": "array",
+          "title": "Tracking URLs",
+          "description": "Locale-specific third-party tracking URLs. Overrides the creative-level tracking URLs for this locale.",
+          "items": {
+            "$ref": "#/definitions/creativeTrackingURL"
+          }
+        },
+        "xdm:assets": {
+          "type": "array",
+          "title": "Creative Assets",
+          "description": "Locale-specific media assets used in the creative. Overrides the creative-level assets for this locale.",
+          "items": {
+            "$ref": "#/definitions/creativeAsset"
+          }
+        }
+      }
+    },
     "paidMediaCreative": {
       "properties": {
         "xdm:paidMediaCreative": {
@@ -53,129 +202,52 @@
             "xdm:title": {
               "type": "string",
               "title": "Title",
-              "description": "Creative title or headline"
+              "description": "Creative title or headline. When the creative defines locale variants, this is the default value used for locales that do not match any entry in xdm:localeVariants."
             },
             "xdm:body": {
               "type": "string",
               "title": "Body Text",
-              "description": "Main body text or description"
+              "description": "Main body text or description. When the creative defines locale variants, this is the default value used for locales that do not match any entry in xdm:localeVariants."
             },
             "xdm:callToAction": {
               "type": "string",
               "title": "Call to Action",
-              "description": "Call to action text or type"
+              "description": "Call to action text or type. When the creative defines locale variants, this is the default value used for locales that do not match any entry in xdm:localeVariants."
             },
             "xdm:destinationURL": {
               "type": "string",
               "format": "uri",
               "title": "Destination URL",
-              "description": "Landing page URL where users are directed"
+              "description": "Landing page URL where users are directed. When the creative defines locale variants, this is the default value used for locales that do not match any entry in xdm:localeVariants."
             },
             "xdm:displayURL": {
               "type": "string",
               "format": "uri",
               "title": "Display URL",
-              "description": "URL displayed in the ad"
+              "description": "URL displayed in the ad. When the creative defines locale variants, this is the default value used for locales that do not match any entry in xdm:localeVariants."
             },
             "xdm:trackingURLs": {
               "type": "array",
               "title": "Tracking URLs",
-              "description": "Third-party tracking URLs",
+              "description": "Third-party tracking URLs. When the creative defines locale variants, this is the default value used for locales that do not match any entry in xdm:localeVariants.",
               "items": {
-                "type": "object",
-                "properties": {
-                  "xdm:eventType": {
-                    "type": "string",
-                    "title": "Event Type",
-                    "description": "Type of event being tracked (click, impression, conversion)"
-                  },
-                  "xdm:url": {
-                    "type": "string",
-                    "format": "uri",
-                    "title": "Tracking URL",
-                    "description": "The tracking URL"
-                  }
-                }
+                "$ref": "#/definitions/creativeTrackingURL"
               }
             },
             "xdm:assets": {
               "type": "array",
               "title": "Creative Assets",
-              "description": "Media assets used in the creative",
+              "description": "Media assets used in the creative. When the creative defines locale variants, this is the default value used for locales that do not match any entry in xdm:localeVariants.",
               "items": {
-                "type": "object",
-                "properties": {
-                  "xdm:assetID": {
-                    "type": "string",
-                    "title": "Asset ID",
-                    "description": "Unique identifier for the asset"
-                  },
-                  "xdm:assetType": {
-                    "type": "string",
-                    "title": "Asset Type",
-                    "description": "Type of media asset",
-                    "enum": ["image", "video", "audio", "document", "other"],
-                    "meta:enum": {
-                      "image": "Image",
-                      "video": "Video",
-                      "audio": "Audio",
-                      "document": "Document",
-                      "other": "Other Asset Type"
-                    }
-                  },
-                  "xdm:name": {
-                    "type": "string",
-                    "title": "Asset Name",
-                    "description": "Name or title of the asset"
-                  },
-                  "xdm:url": {
-                    "type": "string",
-                    "format": "uri",
-                    "title": "Asset URL",
-                    "description": "URL where the asset can be accessed"
-                  },
-                  "xdm:thumbnailURL": {
-                    "type": "string",
-                    "format": "uri",
-                    "title": "Thumbnail URL",
-                    "description": "URL for asset thumbnail"
-                  },
-                  "xdm:dimensions": {
-                    "type": "object",
-                    "title": "Asset Dimensions",
-                    "description": "Dimensions of the asset",
-                    "properties": {
-                      "xdm:width": {
-                        "type": "integer",
-                        "title": "Width",
-                        "description": "Width in pixels",
-                        "minimum": 0
-                      },
-                      "xdm:height": {
-                        "type": "integer",
-                        "title": "Height",
-                        "description": "Height in pixels",
-                        "minimum": 0
-                      }
-                    }
-                  },
-                  "xdm:fileSize": {
-                    "type": "integer",
-                    "title": "File Size",
-                    "description": "File size in bytes",
-                    "minimum": 0
-                  },
-                  "xdm:duration": {
-                    "type": "number",
-                    "title": "Duration",
-                    "description": "Duration in seconds (for video/audio assets)"
-                  },
-                  "xdm:hash": {
-                    "type": "string",
-                    "title": "Asset Hash",
-                    "description": "Unique hash identifier for the asset content"
-                  }
-                }
+                "$ref": "#/definitions/creativeAsset"
+              }
+            },
+            "xdm:localeVariants": {
+              "type": "array",
+              "title": "Locale Variants",
+              "description": "Per-language variants of the creative. Each variant overrides creative-level fields (title, body, call to action, destination URL, display URL, tracking URLs, assets) for users matched to that locale. When a single creative is delivered with locale-specific content (as produced by Meta Marketing API multi-language ads, Google Ads ad customizers, or equivalent ad-network localization features), each language version is represented as one item in this array. Consumers should look up the appropriate variant by xdm:language and fall back to the creative-level fields when no variant matches.",
+              "items": {
+                "$ref": "#/definitions/creativeLocaleVariant"
               }
             }
           }


### PR DESCRIPTION
## What this PR does

Adds an `xdm:localeVariants` array to the `paid-media-creative` datatype so a single creative can carry per-locale overrides for `title`, `body`, `callToAction`, `destinationURL`, `displayURL`, `trackingURLs`, and `assets`. Each variant is keyed by an `xdm:language` BCP 47 tag.

This models how ad networks deliver one creative with multiple language versions:

* **Meta Marketing API** — [multi-language ads](https://developers.facebook.com/docs/marketing-api/multi-language-ads/) and [`asset_feed_spec` `language_label`](https://developers.facebook.com/docs/marketing-api/ad-creative/asset-feed-spec/asset-customization-rules/) customization, where the same ad creative carries multiple body/title/image assets each tagged with a language.
* **Google Ads API** — [RSA customization](https://developers.google.com/google-ads/api/docs/ads/customize-responsive-search-ads), where per-language asset variants are expressed via customizers and locale-specific text.

Real-world evidence (parent ticket): we observed the same Meta ad creative ID carrying different asset IDs, images, body text, and headlines per locale. The current schema can only model one of them.

## Design

* Top-level creative fields are unchanged in shape and remain the **default/fallback** value for locales not matched by any variant — consistent with Meta's behavior where assets without `language_label` are free-form defaults.
* `creativeAsset` and `creativeTrackingURL` are extracted into reusable sub-definitions referenced from both the top-level fields and each locale variant, per [CONTRIBUTING.md – Re-Use and Modularity](https://github.com/adobe/xdm/blob/master/CONTRIBUTING.md#re-use-and-modularity).
* `xdm:language` reuses the BCP 47 regex already in use in `profile-preferences-details` and `content-component-details`.

## Breaking changes

None. New optional field on an `experimental` datatype.

## Validation

* `npm run validate components/datatypes/paid-media` — 14 / 14 examples passing
* `npm test` — 2388 mocha tests passing
* `npm run lint` (prettier) — clean

## Related

* GitHub issue: #2173
* Internal Adobe Jira: AN-451211 (design ticket AN-450480)