### PR TITLE
Add parentSourceMeta entity to AJO entity mixins

### DIFF
--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
@@ -104,6 +104,12 @@
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/versionID": "inline campaign -1-2",
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/actionID": "inline campaign -1-2-3"
   },
+  "https://ns.adobe.com/experience/customerJourneyManagement/entities/parentSourceMeta": {
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/sourceID": "123-1234-8989",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/sourceType": "smbCampaign",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/sourceVersionID": "676-23-1234-8989",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/sourceActionID": "235-898798-989"
+  },
   "https://ns.adobe.com/experience/customerJourneyManagement/entities/tags": {
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/values": [
       "NewsLetter",

--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
@@ -439,6 +439,41 @@
             }
           }
         },
+        "https://ns.adobe.com/experience/customerJourneyManagement/entities/parentSourceMeta": {
+          "title": "AJO Parent Source Meta Entity",
+          "type": "object",
+          "description": "AJO Parent Source Meta Entity Specific Fields. Captures details about the source entity (Campaign, Journey, etc.) from which this AJO entity originated.",
+          "properties": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/sourceID": {
+              "title": "Source ID",
+              "type": "string",
+              "description": "Source Id of the entity where message originate."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/sourceType": {
+              "title": "Source Type",
+              "type": "string",
+              "description": "Classifies the source type of the message.",
+              "meta:enum": {
+                "orchestratedCampaign": "Orchestrated Campaign",
+                "singleStepCampaign": "Single Step Campaign",
+                "journey": "Journey",
+                "b2bAccountJourneys": "B2B Account Journeys",
+                "b2bLeadJourneys": "B2B Lead Journeys",
+                "smbCampaign": "SMB Campaign"
+              }
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/sourceVersionID": {
+              "title": "Source Version ID",
+              "type": "string",
+              "description": "Source Version Id of the entity where message originate."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/sourceActionID": {
+              "title": "Source Action ID",
+              "type": "string",
+              "description": "Action id of the source from where message originate"
+            }
+          }
+        },
         "https://ns.adobe.com/experience/customerJourneyManagement/entities/tags": {
           "title": "AJO Entity tags",
           "type": "object",

--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
@@ -459,7 +459,8 @@
                 "journey": "Journey",
                 "b2bAccountJourneys": "B2B Account Journeys",
                 "b2bLeadJourneys": "B2B Lead Journeys",
-                "smbCampaign": "SMB Campaign"
+                "smbCampaign": "SMB Campaign",
+                "haloCampaign": "Halo Campaign"
               }
             },
             "https://ns.adobe.com/experience/customerJourneyManagement/entities/sourceVersionID": {


### PR DESCRIPTION
## Summary                                                                                                                                                                                
                                                                                                                                                                                            
  Adds a new `parentSourceMeta` entity to the AJO entity mixins, capturing metadata about the source entity (Campaign, Journey, etc.) that an AJO entity originated from — source id, type, 
  version id, and action id. Non-breaking, additive only.                                                                                                                                   
                                                                                                                                                                                            
  ## Motivation                                                                                                                                                                             
                                                                                                                                                                                            
  AJO entities need to record where a message originated (the parent source Campaign/Journey) for downstream reporting and lineage. This fieldgroup groups the source identifiers under a   
  single `parentSourceMeta` object.                                                                                                                                                         
                                                                                                                                                                                            
  ## Changes                                                                                                                                                                                
                                                                                                                                                                                            
  - `extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json` — new `parentSourceMeta` object with `sourceID`, `sourceType` (soft enum), `sourceVersionID`, and 
  `sourceActionID`.                                                           
  - `extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json` — example populated for `parentSourceMeta`.                                                    
                                                                                                                                                                                            
  ## Validation                                                                                                                                                                             
                                                                                                                                                                                            
  - `npm test` — 2408 passing                                                                                                                                                               
  - `npm run lint` — clean                                                                                                                                                                  
  - `npm run incompatibility-check` — no new failures introduced (additive `meta:enum` value only; the pre-existing `subtenant.schema.json` failure on `master` is unrelated to this change)
                                                                                                                                                                                            
  ## Breaking changes                                                                                                                                                                       
                                                                                                                                                                                            
  None.              