### PR TITLE
Add xdm:url to WhatsApp non-text media message types

### DIFF
--- a/components/fieldgroups/whatsapp/whatsapp-webhook.example.1.json
+++ b/components/fieldgroups/whatsapp/whatsapp-webhook.example.1.json
@@ -40,7 +40,8 @@
                     "xdm:id": "media.IMG001",
                     "xdm:mime_type": "image/jpeg",
                     "xdm:sha256": "abc123def456",
-                    "xdm:caption": "Here is a photo of the issue."
+                    "xdm:caption": "Here is a photo of the issue.",
+                    "xdm:url": "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=media.IMG001&ext=1234567890&hash=abc123def456"
                   }
                 },
                 {

--- a/components/fieldgroups/whatsapp/whatsapp-webhook.schema.json
+++ b/components/fieldgroups/whatsapp/whatsapp-webhook.schema.json
@@ -217,6 +217,22 @@
                                         "title": "MIME Type",
                                         "description": "MIME type of the audio file, e.g. 'audio/ogg; codecs=opus'.",
                                         "type": "string"
+                                      },
+                                      "xdm:sha256": {
+                                        "title": "SHA-256",
+                                        "description": "SHA-256 hash of the audio file for integrity verification.",
+                                        "type": "string"
+                                      },
+                                      "xdm:url": {
+                                        "title": "Media URL",
+                                        "description": "URL to download the audio file directly from Meta's CDN.",
+                                        "type": "string",
+                                        "format": "uri"
+                                      },
+                                      "xdm:voice": {
+                                        "title": "Voice",
+                                        "description": "True if the audio was recorded using the WhatsApp in-app voice recorder.",
+                                        "type": "boolean"
                                       }
                                     }
                                   },
@@ -244,6 +260,12 @@
                                         "title": "Caption",
                                         "description": "Optional caption sent with the image.",
                                         "type": "string"
+                                      },
+                                      "xdm:url": {
+                                        "title": "Media URL",
+                                        "description": "URL to download the image file directly from Meta's CDN.",
+                                        "type": "string",
+                                        "format": "uri"
                                       }
                                     }
                                   },
@@ -271,6 +293,12 @@
                                         "title": "Caption",
                                         "description": "Optional caption sent with the video.",
                                         "type": "string"
+                                      },
+                                      "xdm:url": {
+                                        "title": "Media URL",
+                                        "description": "URL to download the video file directly from Meta's CDN.",
+                                        "type": "string",
+                                        "format": "uri"
                                       }
                                     }
                                   },
@@ -303,6 +331,12 @@
                                         "title": "Caption",
                                         "description": "Optional caption sent with the document.",
                                         "type": "string"
+                                      },
+                                      "xdm:url": {
+                                        "title": "Media URL",
+                                        "description": "URL to download the document file directly from Meta's CDN.",
+                                        "type": "string",
+                                        "format": "uri"
                                       }
                                     }
                                   },
@@ -330,6 +364,12 @@
                                         "title": "Animated",
                                         "description": "True if the sticker is animated.",
                                         "type": "boolean"
+                                      },
+                                      "xdm:url": {
+                                        "title": "Media URL",
+                                        "description": "URL to download the sticker file directly from Meta's CDN.",
+                                        "type": "string",
+                                        "format": "uri"
                                       }
                                     }
                                   },


### PR DESCRIPTION
## Summary

Follow-up to #2211.

Adds the missing `xdm:url` field to all non-text media message type objects in the WhatsApp Business Messaging Webhook field group. The Facebook Cloud API webhook reference includes a `url` field on every media-bearing message type pointing to the Meta CDN download location for the asset.

Also adds `xdm:sha256` and `xdm:voice` to `xdm:audio`, which were present in the Facebook API spec but missing from the schema.

Non-breaking additive change on an `experimental` schema.

## Motivation

The WhatsApp Cloud API returns a `url` field in the webhook payload for image, video, audio, document, and sticker messages. Without this field in the XDM schema, the URL is dropped during ingestion. References:
- Image: https://developers.facebook.com/documentation/business-messaging/whatsapp/webhooks/reference/messages/image
- Video: https://developers.facebook.com/documentation/business-messaging/whatsapp/webhooks/reference/messages/video
- Audio: https://developers.facebook.com/documentation/business-messaging/whatsapp/webhooks/reference/messages/audio

## Changes

- \`components/fieldgroups/whatsapp/whatsapp-webhook.schema.json\`
  - \`xdm:audio\`: add \`xdm:url\` (uri), \`xdm:sha256\`, \`xdm:voice\`
  - \`xdm:image\`: add \`xdm:url\` (uri)
  - \`xdm:video\`: add \`xdm:url\` (uri)
  - \`xdm:document\`: add \`xdm:url\` (uri)
  - \`xdm:sticker\`: add \`xdm:url\` (uri)
- \`components/fieldgroups/whatsapp/whatsapp-webhook.example.1.json\`
  - add \`xdm:url\` to the sample image message

## Validation

- \`npm test\` — 2407 passing, 0 failing
- \`npm run lint\` — clean
- \`npm run validate\` — zero new failures vs \`master\` baseline
- \`npm run incompatibility-check\` — clean (additive only)

## Breaking changes

None. Additive fields on an \`experimental\` schema.