### PR TITLE
CJM-148718: Add sourceVersionId to AJO Lifecycle field group

### DIFF
--- a/extensions/adobe/experience/lifecycle/lifecycle.example.1.json
+++ b/extensions/adobe/experience/lifecycle/lifecycle.example.1.json
@@ -1,0 +1,13 @@
+{
+  "https://ns.adobe.com/experience/lifecycle": {
+    "https://ns.adobe.com/experience/lifecycle/sourceId": "campaign-123",
+    "https://ns.adobe.com/experience/lifecycle/sourceType": "campaign",
+    "https://ns.adobe.com/experience/lifecycle/sourceName": "Sample Campaign A",
+    "https://ns.adobe.com/experience/lifecycle/status": "live",
+    "https://ns.adobe.com/experience/lifecycle/statusCode": "",
+    "https://ns.adobe.com/experience/lifecycle/processType": "stopping",
+    "https://ns.adobe.com/experience/lifecycle/processStatus": "failed"
+  }
+}
+
+

--- a/extensions/adobe/experience/lifecycle/lifecycle.example.1.json
+++ b/extensions/adobe/experience/lifecycle/lifecycle.example.1.json
@@ -1,6 +1,7 @@
 {
   "https://ns.adobe.com/experience/lifecycle": {
     "https://ns.adobe.com/experience/lifecycle/sourceId": "campaign-123",
+    "https://ns.adobe.com/experience/lifecycle/sourceVersionId": "campaign-version-456",
     "https://ns.adobe.com/experience/lifecycle/sourceType": "campaign",
     "https://ns.adobe.com/experience/lifecycle/sourceName": "Sample Campaign A",
     "https://ns.adobe.com/experience/lifecycle/status": "live",

--- a/extensions/adobe/experience/lifecycle/lifecycle.example.2.json
+++ b/extensions/adobe/experience/lifecycle/lifecycle.example.2.json
@@ -1,0 +1,13 @@
+{
+  "https://ns.adobe.com/experience/lifecycle": {
+    "https://ns.adobe.com/experience/lifecycle/sourceId": "campaign-456",
+    "https://ns.adobe.com/experience/lifecycle/sourceType": "campaign",
+    "https://ns.adobe.com/experience/lifecycle/sourceName": "Sample Campaign B",
+    "https://ns.adobe.com/experience/lifecycle/status": "stopped",
+    "https://ns.adobe.com/experience/lifecycle/statusCode": "",
+    "https://ns.adobe.com/experience/lifecycle/processType": "stopping",
+    "https://ns.adobe.com/experience/lifecycle/processStatus": "processed"
+  }
+}
+
+

--- a/extensions/adobe/experience/lifecycle/lifecycle.example.3.json
+++ b/extensions/adobe/experience/lifecycle/lifecycle.example.3.json
@@ -1,0 +1,13 @@
+{
+  "https://ns.adobe.com/experience/lifecycle": {
+    "https://ns.adobe.com/experience/lifecycle/sourceId": "campaign-789",
+    "https://ns.adobe.com/experience/lifecycle/sourceType": "campaign",
+    "https://ns.adobe.com/experience/lifecycle/sourceName": "Sample Campaign C",
+    "https://ns.adobe.com/experience/lifecycle/status": "scheduled",
+    "https://ns.adobe.com/experience/lifecycle/statusCode": "",
+    "https://ns.adobe.com/experience/lifecycle/processType": "publishing",
+    "https://ns.adobe.com/experience/lifecycle/processStatus": "processed"
+  }
+}
+
+

--- a/extensions/adobe/experience/lifecycle/lifecycle.schema.json
+++ b/extensions/adobe/experience/lifecycle/lifecycle.schema.json
@@ -43,6 +43,11 @@
                     "type": "string",
                     "description": "Identifier for the AJO entity (e.g., journey ID, campaign ID)."
                 },
+                "https://ns.adobe.com/experience/lifecycle/sourceVersionId": {
+                    "title": "Source Version ID",
+                    "type": "string",
+                    "description": "Identifier for the version of the AJO entity (e.g., journey version ID, campaign version ID)."
+                },
                 "https://ns.adobe.com/experience/lifecycle/sourceType": {
                     "title": "Source Type",
                     "type": "string",

--- a/extensions/adobe/experience/lifecycle/lifecycle.schema.json
+++ b/extensions/adobe/experience/lifecycle/lifecycle.schema.json
@@ -1,0 +1,99 @@
+{
+    "meta:license": [
+        "Copyright 2025 Adobe Systems Incorporated. All rights reserved.",
+        "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+        "you may not use this file except in compliance with the License. You may obtain a copy",
+        "of the License at https://creativecommons.org/licenses/by/4.0/"
+    ],
+    "$id": "https://ns.adobe.com/experience/lifecycle",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Lifecycle Fields",
+    "type": "object",
+    "meta:extensible": false,
+    "meta:abstract": true,
+    "meta:intendedToExtend": [
+        "https://ns.adobe.com/xdm/context/experienceevent"
+    ],
+    "description": "A set of meta-data fields that describe lifecycle events related to AJO entities.",
+    "definitions": {
+        "lifecycle": {
+            "properties": {
+                "https://ns.adobe.com/experience/lifecycle/status": {
+                    "title": "Status",
+                    "type": "string",
+                    "description": "The lifecycle status of the journey step (e.g., draft, live, completed)."
+                },
+                "https://ns.adobe.com/experience/lifecycle/statusCode": {
+                    "title": "Status Code",
+                    "type": "string",
+                    "description": "A machine-readable code representing the lifecycle status."
+                },
+                "https://ns.adobe.com/experience/lifecycle/processType": {
+                    "title": "Process Type",
+                    "type": "string",
+                    "description": "The type of process being executed (e.g., publishing, stopping, delivering)."
+                },
+                "https://ns.adobe.com/experience/lifecycle/processStatus": {
+                    "title": "Process Status",
+                    "type": "string",
+                    "description": "Status of the process (e.g., processing, processed, failed, completed)."
+                },
+                "https://ns.adobe.com/experience/lifecycle/sourceId": {
+                    "title": "Source ID",
+                    "type": "string",
+                    "description": "Identifier for the AJO entity (e.g., journey ID, campaign ID)."
+                },
+                "https://ns.adobe.com/experience/lifecycle/sourceType": {
+                    "title": "Source Type",
+                    "type": "string",
+                    "description": "Type of the AJO entity (e.g., campaign, journey)."
+                },
+                "https://ns.adobe.com/experience/lifecycle/sourceName": {
+                    "title": "Source Name",
+                    "type": "string",
+                    "description": "Human-readable name of the AJO entity."
+                },
+                "https://ns.adobe.com/experience/lifecycle/isRecurrent": {
+                    "title": "Is Recurrent",
+                    "type": "boolean",
+                    "description": "Indicates if this lifecycle event is part of a recurring AJO entity."
+                },
+                "https://ns.adobe.com/experience/lifecycle/batchInstanceId": {
+                    "title": "Batch Instance ID",
+                    "type": "string",
+                    "description": "Unique identifier for the batch instance."
+                },
+                "https://ns.adobe.com/experience/lifecycle/recurrenceIndex": {
+                    "title": "Recurrence Index",
+                    "type": "integer",
+                    "description": "Index value representing the recurrence index of a recurring AJO entity."
+                }
+            },
+            "required": [
+                "https://ns.adobe.com/experience/lifecycle/sourceId",
+                "https://ns.adobe.com/experience/lifecycle/sourceType",
+                "https://ns.adobe.com/experience/lifecycle/sourceName",
+                "https://ns.adobe.com/experience/lifecycle/status"
+            ]
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "#/definitions/lifecycle"
+        }
+    ],
+    "meta:status": "experimental",
+    "examples": [
+        {
+            "https://ns.adobe.com/experience/lifecycle": {
+                "https://ns.adobe.com/experience/lifecycle/sourceId": "campaign-123",
+                "https://ns.adobe.com/experience/lifecycle/sourceType": "campaign",
+                "https://ns.adobe.com/experience/lifecycle/sourceName": "Welcome Campaign",
+                "https://ns.adobe.com/experience/lifecycle/status": "draft",
+                "https://ns.adobe.com/experience/lifecycle/statusCode": "",
+                "https://ns.adobe.com/experience/lifecycle/processType": "publishing",
+                "https://ns.adobe.com/experience/lifecycle/processStatus": "failed"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Summary

  - Adds sourceVersionId as an optional string field to the https://ns.adobe.com/experience/lifecycle field group
  - The field captures the version identifier of an AJO entity (e.g., journey version ID, campaign version ID), complementing the existing sourceId field
  - Updated lifecycle.example.1.json to include a sample value for sourceVersionId

Jira:
https://jira.corp.adobe.com/browse/CJM-148718 