### PR TITLE
CORE-160600 Add xdm:tspec to segment membership datatype

### DIFF
--- a/components/datatypes/segmentmembership.example.1.json
+++ b/components/datatypes/segmentmembership.example.1.json
@@ -3,6 +3,7 @@
   "xdm:version": "1.0",
   "xdm:validUntil": "2017-12-26T15:52:25+00:00",
   "xdm:status": "realized",
+  "xdm:timerSpec": "example-timerSpec",
   "xdm:payload": {
     "xdm:payloadPropensityValue": 0.5,
     "xdm:payloadType": "propensity"

--- a/components/datatypes/segmentmembership.schema.json
+++ b/components/datatypes/segmentmembership.schema.json
@@ -114,6 +114,11 @@
         },
         "xdm:profileStitchID": {
           "$ref": "https://ns.adobe.com/xdm/context/profileStitchIdentity"
+        },
+        "xdm:timerSpec": {
+          "title": "timerSpec",
+          "type": "string",
+          "description": "The time graph specification of the segment qualification."
         }
       }
     }


### PR DESCRIPTION
Add a new optional string field xdm:tspec to the segmentmembership datatype, alongside xdm:lastQualificationTime and xdm:status. The field captures the time graph specification of the segment qualification.

Non-breaking, additive change.

Issue: https://jira.corp.adobe.com/browse/CORE-160600
