### PR TITLE
CJM-148039: Custom Channels execution metrics XDM mixin (Phase 1)

### DIFF
--- a/extensions/adobe/experience/customerJourneyManagement/custom-channel-context.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/custom-channel-context.example.1.json
@@ -1,0 +1,8 @@
+{
+  "https://ns.adobe.com/experience/customerJourneyManagement/customChannelContext/customChannelID": "viber",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customChannelContext/customChannelVersion": "v1_viber",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customChannelContext/customChannelAuthID": "49d80637-3de6-4d74-88bc-6a7fbf5f27de",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customChannelContext/customChannelAuthName": "Viber Marketing Bot — APAC",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customChannelContext/customChannelConfigurationID": "a34cc642-82de-4dfd-847e-4128ddfcab9d",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customChannelContext/customChannelConfigurationName": "Viber Holiday Marketing Config"
+}

--- a/extensions/adobe/experience/customerJourneyManagement/custom-channel-context.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/custom-channel-context.schema.json
@@ -1,0 +1,61 @@
+{
+  "meta:license": [
+    "Copyright 2026 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/experience/customerJourneyManagement/customChannelContext",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Adobe CJM ExperienceEvent - Custom Channel Context",
+  "description": "Per-event channel-family identity for outbound open-channel deliveries (Custom Channels — Viber, Kakao, customer-created — and Adobe-provided open channels like LINE). Populated by Message Streaming Worker (MSW) alongside `customExecutionMetrics` when `customExecutionMetrics.executionType=channel`. Carries identifiers for the three Open Message architecture layers: the Custom Channel template (Layer 1 — `customChannelID` / `customChannelVersion`), the API Credentials credential bundle (Layer 2 — `customChannelAuthID` / `customChannelAuthName`), and the Custom Channel Configuration usage policy (Layer 3 — `customChannelConfigurationID` / `customChannelConfigurationName`). See wiki 3886615741 Appendix A for the 3-layer Open Message model. Other channel families (email, SMS, push) use their own dedicated channel-context field groups and leave this absent.",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
+  "definitions": {
+    "customChannelContext": {
+      "properties": {
+        "https://ns.adobe.com/experience/customerJourneyManagement/customChannelContext/customChannelID": {
+          "title": "Custom Channel ID",
+          "type": "string",
+          "description": "Layer-1 Custom Channel identifier — the slug that identifies the channel TEMPLATE this send is for. For Adobe-provided channels: stable slug like `line`, `whatsApp`. For customer-created Custom Channels: the customer-chosen slug (e.g. `viber`, `kakao`, `myCustomChannel`). Stable for the lifetime of the registered Custom Channel. Used as the PRIMARY reporting filter for the Custom Channels Monitoring page in cjm-config-ui (each listing-page row maps to exactly one value here). Slug doubles as the human-readable display name in reports; a separate display field is not provided."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customChannelContext/customChannelVersion": {
+          "title": "Custom Channel Version",
+          "type": "string",
+          "description": "Layer-1 Custom Channel template version identifier (e.g. `v1_line`, `v1_viber`). Used to distinguish reports across template evolution; e.g., separating pre-template-bump and post-template-bump metrics. Stable for a given publication of the Custom Channel template."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customChannelContext/customChannelAuthID": {
+          "title": "API Credentials ID",
+          "type": "string",
+          "description": "Layer-2 API Credentials identifier — the UUID of the specific credential bundle used for this send. Distinct from `customChannelID` (Layer 1 template). One Layer-2 entity per credential bundle; many Layer-2 per Layer-1. Reserved for future support drilldown reports (\"which credentials produced this failure?\"). Phase-1 reporting does not surface this as a filter dimension. May be empty if upstream did not populate (e.g. headless / API-triggered paths that bypass the API Credentials layer)."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customChannelContext/customChannelAuthName": {
+          "title": "API Credentials Name",
+          "type": "string",
+          "description": "Layer-2 API Credentials display name (e.g. `Line Test Bot 2`, `Viber Marketing Bot — APAC`). Customer-chosen at API Credentials creation. Reserved for future support drilldown reports. Phase-1 may emit as empty string when upstream wiring (lazy-fetch of API-Credentials entity by id) has not yet landed; populated when the upstream wiring lands in a follow-up phase."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customChannelContext/customChannelConfigurationID": {
+          "title": "Custom Channel Configuration ID",
+          "type": "string",
+          "description": "Layer-3 Custom Channel Configuration identifier — the UUID of the marketer-facing usage policy that this campaign/journey selected. Distinct from `customChannelAuthID` (Layer 2 credentials). Many Layer-3 configurations CAN reference the same Layer-2 credentials. Reserved for future marketer-facing drilldown reports (\"how is my Halloween marketing config performing?\"). Phase-1 reporting does not surface this as a filter dimension. May be empty for headless / API-triggered paths that bypass the Custom Channel Configuration layer (per wiki 3598294946)."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customChannelContext/customChannelConfigurationName": {
+          "title": "Custom Channel Configuration Name",
+          "type": "string",
+          "description": "Layer-3 Custom Channel Configuration display name (e.g. `Viber Holiday Marketing Config`, `Line Order Confirmation Config`). Customer-chosen at Custom Channel Configuration creation. Reserved for future marketer-facing drilldown reports. May be empty for headless / API-triggered paths."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "#/definitions/customChannelContext"
+    }
+  ],
+  "meta:status": "experimental"
+}

--- a/extensions/adobe/experience/customerJourneyManagement/custom-execution-metrics.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/custom-execution-metrics.example.1.json
@@ -1,0 +1,10 @@
+{
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/executionType": "channel",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/endpoint": "https://api.viber.com/v1/send",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/method": "POST",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/requestTimestamp": "2026-05-20T14:35:22.264Z",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/responseTime": 187,
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/statusCode": 200,
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/throttleApplicable": false,
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/cacheApplicable": false
+}

--- a/extensions/adobe/experience/customerJourneyManagement/custom-execution-metrics.example.2.json
+++ b/extensions/adobe/experience/customerJourneyManagement/custom-execution-metrics.example.2.json
@@ -1,0 +1,12 @@
+{
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/executionType": "channel",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/endpoint": "https://api.viber.com/v1/send",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/method": "POST",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/requestTimestamp": "2026-05-20T14:36:06.450Z",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/responseTime": 2462,
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/statusCode": 503,
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/throttleApplicable": false,
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/cacheApplicable": false,
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/errorCode": "HTTP_5XX",
+  "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/errorReason": "503 Service Unavailable after 3 retries"
+}

--- a/extensions/adobe/experience/customerJourneyManagement/custom-execution-metrics.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/custom-execution-metrics.schema.json
@@ -1,0 +1,92 @@
+{
+  "meta:license": [
+    "Copyright 2026 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Adobe CJM ExperienceEvent - Custom Execution Metrics",
+  "description": "Per-call HTTP-dispatch execution telemetry for customer-configured outbound HTTP integrations. Populated by Message Streaming Worker (MSW) for any send routed through the customer-defined HTTP execution path: Custom Channels (Viber, Kakao, customer-created) and Adobe-provided open channels (LINE). Email / SMS / Push / Web / InApp / DirectMail / Inbox / MessageFeed paths use their own delivery infrastructure and leave this field group absent. Validity-expired events also leave this block absent (handled via messageDeliveryfeedback.messageExclusion). The companion field group `customChannelContext` carries the channel-specific identity (customChannelID, customChannelAuthID, customChannelConfigurationID) when `executionType=channel`. See wiki 3886615741 for design rationale and Appendix A for the 3-layer Open Message model.",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
+  "definitions": {
+    "customExecutionMetrics": {
+      "properties": {
+        "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/executionType": {
+          "title": "Execution Type",
+          "type": "string",
+          "description": "Discriminator describing which kind of customer-configured HTTP execution this event represents. Lets consumers select the appropriate context field group. Free-form string (no enum constraint) so producers can introduce new values without a schema update. Phase-1 known value: `channel` — Custom Channels and Adobe-provided open channels (LINE). The companion identity field group `customChannelContext` carries channel-family identity when this value is `channel`. Future producer-defined values may emerge for other customer-configured HTTP execution paths."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/endpoint": {
+          "title": "Endpoint",
+          "type": "string",
+          "description": "URL template of the customer-configured endpoint, with placeholders un-substituted (e.g. `https://api.viber.com/v1/{{profile.id}}/send`). Stored as the template form — NOT the runtime-interpolated URL — to prevent per-user / per-record cardinality explosion in live reporting (confirmed with reporting team 2026-05-22; precedent is AJO's existing email `domain` derived field that truncates the link URL). Query parameters are stripped before storage. Live reporting derives a coarser `endpointHost` tag from this for Cortex tagging; all-time CJA can use the full template for endpoint-level drilldown. Null when the call was skipped before HTTP was attempted (errorCode set to AUTH_* / REQUEST_GENERATION_ERROR)."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/method": {
+          "title": "HTTP Method",
+          "type": "string",
+          "description": "HTTP method used for the call (POST, GET, PUT, etc.). Null when the call was skipped."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/requestTimestamp": {
+          "title": "Request Timestamp",
+          "type": "string",
+          "format": "date-time",
+          "description": "Wall-clock timestamp (UTC) captured immediately before the customer-endpoint HTTP request is sent on the wire. Null when the call was skipped."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/responseTime": {
+          "title": "Response Time",
+          "type": "integer",
+          "description": "Server HTTP response time in milliseconds. Measured around the customer-endpoint HTTP exchange only - excludes auth latency, connection acquisition, throttle wait (see waitTime), and pool wait. Matches Custom Action XDM actionExecutionOriginTime semantics. For HTTP_TIMEOUT: equals the configured timeout duration. Null when the call was skipped."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/waitTime": {
+          "title": "Wait Time",
+          "type": "integer",
+          "description": "Time in milliseconds the call waited in the throttle queue before the HTTP exchange started. Phase 2: populated when per-call throttle wait instrumentation lands. Phase 1: null/absent (not yet populated by MSW). When populated, total wall-clock latency = waitTime + responseTime + auth/cache overhead."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/statusCode": {
+          "title": "Status Code",
+          "type": "integer",
+          "description": "HTTP response status code from the customer endpoint, preserved as the raw integer (e.g. 401, 503) for finer-grained drilldown and manual debugging. The HTTP_4XX / HTTP_5XX classification in errorCode is a producer-side convenience for bucket gating; consumers SHOULD use statusCode for exact-code analysis. Null when the call was skipped (no HTTP attempt) or timed out without a response."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/throttleApplicable": {
+          "title": "Throttle Applicable",
+          "type": "boolean",
+          "description": "Config-level flag: whether throttling configuration is applied to this endpoint at the time of dispatch. Mirrors the cacheApplicable pattern (config-level vs runtime-level). Does NOT indicate this specific call actually waited in a queue - that signal would require per-call instrumentation (Phase 2; reserved for a separate runtime field). Matches Custom Action XDM actionIsThrottled literal meaning."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/cacheApplicable": {
+          "title": "Cache Applicable",
+          "type": "boolean",
+          "description": "Config-level flag: whether response caching is enabled for this endpoint at the time of dispatch. Mirrors the `throttleApplicable` pattern. Custom Channels and Adobe-provided open channels (LINE) never enable response caching (Caveat E: `responseCacheConfig` default disabled), so this will be `false` for `executionType=channel`. Future Data Integration producers may enable response caching and populate this as `true`. Null when not applicable."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/cacheHit": {
+          "title": "Cache Hit",
+          "type": "boolean",
+          "description": "Runtime indicator: whether this specific call was served from the response cache without hitting the customer endpoint. Only meaningful when `cacheApplicable=true`. Always null for Custom Channels and open channels (caching disabled). Future Data Integration producers populate when applicable. Per Caveat A, response cache only applies for service-user calls; user-initiated calls always skip the cache and populate `cacheHit=false`."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/errorCode": {
+          "title": "Error Code",
+          "type": "string",
+          "description": "Unified error envelope covering both skip-stage (auth/cache) and HTTP-stage (4xx/5xx/timeout) failures. Null on success. Producers SHOULD use the controlled vocabulary documented in wiki 3886615741 section 7 - example values: AUTH_CACHE_IO, AUTH_HTTP_ERROR, AUTH_TOKEN_PARSE, AUTH_TOKEN_EXPIRED, REQUEST_GENERATION_ERROR, HTTP_4XX, HTTP_5XX, HTTP_TIMEOUT, HTTP_PARSE_ERROR. Schema does NOT enum-constrain the value so producer code can evolve the vocabulary without an XDM schema update."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/customExecutionMetrics/errorReason": {
+          "title": "Error Reason",
+          "type": "string",
+          "description": "Human-readable detail of the failure (exception message, parsed error body, etc.). Used for drilldown tooltips and debugging. Not intended for aggregation - use errorCode for grouping. Null on success."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "#/definitions/customExecutionMetrics"
+    }
+  ],
+  "meta:status": "experimental"
+}

--- a/extensions/adobe/experience/customerJourneyManagement/integration-context.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/integration-context.example.1.json
@@ -1,0 +1,4 @@
+{
+  "https://ns.adobe.com/experience/customerJourneyManagement/integrationContext/integrationID": "7f6d8a12-44b2-4f1d-a8c7-2e2a55c0a8f1",
+  "https://ns.adobe.com/experience/customerJourneyManagement/integrationContext/integrationName": "Salesforce Lead Push"
+}

--- a/extensions/adobe/experience/customerJourneyManagement/integration-context.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/integration-context.schema.json
@@ -1,0 +1,41 @@
+{
+  "meta:license": [
+    "Copyright 2026 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/experience/customerJourneyManagement/integrationContext",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Adobe CJM ExperienceEvent - Integration Context",
+  "description": "Per-event integration identity for outbound integration (Data Integration / DI) executions. Populated by Message Streaming Worker (MSW) alongside `customExecutionMetrics` when `customExecutionMetrics.executionType=integration`. Integrations are a flat (single-layer) entity in contrast to the 3-layer Custom Channel model: a single `integrationID` + `integrationName` pair fully identifies the integration definition that this execution invoked. Other execution types (e.g. `channel`) populate their own context field group (`customChannelContext`) and leave this absent.",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
+  "definitions": {
+    "integrationContext": {
+      "properties": {
+        "https://ns.adobe.com/experience/customerJourneyManagement/integrationContext/integrationID": {
+          "title": "Integration ID",
+          "type": "string",
+          "description": "Integration definition identifier — the UUID of the customer-configured integration that this execution invoked. Used as the PRIMARY reporting filter for the Integrations Monitoring page in cjm-config-ui (each listing-page row maps to exactly one value here). Stable for the lifetime of the integration definition."
+        },
+        "https://ns.adobe.com/experience/customerJourneyManagement/integrationContext/integrationName": {
+          "title": "Integration Name",
+          "type": "string",
+          "description": "Integration definition display name (e.g. `My CRM Sync`, `Salesforce Lead Push`). Customer-chosen at integration creation. Surfaced as the row label on the Integrations Monitoring listing page."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "#/definitions/integrationContext"
+    }
+  ],
+  "meta:status": "experimental"
+}


### PR DESCRIPTION
## Summary

**Phase 1 scope: Custom Channels monitoring only.** Adds the `custom-channel-execution-metrics` XDM field group under `extensions/adobe/experience/customerJourneyManagement/`, capturing per-call HTTP execution detail for AJO Custom Channel sends.

This is the schema layer for epic **CJM-119729**, paired with:
- [Adobe-CJM/message-runtime#5962](https://github.com/Adobe-CJM/message-runtime/pull/5962) — Scala model + error vocabulary
- [Adobe-CJM/message-streaming-worker#91](https://github.com/Adobe-CJM/message-streaming-worker/pull/91) — feedback event producer
- [AdobeAnalytics/aaui-features#397](https://github.com/AdobeAnalytics/aaui-features/pull/397) — CJA Workspace template (S1)

Design source-of-truth: wiki 3886615741.

## Explicitly out of scope (Phase 1B)

- **Integrations monitoring** — no `integration-execution-metrics` mixin, no `integrationExecutionMetrics` field, no integration resolver, no `ajo-integration` CJA template in this PR or its linked stack.
- Integrations design remains documented in the wiki for a future phase.

## Field design (`custom-channel-execution-metrics`)

| Field | Semantics |
|---|---|
| `endpoint` | URL template (un-interpolated) — cardinality control |
| `method` | HTTP verb |
| `requestTimestamp` | ISO-8601 at HTTP boundary |
| `responseTime` | ms at HTTP boundary only (auth excluded) |
| `waitTime` | Phase-2 reserved (emit 0 today) |
| `statusCode` | Raw integer HTTP status |
| `throttleApplicable` | Config-applied throttling flag |
| `errorCode` | Free-form string; producer vocabulary in `ExecutionErrorCode` |
| `errorReason` | Human-readable detail |

## Test plan

- [x] Local: `npm run format:check`, `npm test`, `npm run xed-validation`
- [ ] CI green on fork branch `feature/custom-channel-execution-metrics-mixin-v2` @ `c797877de`