### PR TITLE
CJM-141473: Add isBot boolean field in messageInteraction schema

### DIFF
--- a/docs/reference/adobe/experience/customerJourneyManagement/message-interaction.schema.json
+++ b/docs/reference/adobe/experience/customerJourneyManagement/message-interaction.schema.json
@@ -88,6 +88,14 @@
                     "meta:titleId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/label##title##38721",
                     "meta:descriptionId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/label##description##5891"
                 },
+                "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/isBot": {
+                    "title": "Is Bot Interaction",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "True if this interaction was identified as automated/non-human by bot detection. Additive field — independent of interactionType. Absent is equivalent to false; no backfill required for historical events.",
+                    "meta:titleId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/isBot##title##1",
+                    "meta:descriptionId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/isBot##description##1"
+                },
                 "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/offers": {
                     "title": "Offer Details",
                     "$ref": "https://ns.adobe.com/experience/customerJourneyManagement/offers",

--- a/extensions/adobe/experience/customerJourneyManagement/message-interaction.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/message-interaction.schema.json
@@ -93,6 +93,14 @@
           "meta:titleId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/label##title##38721",
           "meta:descriptionId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/label##description##5891"
         },
+        "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/isBot": {
+          "title": "Is Bot Interaction",
+          "type": "boolean",
+          "default": false,
+          "description": "True if this interaction was identified as automated/non-human by bot detection. Additive field — independent of interactionType. Absent is equivalent to false; no backfill required for historical events.",
+          "meta:titleId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/isBot##title##1",
+          "meta:descriptionId": "message-interaction##https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/isBot##description##1"
+        },
         "https://ns.adobe.com/experience/customerJourneyManagement/messageInteraction/offers": {
           "title": "Offer Details",
           "$ref": "https://ns.adobe.com/experience/customerJourneyManagement/offers",


### PR DESCRIPTION
Additive boolean field for bot detection. Does not change the interactionType enum — click/open values are preserved unchanged. Absent field is equivalent to false; no historical backfill needed.
