### PR TITLE
CJM-153228 Add AJO Holdout Entity to AJO entity mixins

### DIFF
--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
@@ -75,6 +75,16 @@
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/id": "a2YioO",
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/name": "Rule Set Name"
   },
+  "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdout": {
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutType": "journeyHoldout",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeType": "journey",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeName": "Marketing Test Journey",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutID": "8f14e45f-ceea-467d-9c9d-4f7a2b6c1a20",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/name": "Journey Holdout",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/decisionPolicyID": "8f14e45f-ceea-467d-9c9d-4f7a2b6c1a20",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutPercentage": 10
+  },
   "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey": {
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyVersionID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyName": "Marketing Test Journey",

--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
@@ -298,6 +298,63 @@
             }
           }
         },
+        "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdout": {
+          "title": "AJO Holdout Entity",
+          "type": "object",
+          "description": "AJO Holdout (control group) Entity Specific Fields. A first-class holdout entity, symmetric to the entry-arm entities (journey/campaign), used to report the control group a profile was held out into. The same shape represents journey-level holdouts, engagement-strategy-level shared control groups, and sandbox-level global control groups; the tier and the artifact it is anchored to are given by holdoutType and scopeType/scopeID. The record is keyed by the backing decision policy id.",
+          "properties": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutType": {
+              "title": "Holdout Type",
+              "type": "string",
+              "description": "The tier of holdout this entity represents.",
+              "meta:enum": {
+                "journeyHoldout": "Journey-level holdout",
+                "sharedControlGroup": "Engagement-strategy-level shared control group",
+                "globalControlGroup": "Sandbox-level global control group"
+              }
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeType": {
+              "title": "Holdout Scope Type",
+              "type": "string",
+              "description": "The artifact scope this holdout is anchored to. Open enum; additional scopes may be added as further holdout tiers ship.",
+              "meta:enum": {
+                "journey": "Journey (journey-level holdout)",
+                "engagementStrategy": "Engagement strategy (shared control group)",
+                "sandbox": "Sandbox (global control group)"
+              }
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeID": {
+              "title": "Holdout Scope ID",
+              "type": "string",
+              "description": "Identifier of the scoped artifact: the journey version id for journey scope, the engagement strategy id for engagement-strategy scope, or the sandbox id for sandbox scope."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeName": {
+              "title": "Holdout Scope Name",
+              "type": "string",
+              "description": "Human-readable name of the scoped artifact."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutID": {
+              "title": "Holdout ID",
+              "type": "string",
+              "description": "Stable business identifier of the holdout. Remains unchanged across republishing of the scoped artifact."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/name": {
+              "title": "Holdout Name",
+              "type": "string",
+              "description": "Holdout / control group name."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/decisionPolicyID": {
+              "title": "Holdout Decision Policy ID",
+              "type": "string",
+              "description": "Identifier of the Unified Decisioning decision policy backing this holdout. The entity record id is derived from this value, and step-event propositions reference the entity by it."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutPercentage": {
+              "title": "Holdout Percentage",
+              "type": "number",
+              "description": "Percentage of the eligible population held out for this scope."
+            }
+          }
+        },
         "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey": {
           "title": "AJO Journey Entity",
           "type": "object",

--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
@@ -306,12 +306,22 @@
             "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutType": {
               "title": "Holdout Type",
               "type": "string",
-              "description": "The tier of holdout this entity represents, e.g. journeyHoldout (journey-level), sharedControlGroup (engagement-strategy-level), or globalControlGroup (sandbox-level)."
+              "description": "The tier of holdout this entity represents. Open (soft) enum; additional tiers may be added over time.",
+              "meta:enum": {
+                "journeyHoldout": "Journey-level holdout",
+                "sharedControlGroup": "Engagement-strategy-level shared control group",
+                "globalControlGroup": "Sandbox-level global control group"
+              }
             },
             "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeType": {
               "title": "Holdout Scope Type",
               "type": "string",
-              "description": "The artifact scope this holdout is anchored to, e.g. journey, engagementStrategy, or sandbox. Additional scopes may be added as further holdout tiers ship."
+              "description": "The artifact scope this holdout is anchored to. Open (soft) enum; additional scopes may be added as further holdout tiers ship.",
+              "meta:enum": {
+                "journey": "Journey (journey-level holdout)",
+                "engagementStrategy": "Engagement strategy (shared control group)",
+                "sandbox": "Sandbox (global control group)"
+              }
             },
             "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeID": {
               "title": "Holdout Scope ID",

--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
@@ -306,22 +306,12 @@
             "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutType": {
               "title": "Holdout Type",
               "type": "string",
-              "description": "The tier of holdout this entity represents.",
-              "meta:enum": {
-                "journeyHoldout": "Journey-level holdout",
-                "sharedControlGroup": "Engagement-strategy-level shared control group",
-                "globalControlGroup": "Sandbox-level global control group"
-              }
+              "description": "The tier of holdout this entity represents, e.g. journeyHoldout (journey-level), sharedControlGroup (engagement-strategy-level), or globalControlGroup (sandbox-level)."
             },
             "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeType": {
               "title": "Holdout Scope Type",
               "type": "string",
-              "description": "The artifact scope this holdout is anchored to. Open enum; additional scopes may be added as further holdout tiers ship.",
-              "meta:enum": {
-                "journey": "Journey (journey-level holdout)",
-                "engagementStrategy": "Engagement strategy (shared control group)",
-                "sandbox": "Sandbox (global control group)"
-              }
+              "description": "The artifact scope this holdout is anchored to, e.g. journey, engagementStrategy, or sandbox. Additional scopes may be added as further holdout tiers ship."
             },
             "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeID": {
               "title": "Holdout Scope ID",


### PR DESCRIPTION
## Summary

Adds a new generic `holdout` entity to the AJO entity mixins, representing a
holdout / control group as a first-class entity (symmetric to the entry-arm
`journey` / `campaign` entities) so a profile held out of a treatment can be
reported against a dedicated entity. Non-breaking, additive only.

The entity is deliberately tier-agnostic: a single shape covers journey-level
holdouts, engagement-strategy-level shared control groups, and sandbox-level
global control groups, discriminated by `holdoutType` + `scopeType`/`scopeID`.
The record is keyed by the backing decision policy id, so all tiers share one
join key.

## Motivation

AJO is introducing control groups across all artifact scopes (journey, shared,
and global). Today journey holdouts are reported by composing existing entities
on a single record, which does not scale to shared/global scopes. This change
introduces one generic holdout entity so holdouts are represented consistently
regardless of scope, and downstream reporting can join step-event propositions
to a single, well-typed entity via the decision policy id.

## Changes

- `extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json`
  — new `holdout` object under `.../entities` with `holdoutType`, `scopeType`,
  `scopeID`, `scopeName`, `holdoutID`, `name`, `decisionPolicyID` (all strings)
  and `holdoutPercentage` (number). Accepted values for `holdoutType`/`scopeType`
  documented in their field descriptions.
- `extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json`
  — example populated for `holdout` (journey scope).

## Validation

- `npm test` — 2408 passing
- `npm run lint` — clean (prettier: all files use Prettier code style)
- `npm run validate` — zero new failures vs the `master` baseline (pre-existing
  unrelated failures only; none in `customerJourneyManagement`)
- `npm run incompatibility-check` — clean; additive change, no breaking edits

## Breaking changes

None.