### PR TITLE
Promote paid-media schemas from experimental to stable

### DIFF
--- a/components/classes/paid-media.schema.json
+++ b/components/classes/paid-media.schema.json
@@ -137,5 +137,5 @@
       "$ref": "#/definitions/paid-media"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/datatypes/paid-media/paid-media-additional-field.schema.json
+++ b/components/datatypes/paid-media/paid-media-additional-field.schema.json
@@ -48,5 +48,5 @@
       "$ref": "#/definitions/additionalField"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/datatypes/paid-media/paid-media-creative.schema.json
+++ b/components/datatypes/paid-media/paid-media-creative.schema.json
@@ -390,5 +390,5 @@
       "$ref": "#/definitions/paidMediaCreative"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/datatypes/paid-media/paid-media-targeting.schema.json
+++ b/components/datatypes/paid-media/paid-media-targeting.schema.json
@@ -293,5 +293,5 @@
       "$ref": "#/definitions/targeting"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/datatypes/paid-media/paid-media-url-tracking.schema.json
+++ b/components/datatypes/paid-media/paid-media-url-tracking.schema.json
@@ -51,5 +51,5 @@
       "$ref": "#/definitions/urlTracking"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-account-details.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-account-details.schema.json
@@ -226,5 +226,5 @@
       "$ref": "#/definitions/account-details"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-ad-details.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-ad-details.schema.json
@@ -407,5 +407,5 @@
       "$ref": "#/definitions/ad-details"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-adgroup-details.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-adgroup-details.schema.json
@@ -394,5 +394,5 @@
       "$ref": "#/definitions/adgroup-details"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-asset-details.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-asset-details.schema.json
@@ -415,5 +415,5 @@
       "$ref": "#/definitions/asset-details"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-attribution-metrics.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-attribution-metrics.schema.json
@@ -340,5 +340,5 @@
       "$ref": "#/definitions/attribution-metrics"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-campaign-details.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-campaign-details.schema.json
@@ -620,5 +620,5 @@
       "$ref": "#/definitions/campaign-details"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-conversion-metrics.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-conversion-metrics.schema.json
@@ -283,5 +283,5 @@
       "$ref": "#/definitions/conversion-metrics"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-cost-metrics.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-cost-metrics.schema.json
@@ -325,5 +325,5 @@
       "$ref": "#/definitions/cost-metrics"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-denormalized-names.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-denormalized-names.schema.json
@@ -71,5 +71,5 @@
       "$ref": "#/definitions/denormalized-names"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-dimensional-breakdowns.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-dimensional-breakdowns.schema.json
@@ -194,5 +194,5 @@
       "$ref": "#/definitions/dimensional-breakdowns"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-experience-details.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-experience-details.schema.json
@@ -319,5 +319,5 @@
       "$ref": "#/definitions/experience-details"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-extended-metrics.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-extended-metrics.schema.json
@@ -259,5 +259,5 @@
       "$ref": "#/definitions/extended-metrics"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-identifiers.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-identifiers.schema.json
@@ -148,5 +148,5 @@
       "$ref": "#/definitions/core-identifiers"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-metadata.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-metadata.schema.json
@@ -229,5 +229,5 @@
       "$ref": "#/definitions/core-metadata"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-metrics.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-metrics.schema.json
@@ -165,5 +165,5 @@
       "$ref": "#/definitions/core-metrics"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-quality-metrics.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-quality-metrics.schema.json
@@ -243,5 +243,5 @@
       "$ref": "#/definitions/quality-metrics"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/components/fieldgroups/paid-media/core-paid-media-video-metrics.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-video-metrics.schema.json
@@ -256,5 +256,5 @@
       "$ref": "#/definitions/video-metrics"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/schemas/paid-media/paid-media-account-lookup.schema.json
+++ b/schemas/paid-media/paid-media-account-lookup.schema.json
@@ -30,5 +30,5 @@
       "$ref": "https://ns.adobe.com/xdm/mixins/paid-media/account-details"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/schemas/paid-media/paid-media-ad-lookup.schema.json
+++ b/schemas/paid-media/paid-media-ad-lookup.schema.json
@@ -30,5 +30,5 @@
       "$ref": "https://ns.adobe.com/xdm/mixins/paid-media/ad-details"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/schemas/paid-media/paid-media-adgroup-lookup.schema.json
+++ b/schemas/paid-media/paid-media-adgroup-lookup.schema.json
@@ -30,5 +30,5 @@
       "$ref": "https://ns.adobe.com/xdm/mixins/paid-media/adgroup-details"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/schemas/paid-media/paid-media-asset-lookup.schema.json
+++ b/schemas/paid-media/paid-media-asset-lookup.schema.json
@@ -30,5 +30,5 @@
       "$ref": "https://ns.adobe.com/xdm/mixins/paid-media/asset-details"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/schemas/paid-media/paid-media-campaign-lookup.schema.json
+++ b/schemas/paid-media/paid-media-campaign-lookup.schema.json
@@ -30,5 +30,5 @@
       "$ref": "https://ns.adobe.com/xdm/mixins/paid-media/campaign-details"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/schemas/paid-media/paid-media-experience-lookup.schema.json
+++ b/schemas/paid-media/paid-media-experience-lookup.schema.json
@@ -30,5 +30,5 @@
       "$ref": "https://ns.adobe.com/xdm/mixins/paid-media/experience-details"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }

--- a/schemas/paid-media/paid-media-summary-metrics.schema.json
+++ b/schemas/paid-media/paid-media-summary-metrics.schema.json
@@ -48,5 +48,5 @@
       "$ref": "https://ns.adobe.com/xdm/mixins/paid-media/denormalized-names"
     }
   ],
-  "meta:status": "experimental"
+  "meta:status": "stable"
 }


### PR DESCRIPTION
## Summary

Closes #2199

Internal documentation ticket: AN-455318

Promotes all **paid-media** XDM components from `meta:status: experimental` to `meta:status: stable`. Metadata-only, **non-breaking** — no fields, types, enums, or `$ref`s change.

## Motivation

The paid-media model has stabilized and now meets the [`meta:status` criteria in CONTRIBUTING.md](https://github.com/adobe/xdm/blob/master/CONTRIBUTING.md#specify-the-metastatus) for `stable`. Promoting it signals to downstream AEP/CJA consumers that the field shapes are committed and will only evolve additively.

## Changes

Top-level `meta:status` flipped `experimental` → `stable` in 29 schemas:

- `components/classes/paid-media.schema.json` — 1 class
- `components/datatypes/paid-media/*.schema.json` — 4 datatypes
- `components/fieldgroups/paid-media/*.schema.json` — 17 field groups
- `schemas/paid-media/*.schema.json` — 7 global lookup/summary schemas

Property-level `meta:status: deprecated` annotations inside these schemas are intentionally left untouched.

## Validation

- `npm test` — 2407 passing
- `npm run lint` — clean (only `meta:status` lines changed)
- `npm run validate` (paid-media scope) — 113/113 examples passed, zero new failures vs `master`
- `npm run incompatibility-check` — clean

## Breaking changes

None.
