### PR TITLE
Re-introduce extensible conversation signals with map-depth-safe metadata

### DIFF
--- a/components/fieldgroups/agentic/conversation-event.example.4.json
+++ b/components/fieldgroups/agentic/conversation-event.example.4.json
@@ -1,0 +1,99 @@
+{
+  "xdm:eventType": "conversation.turn",
+  "xdm:conversation": {
+    "xdm:conversationID": "conv-002",
+    "xdm:conversationName": "Geography of Europe",
+    "xdm:turnID": "turn-001",
+    "xdm:signals": [
+      {
+        "xdm:scope": "turn",
+        "xdm:attributesMap": {
+          "subjects": {
+            "xdm:type": "string",
+            "xdm:values": [
+              {
+                "xdm:stringValue": "capital of France",
+                "xdm:qualifiers": ["geographic", "factual", "educational"]
+              },
+              {
+                "xdm:stringValue": "Paris",
+                "xdm:qualifiers": ["city", "capital"]
+              }
+            ]
+          },
+          "intents": {
+            "xdm:type": "string",
+            "xdm:values": [
+              { "xdm:stringValue": "learn more" },
+              { "xdm:stringValue": "fact-checking" }
+            ]
+          },
+          "tones": {
+            "xdm:type": "string",
+            "xdm:values": [
+              { "xdm:stringValue": "curious" },
+              { "xdm:stringValue": "questioning" }
+            ]
+          },
+          "sentiment": {
+            "xdm:type": "number",
+            "xdm:values": [{ "xdm:numberValue": 0.3, "xdm:confidence": 0.9 }]
+          },
+          "language": {
+            "xdm:type": "string",
+            "xdm:values": [{ "xdm:stringValue": "fr", "xdm:confidence": 0.98 }]
+          },
+          "keywords": {
+            "xdm:type": "string",
+            "xdm:values": [
+              { "xdm:stringValue": "France" },
+              { "xdm:stringValue": "Paris" },
+              { "xdm:stringValue": "capital" }
+            ]
+          },
+          "topics": {
+            "xdm:type": "string",
+            "xdm:values": [
+              {
+                "xdm:stringValue": "Questions about European Geography",
+                "xdm:metadata": [
+                  {
+                    "xdm:key": "context",
+                    "xdm:value": "There is a question about the capital of France"
+                  }
+                ]
+              },
+              {
+                "xdm:stringValue": "Questions about Countries and Capitals",
+                "xdm:metadata": [
+                  {
+                    "xdm:key": "context",
+                    "xdm:value": "Specific question about the capital of France which is Paris"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "xdm:prompt": {
+      "xdm:source": "end-user",
+      "xdm:raw": [
+        {
+          "xdm:text": "What is the capital of France?",
+          "xdm:purpose": "User Input"
+        }
+      ]
+    },
+    "xdm:response": {
+      "xdm:source": "concierge",
+      "xdm:raw": [
+        {
+          "xdm:text": "The capital of France is Paris.",
+          "xdm:purpose": "main"
+        }
+      ]
+    }
+  }
+}

--- a/components/fieldgroups/agentic/conversation-event.schema.json
+++ b/components/fieldgroups/agentic/conversation-event.schema.json
@@ -69,6 +69,8 @@
                   "xdm:attributes": {
                     "title": "Attributes",
                     "type": "object",
+                    "description": "(DEPRECATED — use xdm:attributesMap) The set of derived signals for this scope. Superseded by xdm:attributesMap, which models signals as an extensible map keyed by signal id.",
+                    "meta:status": "deprecated",
                     "properties": {
                       "xdm:subjects": {
                         "type": "object",
@@ -147,6 +149,79 @@
                             "minimum": -1.0,
                             "maximum": 1.0,
                             "examples": [-1.0, -0.34, 0, 0.7, 1.0]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "xdm:attributesMap": {
+                    "title": "Signal Attributes Map",
+                    "type": "object",
+                    "description": "Map of signal id to signal value. The key is the signal identifier (for example 'subjects', 'intents', 'tones', 'sentiment', or any producer-defined signal). Supersedes xdm:attributes; new signal types require no schema change.",
+                    "meta:xdmType": "map",
+                    "meta:status": "experimental",
+                    "additionalProperties": {
+                      "type": "object",
+                      "title": "Conversation Signal",
+                      "description": "A single derived conversation signal. The xdm:type discriminator indicates which typed value field (xdm:stringValue, xdm:numberValue, or xdm:booleanValue) is populated on each entry of xdm:values.",
+                      "properties": {
+                        "xdm:type": {
+                          "title": "Signal Value Type",
+                          "type": "string",
+                          "description": "Data type of this signal's values; tells consumers which typed value field is populated on each entry of xdm:values.",
+                          "enum": ["string", "number", "boolean"],
+                          "meta:enum": {
+                            "string": "Values carry xdm:stringValue (e.g. an intent, tone, or extracted phrase)",
+                            "number": "Values carry xdm:numberValue (e.g. a sentiment score or intensity)",
+                            "boolean": "Values carry xdm:booleanValue (a true/false flag)"
+                          }
+                        },
+                        "xdm:values": {
+                          "title": "Signal Values",
+                          "type": "array",
+                          "description": "One or more values for this signal.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "xdm:stringValue": {
+                                "title": "String Value",
+                                "type": "string",
+                                "description": "Populated when xdm:type is 'string'. A categorical value such as an intent, tone, or extracted phrase."
+                              },
+                              "xdm:numberValue": {
+                                "title": "Number Value",
+                                "type": "number",
+                                "description": "Populated when xdm:type is 'number'. For example a sentiment score from -1 to 1, or an intensity."
+                              },
+                              "xdm:booleanValue": {
+                                "title": "Boolean Value",
+                                "type": "boolean",
+                                "description": "Populated when xdm:type is 'boolean'. A true or false flag."
+                              },
+                              "xdm:confidence": {
+                                "title": "Confidence",
+                                "type": "number",
+                                "description": "Confidence the producer assigns to this value, from 0 to 1.",
+                                "minimum": 0,
+                                "maximum": 1
+                              },
+                              "xdm:qualifiers": {
+                                "title": "Qualifiers",
+                                "type": "array",
+                                "description": "Additional descriptors for this value, similar to keywords but more meaningful.",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "xdm:metadata": {
+                                "title": "Metadata",
+                                "type": "array",
+                                "description": "Producer-defined metadata for this value as key/value pairs (for example the context around a signal value). Modeled as an array of key/value pairs rather than a nested map so the enclosing xdm:attributesMap stays within the single-level map-depth limit.",
+                                "items": {
+                                  "$ref": "https://ns.adobe.com/xdm/datatypes/keyvalue"
+                                }
+                              }
+                            }
                           }
                         }
                       }


### PR DESCRIPTION
## Summary

Closes #2206

Re-introduces the generic, extensible `xdm:attributesMap` on the agentic Conversation
Event field group (originally PR #2207, backed out by revert #2231 / released in 1.73.3)
with one design change so it complies with the platform's single-level map-nesting-depth
limit. **Additive / non-breaking.**

## Motivation

#2207 added `xdm:attributesMap` — a `meta:xdmType: "map"` keyed by signal id — so
producers can emit new conversation signals without a schema change. Inside each signal
value, `xdm:values[].xdm:metadata` was itself a second `meta:xdmType: "map"`, which made
`xdm:attributesMap` a **depth-2** (map-of-map) structure. A platform guardrail limits map
nesting depth to 1, so provisioning any schema that used it failed with:

> `Map field exceeds maximum allowed depth for this organization: 1`

That broke production provisioning for conversational products, so #2207 was reverted in
#2231. This PR brings the feature back in a compliant shape.

## Changes

- `components/fieldgroups/agentic/conversation-event.schema.json`
  - Re-add `xdm:attributesMap` (`meta:xdmType: "map"`, `meta:status: experimental`) keyed
    by signal id; the value is an inlined typed signal envelope: `xdm:type` discriminator
    (documented in `meta:enum`) plus `xdm:values[]` of `xdm:stringValue` /
    `xdm:numberValue` / `xdm:booleanValue` / `xdm:confidence` / `xdm:qualifiers`.
  - **Only change vs #2207:** `xdm:values[].xdm:metadata` is now `type: array` of the
    existing **stable** `keyvalue` datatype (`$ref https://ns.adobe.com/xdm/datatypes/keyvalue`,
    `xdm:key` / `xdm:value`) instead of a nested map. Arrays do not count toward map
    depth, so `xdm:attributesMap` stays a single-level (depth-1) map that provisions
    correctly, while the producer-defined per-value metadata capability is preserved.
  - Deprecate the legacy `xdm:attributes` container (`meta:status: deprecated`), retained
    for backward compatibility.
- `components/fieldgroups/agentic/conversation-event.example.4.json`
  - Re-add the example, with the `topics` per-value metadata expressed as `keyvalue`
    pairs.

## Validation

- `npm test` — 2408 passing
- `npm run lint` — clean (prettier)
- `npm run incompatibility-check` — clean (exit 0); the change is purely additive on top
  of the post-revert `master`
- `npm run validate` — agentic examples are exercised by `npm test` (not in
  `validate-schemas.js` scope); no new failures introduced

## Breaking changes

None. Additive; the legacy `xdm:attributes` fields are deprecated, not removed. The only
difference from the reverted #2207 is that per-value metadata is a key/value array rather
than a nested map.
