### PR TITLE
Fix duplicate subtenant field hierarchy

### DIFF
--- a/extensions/adobe/experience/customerJourneyManagement/subtenant.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/subtenant.example.1.json
@@ -1,5 +1,5 @@
 {
   "https://ns.adobe.com/experience/customerJourneyManagement/subtenant": {
-    "https://ns.adobe.com/experience/customerJourneyManagement/subtenant/id": "acme-corp-west"
+    "xdm:id": "acme-corp-west"
   }
 }

--- a/extensions/adobe/experience/customerJourneyManagement/subtenant.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/subtenant.schema.json
@@ -12,7 +12,10 @@
   "type": "object",
   "meta:extensible": true,
   "meta:abstract": true,
-  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
+  "meta:intendedToExtend": [
+    "https://ns.adobe.com/xdm/context/experienceevent",
+    "https://ns.adobe.com/experience/customerJourneyManagement/ajoEntity"
+  ],
 
   "definitions": {
     "subtenant": {
@@ -22,7 +25,7 @@
           "type": "object",
           "description": "Sub-tenant context for partitioning message delivery feedback data within a multi-tenant sandbox.",
           "properties": {
-            "https://ns.adobe.com/experience/customerJourneyManagement/subtenant/id": {
+            "xdm:id": {
               "title": "Sub-Tenant Identifier",
               "type": "string",
               "description": "Identifies the sub-tenant within a multi-tenant sandbox. Used to partition message delivery feedback data across logical tenant boundaries."


### PR DESCRIPTION
## What

Closes #2221

Corrects the CJM subtenant field-group definition introduced by #2209 so Schema Registry/UI renders the intended field exactly once:

`_experience.customerJourneyManagement.subtenant.id`

This keeps the intentional logical model `subtenant: { id: string }` and preserves explicit object validation for future extensibility.

## Why / Root Cause

The current schema nests the absolute child URI
`https://ns.adobe.com/experience/customerJourneyManagement/subtenant/id`
inside the absolute object URI
`https://ns.adobe.com/experience/customerJourneyManagement/subtenant`.

Schema Registry expands an absolute property URI from the root, even when that property is declared inside another object. The nested absolute child is therefore re-expanded and produces the malformed hierarchy:

`_experience.customerJourneyManagement.subtenant._experience.customerJourneyManagement.subtenant.id`

This is a field-group definition issue, not a duplicate field-group attachment.

## Resulting Shape

The corrected schema follows the established CJM nested-object convention used by fields such as `messageExecution.audience` and AJO entity objects:

```json
{
  "https://ns.adobe.com/experience/customerJourneyManagement/subtenant": {
    "xdm:id": "acme-corp-west"
  }
}
```

The outer CJM property remains an explicit `type: object`. Its compact `xdm:id` child resolves locally under that object, yielding only `_experience.customerJourneyManagement.subtenant.id`.

## Supported Classes

`meta:intendedToExtend` now includes both:

- `https://ns.adobe.com/xdm/context/experienceevent`
- `https://ns.adobe.com/experience/customerJourneyManagement/ajoEntity`

## Files Changed

| File | Change |
| --- | --- |
| `extensions/adobe/experience/customerJourneyManagement/subtenant.schema.json` | Replaces the nested absolute child URI with `xdm:id` and adds AJO Entity class support. |
| `extensions/adobe/experience/customerJourneyManagement/subtenant.example.1.json` | Updates the example payload to use `xdm:id` inside the namespaced `subtenant` object. |

## Compatibility / Impact

This is an intentional corrective follow-up to #2209. It replaces the malformed raw child key before the field group is wired into downstream schemas. Consumers that directly adopted the short-lived malformed absolute child key must use `xdm:id`; the intended logical object and rendered field path remain `subtenant.id`.

No composite schema wiring is included here. Adding this field group to specific schemas remains a separate change from defining the field group correctly.

## Testing

- `npm test` - 2408 passing, 1 pending
- `npm test -- --grep subtenant` - 1 passing
- Direct AJV validation - `subtenant.example.1.json` validates against `subtenant.schema.json`
- Targeted Prettier check - clean
- Explicit namespace/path assertion - `_experience.customerJourneyManagement.subtenant.id`
- CircleCI lint job - passed
- CircleCI Mocha and XED validation steps - passed

The CJM directory validator also reports two existing unrelated example filename/schema lookup mismatches (`message-reply.schema.example.2.json` and `offers.schema.example.1.json`); neither file is modified by this PR.

### CI incompatibility guard

`npm run incompatibility-check` intentionally flags removal of the malformed absolute child property added by #2209. Retaining or merely deprecating that property would keep the repeated `_experience.customerJourneyManagement.subtenant` hierarchy visible in Schema Registry/UI and would not correct #2221. The replacement is limited to this newly introduced, not-yet-wired field group; all other CI validation steps pass. This guard failure therefore requires maintainer review/override rather than a compatibility shim that preserves the defect.

## References

- Corrective follow-up to #2209
- Tracking issue: #2221
- Original work item: CJM-148040
