### PR TITLE
paid-media: add optional denormalized-names fieldgroup for summary metrics

### DIFF
--- a/components/fieldgroups/paid-media/core-paid-media-denormalized-names.example.1.json
+++ b/components/fieldgroups/paid-media/core-paid-media-denormalized-names.example.1.json
@@ -1,0 +1,13 @@
+{
+  "xdm:paidMedia": {
+    "xdm:denormalizedNames": {
+      "xdm:accountName": "Acme Corp - Meta Business Account",
+      "xdm:campaignName": "Spring 2026 Brand Awareness - US",
+      "xdm:adGroupName": "Lookalike 1% - Tech Enthusiasts",
+      "xdm:adName": "Hero Video 15s - Variant B",
+      "xdm:experienceName": "Multi-Asset Carousel - Spring Launch",
+      "xdm:assetName": "spring_hero_15s_v2.mp4",
+      "xdm:portfolioName": "Brand Awareness Q2"
+    }
+  }
+}

--- a/components/fieldgroups/paid-media/core-paid-media-denormalized-names.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-denormalized-names.schema.json
@@ -1,0 +1,75 @@
+{
+  "meta:license": [
+    "Copyright 2026 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "https://ns.adobe.com/xdm/mixins/paid-media/denormalized-names",
+  "title": "Core Paid Media Denormalized Names",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/classes/paid-media"],
+  "description": "Optional denormalized entity names for paid media summary datasets. Intended for ingestion shapes where lookup datasets are not available (e.g., MCA single-dataset feeds) and entity names must be carried inline on each summary row. Lookup-driven ingestions should leave these fields null and resolve names via the corresponding lookup datasets.",
+  "definitions": {
+    "denormalized-names": {
+      "properties": {
+        "xdm:paidMedia": {
+          "type": "object",
+          "properties": {
+            "xdm:denormalizedNames": {
+              "type": "object",
+              "title": "Denormalized Names",
+              "description": "Entity display names carried inline on the summary row when lookup datasets are not available.",
+              "properties": {
+                "xdm:accountName": {
+                  "type": "string",
+                  "title": "Account Name",
+                  "description": "Display name of the ad account. Mirrors accountDetails.accountName from the account lookup."
+                },
+                "xdm:campaignName": {
+                  "type": "string",
+                  "title": "Campaign Name",
+                  "description": "Display name of the campaign. Mirrors metadata.name from the campaign lookup."
+                },
+                "xdm:adGroupName": {
+                  "type": "string",
+                  "title": "Ad Group Name",
+                  "description": "Display name of the ad group/ad set/ad squad. Mirrors metadata.name from the ad group lookup."
+                },
+                "xdm:adName": {
+                  "type": "string",
+                  "title": "Ad Name",
+                  "description": "Display name of the individual ad. Mirrors metadata.name from the ad lookup."
+                },
+                "xdm:experienceName": {
+                  "type": "string",
+                  "title": "Experience Name",
+                  "description": "Display name of the creative experience. Mirrors metadata.name from the experience lookup."
+                },
+                "xdm:assetName": {
+                  "type": "string",
+                  "title": "Asset Name",
+                  "description": "Display name of the creative asset. Mirrors metadata.name from the asset lookup."
+                },
+                "xdm:portfolioName": {
+                  "type": "string",
+                  "title": "Portfolio Name",
+                  "description": "Display name of the portfolio (Amazon Ads and similar platforms)."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/denormalized-names"
+    }
+  ],
+  "meta:status": "experimental"
+}

--- a/schemas/paid-media/paid-media-summary-metrics.example.8.json
+++ b/schemas/paid-media/paid-media-summary-metrics.example.8.json
@@ -1,0 +1,41 @@
+{
+  "xdm:timestamp": "2026-05-15T00:00:00Z",
+  "xdm:paidMedia": {
+    "xdm:adNetwork": "other",
+    "xdm:accountID": "mca_account_abc123",
+    "xdm:accountGUID": "mca_act_abc123",
+    "xdm:campaignID": "mca_campaign_990011",
+    "xdm:campaignGUID": "mca_cmp_990011",
+    "xdm:adGroupID": "mca_adgroup_445566",
+    "xdm:adGroupGUID": "mca_adg_445566",
+    "xdm:adID": "mca_ad_778899",
+    "xdm:adGUID": "mca_ad_778899",
+    "xdm:hierarchyPath": "mca_account_abc123/mca_campaign_990011/mca_adgroup_445566/mca_ad_778899",
+    "xdm:channel": "PaidMedia",
+    "xdm:denormalizedNames": {
+      "xdm:accountName": "Acme Corp - MCA Paid Media Feed",
+      "xdm:campaignName": "Spring 2026 Brand Awareness - US",
+      "xdm:adGroupName": "Lookalike 1% - Tech Enthusiasts",
+      "xdm:adName": "Hero Video 15s - Variant B",
+      "xdm:experienceName": "Multi-Asset Carousel - Spring Launch",
+      "xdm:assetName": "spring_hero_15s_v2.mp4",
+      "xdm:portfolioName": "Brand Awareness Q2"
+    },
+    "xdm:metrics": {
+      "xdm:impressions": 87000,
+      "xdm:clicks": 2900,
+      "xdm:spend": 2175.50,
+      "xdm:conversions": 142,
+      "xdm:conversionValue": 7820.0,
+      "xdm:ctr": 0.0333,
+      "xdm:cpc": 0.75,
+      "xdm:cpm": 25.0,
+      "xdm:costPerConversion": 15.32,
+      "xdm:roas": 3.59
+    },
+    "xdm:dimensionalBreakdowns": {
+      "xdm:deviceType": "desktop",
+      "xdm:country": "US"
+    }
+  }
+}

--- a/schemas/paid-media/paid-media-summary-metrics.schema.json
+++ b/schemas/paid-media/paid-media-summary-metrics.schema.json
@@ -43,6 +43,9 @@
     },
     {
       "$ref": "https://ns.adobe.com/xdm/mixins/paid-media/quality-metrics"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/mixins/paid-media/denormalized-names"
     }
   ],
   "meta:status": "experimental"


### PR DESCRIPTION
## Summary

Adds a new optional fieldgroup `core-paid-media-denormalized-names` and references it from the `paid-media-summary-metrics` schema.

The fieldgroup carries inline entity display names (`accountName`, `campaignName`, `adGroupName`, `adName`, `experienceName`, `assetName`, `portfolioName`) on each summary row.

## Motivation

The current Paid Media model expects entity names to be resolved via the per-entity lookup datasets (`paid-media-campaign-lookup`, `paid-media-ad-group-lookup`, etc.) to avoid duplicating name strings on every summary row.

For the MCA (Marketing Campaign Analytics) single-dataset use case — where a customer brings their own paid media data in a single flat feed without separate lookup datasets — there is no way today to surface entity names in reporting.

This change introduces an **optional** fieldgroup so:

- Lookup-driven ingestions leave `xdm:paidMedia.xdm:denormalizedNames.*` null and resolve names via lookups (no regression, no bloat).
- MCA / single-dataset ingestions populate the fields inline.

## Files

- New: `components/fieldgroups/paid-media/core-paid-media-denormalized-names.schema.json`
- New: `components/fieldgroups/paid-media/core-paid-media-denormalized-names.example.1.json`
- Modified: `schemas/paid-media/paid-media-summary-metrics.schema.json` — added `$ref` to the new fieldgroup in `allOf`.

## Notes

- Fieldgroup is marked `meta:status: experimental` consistent with the rest of the paid-media schemas.
- Open question: whether MCA needs additional cross-channel fields here (e.g., Big-C Marketing Campaign, Marketing Channel) — likely belongs in a separate shared MCA fieldgroup rather than this one. Tracking that conversation with Amanda Diamante.