### PR TITLE
Add channelName to AJO entity channelDetails

### DIFF
--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
@@ -25,6 +25,7 @@
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/channel": {
       "@id": "https://ns.adobe.com/xdm/channels/email"
     },
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelName": "Acme Marketing Channel",
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/template": "Hi {{person.firstName}}",
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/messagePublishedAt": "2021-06-25T15:52:25+00:00",
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelConfigName": "Push Configuration Name",

--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
@@ -129,6 +129,11 @@
               "$ref": "https://ns.adobe.com/xdm/channels/channel",
               "description": "Each specific experience channel defines a constant `@id`."
             },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelName": {
+              "title": "Channel Name",
+              "type": "string",
+              "description": "Human-readable display name of the channel instance — for customer-created custom channels, the configured channel name (for example, the name a customer gives their Viber channel). The name is user-editable, so reporting aggregates on the immutable channel id (`channel.@id`) and renders this denormalized name for display only; it is resolved when the entity row is emitted."
+            },
             "https://ns.adobe.com/experience/customerJourneyManagement/entities/template": {
               "title": "The json template used in the message",
               "type": "string",

--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
@@ -132,7 +132,7 @@
             "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelName": {
               "title": "Channel Name",
               "type": "string",
-              "description": "Human-readable display name of the channel instance — for customer-created custom channels, the configured channel name (for example, the name a customer gives their Viber channel). The name is user-editable, so reporting aggregates on the immutable channel id (`channel.@id`) and renders this denormalized name for display only; it is resolved when the entity row is emitted."
+              "description": "The display name of the channel. For customer-created custom channels, this is the channel name configured by the customer."
             },
             "https://ns.adobe.com/experience/customerJourneyManagement/entities/template": {
               "title": "The json template used in the message",


### PR DESCRIPTION
## Summary

Closes #2195

Adds an optional `channelName` string to `entities.channelDetails` so reporting can show a channel's display name. **Additive, non-breaking.**

## Motivation

`channelDetails` carries the channel id (`channel.@id`) and the channel configuration name/id, but has no field for the channel instance's own display name. Custom channels need this so dashboards can show the channel's name (for example, "Acme Marketing Channel") resolved from its id — the same pattern `entities.journey` (`journeyName`) already uses.

## Changes

- `ajo-entity-mixins.schema.json` — add `entities/channelName` (string) to `channelDetails`.
- `ajo-entity-mixins.example.1.json` — add a `channelName` value.

## Validation

- `npm test` — 2405 passing
- `npm run lint` — clean

## Breaking changes

None. Additive optional property on an existing field group.

<details>
<summary>🔍 Why a separate field</summary>

`channelConfigName` is the *configuration's* name; `channelName` is the channel instance's own display name — a distinct value. The name is user-editable, so reporting keys on the immutable channel id and renders `channelName` for display only, mirroring how `entities.journey.journeyName` works.
</details>
