### PR TITLE
CJM-153228 Add AJO Holdout Entity to ajo_entity_dataset field-group

### DIFF
--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.example.1.json
@@ -75,6 +75,16 @@
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/id": "a2YioO",
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/name": "Rule Set Name"
   },
+  "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdout": {
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutType": "journeyHoldout",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeType": "journey",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeName": "Marketing Test Journey",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutID": "8f14e45f-ceea-467d-9c9d-4f7a2b6c1a20",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/name": "Journey Holdout",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/decisionPolicyID": "8f14e45f-ceea-467d-9c9d-4f7a2b6c1a20",
+    "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutPercentage": 10
+  },
   "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey": {
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyVersionID": "04832ee5-51ff-4706-af8a-a8ff6756308b",
     "https://ns.adobe.com/experience/customerJourneyManagement/entities/journeyName": "Marketing Test Journey",

--- a/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
+++ b/extensions/adobe/experience/customerJourneyManagement/ajo-entity-mixins.schema.json
@@ -298,6 +298,53 @@
             }
           }
         },
+        "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdout": {
+          "title": "AJO Holdout Entity",
+          "type": "object",
+          "description": "AJO Holdout (control group) Entity Specific Fields. A first-class holdout entity, symmetric to the entry-arm entities (journey/campaign), used to report the control group a profile was held out into. The same shape represents journey-level holdouts, engagement-strategy-level shared control groups, and sandbox-level global control groups; the tier and the artifact it is anchored to are given by holdoutType and scopeType/scopeID. The record is keyed by the backing decision policy id.",
+          "properties": {
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutType": {
+              "title": "Holdout Type",
+              "type": "string",
+              "description": "The tier of holdout this entity represents, e.g. journeyHoldout (journey-level), sharedControlGroup (engagement-strategy-level), or globalControlGroup (sandbox-level)."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeType": {
+              "title": "Holdout Scope Type",
+              "type": "string",
+              "description": "The artifact scope this holdout is anchored to, e.g. journey, engagementStrategy, or sandbox. Additional scopes may be added as further holdout tiers ship."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeID": {
+              "title": "Holdout Scope ID",
+              "type": "string",
+              "description": "Identifier of the scoped artifact: the journey version id for journey scope, the engagement strategy id for engagement-strategy scope, or the sandbox id for sandbox scope."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/scopeName": {
+              "title": "Holdout Scope Name",
+              "type": "string",
+              "description": "Human-readable name of the scoped artifact."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutID": {
+              "title": "Holdout ID",
+              "type": "string",
+              "description": "Stable business identifier of the holdout. Remains unchanged across republishing of the scoped artifact."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/name": {
+              "title": "Holdout Name",
+              "type": "string",
+              "description": "Holdout / control group name."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/decisionPolicyID": {
+              "title": "Holdout Decision Policy ID",
+              "type": "string",
+              "description": "Identifier of the Unified Decisioning decision policy backing this holdout. The entity record id is derived from this value, and step-event propositions reference the entity by it."
+            },
+            "https://ns.adobe.com/experience/customerJourneyManagement/entities/holdoutPercentage": {
+              "title": "Holdout Percentage",
+              "type": "number",
+              "description": "Percentage of the eligible population held out for this scope."
+            }
+          }
+        },
         "https://ns.adobe.com/experience/customerJourneyManagement/entities/journey": {
           "title": "AJO Journey Entity",
           "type": "object",


### PR DESCRIPTION
    Add a generic, first-class holdout (control group) entity to the AJO Entity
    Fields field-group so holdouts are represented symmetric to the entry-arm
    entities. A single shape covers journey-level holdouts, engagement-strategy-level
    shared control groups, and sandbox-level global control groups via
    holdoutType + scopeType/scopeID; the record is keyed by the backing decision
    policy id. Additive, non-breaking; new fields marked meta:status experimental.

Please link to the issue #…
