### PR TITLE
CJM-141473: Add isBot boolean field to messageInteraction schema

### DIFF
--- a/docs/reference/adobe/experience/customerJourneyManagement/message-interaction.schema.json
+++ b/docs/reference/adobe/experience/customerJourneyManagement/message-interaction.schema.json
@@ -88,6 +88,14 @@
                     "meta:titleId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/label##title##38721",
                     "meta:descriptionId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/label##description##5891"
                 },
+                "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/isBot": {
+                    "title": "Is Bot Interaction",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "True if this interaction was identified as automated/non-human by bot detection. Additive field — independent of interactionType. Absent is equivalent to false; no backfill required for historical events.",
+                    "meta:titleId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/isBot##title##1",
+                    "meta:descriptionId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/isBot##description##1"
+                },
                 "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/offers": {
                     "title": "Offer Details",
                     "$ref": "https://ns.adobe.com/experience/customerJourneyManagement/offers",

--- a/extensions/adobe/experience/customerJourneyManagement/message-interaction.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/message-interaction.schema.json
@@ -93,6 +93,14 @@
           "meta:titleId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/label##title##38721",
           "meta:descriptionId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/label##description##5891"
         },
+        "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/isBot": {
+          "title": "Is Bot Interaction",
+          "type": "boolean",
+          "default": false,
+          "description": "True if this interaction was identified as automated/non-human by bot detection. Additive field — independent of interactionType. Absent is equivalent to false; no backfill required for historical events.",
+          "meta:titleId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/isBot##title##1",
+          "meta:descriptionId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/isBot##description##1"
+        },
         "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/offers": {
           "title": "Offer Details",
           "$ref": "https://ns.adobe.com/experience/customerJourneyManagement/offers",


### PR DESCRIPTION
Additive boolean field for bot detection. Does not change the interactionType enum — click/open values are preserved unchanged.  

## Summary

Adds an additive `isBot` boolean field to `message-interaction` under
`extensions/adobe/experience/customerJourneyManagement/`. Marks a recipient
interaction (click/open) as identified by bot detection. Field is absent
when false; no backfill required for historical events. The `interactionType`
enum is preserved unchanged.

This is the schema layer for **CJM-141473** (replacement design for the
destructive `bot_click`/`bot_open` enum approach that caused PLATIR-63838 /
PLATIR-64150 on May 8–12). Paired with:

- [cjm/tracker#605](https://git.corp.adobe.com/cjm/tracker/pull/605) — Tracker stops emitting BOT_CLICK / BOT_OPEN; sets `messageInteraction.isBot = true` on bot-detected clicks
- [AresSolutionConfig/ares_ajo_config#181](https://git.corp.adobe.com/AresSolutionConfig/ares_ajo_config/pull/181) — `sm_ajo_outboundBotClicks` backed by composite derived field (`isBot=true ∧ interactionType=click ∧ entityType=message`)

 

## Explicitly out of scope
 

## Field design

| Field | Type | Required | Semantics |
|---|---|---|---|
| `isBot` | boolean | no | `true` ⇒ this interaction was identified as automated/non-human. Absent or `false` ⇒ human (or unknown). |
 