### PR TITLE
Add endpoint, httpMethod, throttleRate to AJO entity channelDetails

### DIFF
--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
@@ -26,6 +26,9 @@
       "@id": "https://ns.adobe.com/xdm/channels/email"
     },
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelName": "Acme Marketing Channel",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/endpoint": "https://api.example.com/v1/messages",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/httpMethod": "POST",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/throttleRate": 100,
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/template": "Hi {{person.firstName}}",
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/messagePublishedAt": "2021-06-25T15:52:25+00:00",
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/channelConfigName": "Push Configuration Name",

--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
@@ -134,6 +134,21 @@
               "type": "string",
               "description": "The display name of the channel. For customer-created custom channels, this is the channel name configured by the customer."
             },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/endpoint": {
+              "title": "Endpoint",
+              "type": "string",
+              "description": "For customer-created custom channels, the configured endpoint URL in template form, with placeholders left un-substituted and query parameters removed."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/httpMethod": {
+              "title": "HTTP Method",
+              "type": "string",
+              "description": "For customer-created custom channels, the HTTP method used to call the endpoint (for example, POST)."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/throttleRate": {
+              "title": "Throttle Rate",
+              "type": "integer",
+              "description": "For customer-created custom channels, the configured throttling rate as requests admitted per refill interval. Absent when the channel is not throttled."
+            },
             "https://ns.adobe.com/experience/customerJourneyManagement/entities/template": {
               "title": "The json template used in the message",
               "type": "string",


### PR DESCRIPTION
## Summary

Closes #2197

Adds three custom-channel configuration fields — `endpoint`, `httpMethod`, `throttleRate` — to `entities.channelDetails`. **Additive, non-breaking.**

## Motivation

These describe the channel configuration a delivery used, and they are the same for every recipient of an execution. So reporting reads them once from the channel entity rather than from each per-recipient delivery-feedback event. They sit alongside the existing `channelName` / `channelConfigName` / `channelConfigID` on `channelDetails` (follow-up to #2196, which added `channelName`).

## Changes

- `ajo-entity-mixins.schema.json` — add `entities/endpoint`, `entities/httpMethod`, `entities/throttleRate` to `channelDetails`.
- `ajo-entity-mixins.example.1.json` — add example values.

## Validation

- `npm test` — **2409 passing**
- `npm run lint` — clean (prettier)

## Breaking changes

None. Additive optional properties on an existing field group.

<details>
<summary>🔍 Why on the channel entity (not the feedback event)</summary>

A delivery-feedback event fires once per recipient per attempt, so it should carry only what *varies* by recipient (HTTP status, latency, error). `endpoint` / `httpMethod` / `throttleRate` come from the channel configuration and are constant across all recipients of an execution, so carrying them on every feedback event would duplicate them. They belong on the channel entity, which reporting already joins — the same reasoning behind keeping the per-recipient results on the feedback group and the channel's display name (`channelName`) here.
</details>
