### PR TITLE
paid-media: add optional measurement-run fieldgroup for identity-based measurement summary outputs

### DIFF
--- a/components/fieldgroups/paid-media/core-paid-media-measurement-run.example.1.json
+++ b/components/fieldgroups/paid-media/core-paid-media-measurement-run.example.1.json
@@ -1,0 +1,13 @@
+{
+  "xdm:paidMedia": {
+    "xdm:measurementRun": {
+      "xdm:moduleID": "collab_paid_media_measurement_v1",
+      "xdm:matchRate": 0.155,
+      "xdm:groupedConversions": 12450,
+      "xdm:conversionEventType": "retail.purchase",
+      "xdm:audienceName": "Tech Enthusiasts 25-54",
+      "xdm:placementName": "Instagram Feed - Stories",
+      "xdm:siteName": "example.com"
+    }
+  }
+}

--- a/components/fieldgroups/paid-media/core-paid-media-measurement-run.schema.json
+++ b/components/fieldgroups/paid-media/core-paid-media-measurement-run.schema.json
@@ -1,0 +1,78 @@
+{
+  "meta:license": [
+    "Copyright 2026 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "https://ns.adobe.com/xdm/mixins/paid-media/measurement-run",
+  "title": "Core Paid Media Measurement Run",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/classes/summarymetrics"],
+  "description": "Run-level lineage, identity-match metrics, and additional dimension display names emitted by paid media measurement and attribution runs (e.g. Real-Time CDP Collaboration paid-media summary outputs). Carries per-run context and denormalized display values that do not fit the core identifier, metric, denormalized-name, or dimensional-breakdown fieldgroups.",
+  "definitions": {
+    "measurement-run": {
+      "properties": {
+        "xdm:paidMedia": {
+          "type": "object",
+          "properties": {
+            "xdm:measurementRun": {
+              "type": "object",
+              "title": "Measurement Run",
+              "description": "Fields stamped by a paid media measurement or attribution run onto each summary row.",
+              "properties": {
+                "xdm:moduleID": {
+                  "type": "string",
+                  "title": "Module ID",
+                  "description": "Identifier of the measurement module or report that emitted this row. Constant across every row produced by a single run and used to trace a row back to its originating pipeline execution."
+                },
+                "xdm:matchRate": {
+                  "type": "number",
+                  "title": "Identity Match Rate",
+                  "description": "Fraction of source conversions that identity-joined at least one impression across the fixed match-key set, ignoring time windows. Typically populated only on the whole-input rollup grain and left null on lower-grain rows where a single ratio is not meaningful. Expressed as a fraction in [0, 1].",
+                  "minimum": 0,
+                  "maximum": 1
+                },
+                "xdm:groupedConversions": {
+                  "type": "number",
+                  "title": "Grouped Conversions",
+                  "description": "Attributed conversions deduplicated by a resolved household or identity group. Complements xdm:paidMedia.metrics.conversions (per-conversion count) with a household or group-level count at the same rollup grain.",
+                  "minimum": 0
+                },
+                "xdm:conversionEventType": {
+                  "type": "string",
+                  "title": "Conversion Event Type",
+                  "description": "Type of the source conversion event, carried through from the upstream conversion source (e.g. a dotted taxonomy like 'retail.purchase' or an ad-network event name). Customer-defined and unbounded: no fixed vocabulary is enforced. Populated on rows scoped to a single conversion event type and left null on impression-only breakdowns."
+                },
+                "xdm:audienceName": {
+                  "type": "string",
+                  "title": "Audience Name",
+                  "description": "Display name of the audience segment for this row. Mirrors xdm:paidMedia.dimensionalBreakdowns.audienceSegment (the identifier) with a human-readable label; populated on audience breakdown rows."
+                },
+                "xdm:placementName": {
+                  "type": "string",
+                  "title": "Placement Name",
+                  "description": "Display name of the placement for this row. Mirrors xdm:paidMedia.dimensionalBreakdowns.placement (the identifier) with a human-readable label; populated on placement breakdown rows."
+                },
+                "xdm:siteName": {
+                  "type": "string",
+                  "title": "Site Name",
+                  "description": "Site or domain on which the impression was served. Populated on site breakdown rows."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/measurement-run"
+    }
+  ],
+  "meta:status": "experimental"
+}

--- a/schemas/paid-media/paid-media-summary-metrics.example.9.json
+++ b/schemas/paid-media/paid-media-summary-metrics.example.9.json
@@ -1,0 +1,39 @@
+{
+  "xdm:timestamp": "2026-04-15T00:00:00Z",
+  "xdm:paidMedia": {
+    "xdm:adNetwork": "other",
+    "xdm:accountID": "advertiser_69a8807d673af677c92bddbc",
+    "xdm:campaignID": "cmp_2026_spring_launch",
+    "xdm:channel": "PaidMedia",
+    "xdm:denormalizedNames": {
+      "xdm:accountName": "Acme Corp",
+      "xdm:campaignName": "Spring 2026 Launch",
+      "xdm:adName": "Hero Video 15s"
+    },
+    "xdm:metrics": {
+      "xdm:impressions": 4820000,
+      "xdm:reach": 1750000,
+      "xdm:conversions": 18450
+    },
+    "xdm:dimensionalBreakdowns": {
+      "xdm:breakdownType": "PLACEMENT_PER_CAMPAIGN",
+      "xdm:placement": "placement_abc123",
+      "xdm:audienceSegment": "audience_tech_enthusiasts",
+      "xdm:deviceType": "mobile",
+      "xdm:creativeFormat": "video"
+    },
+    "xdm:attributionMetrics": {
+      "xdm:clickAttributionWindow": "14_DAY",
+      "xdm:viewAttributionWindow": "14_DAY"
+    },
+    "xdm:measurementRun": {
+      "xdm:moduleID": "collab_paid_media_measurement_v1",
+      "xdm:matchRate": 0.155,
+      "xdm:groupedConversions": 12450,
+      "xdm:conversionEventType": "retail.purchase",
+      "xdm:audienceName": "Tech Enthusiasts 25-54",
+      "xdm:placementName": "Instagram Feed - Stories",
+      "xdm:siteName": "example.com"
+    }
+  }
+}

--- a/schemas/paid-media/paid-media-summary-metrics.schema.json
+++ b/schemas/paid-media/paid-media-summary-metrics.schema.json
@@ -46,6 +46,9 @@
     },
     {
       "$ref": "https://ns.adobe.com/xdm/mixins/paid-media/denormalized-names"
+    },
+    {
+      "$ref": "https://ns.adobe.com/xdm/mixins/paid-media/measurement-run"
     }
   ],
   "meta:status": "stable"


### PR DESCRIPTION
## Summary

Adds a new optional fieldgroup `core-paid-media-measurement-run` and references it from the `paid-media-summary-metrics` composite schema. The fieldgroup carries run-level context that identity-based paid-media measurement pipelines (clean-room measurement, first-party attribution, third-party measurement partners) stamp onto each summary row and that does not fit the existing paid-media fieldgroups.

Fixes #2233

## Motivation

Identity-based paid-media measurement — where impressions and conversions are joined across a shared identity space (hashed email, hashed IP, device id, ECID, …), aggregated across breakout dims, and written out as pre-rolled summary rows for CJA / analytics ingestion — is a common pattern across clean-room measurement, first-party attribution pipelines, and third-party measurement partners.

These pipelines need to stamp each summary row with seven fields that don't fit the existing paid-media fieldgroups:

- **`moduleID`** — identifier of the measurement module / report that produced this run; constant across every row of a single run so a row can be traced back to its originating pipeline execution.
- **`matchRate`** — identity match rate (fraction of source conversions that identity-joined at least one impression across the shared identity space, ignoring time windows). Meaningful only at the whole-input rollup grain. Conceptually distinct from `attributionMetrics.attributionConfidence` (a per-touchpoint credibility score under a multi-touch model).
- **`groupedConversions`** — attributed conversions deduplicated by resolved household or identity group. Complements `paidMedia.metrics.conversions` (per-conversion count) with a household/group-level count at the same rollup grain.
- **`conversionEventType`** — type of the source conversion event (e.g. `retail.purchase`, `signup`), carried through verbatim from the upstream conversion source. Customer-defined vocabulary; no fixed set. Used to slice conversion breakouts in a summary output; no existing string dimension for conversion event type in `core-paid-media-dimensional-breakdowns`.
- **`audienceName` / `placementName` / `siteName`** — human-readable display names for the audience segment, placement, and site associated with the row. `dimensionalBreakdowns.audienceSegment` and `dimensionalBreakdowns.placement` carry the IDs but the summary dataset (unlike campaign / ad / account) has no corresponding lookup dataset for these dims, and `denormalizedNames` today only covers entity names that mirror the paid-media lookups. `siteName` has no ID form at all (open publisher domain).

Producers today have no global place to put these fields. Downstream consumers that want to ingest such a summary output into AEP have to define these as tenant-specific field groups per sandbox, which prevents cross-sandbox and cross-customer productization on a single global schema.

This change introduces an **optional** fieldgroup, following the exact shape and precedent of `core-paid-media-denormalized-names` (#2187 / #2188):

- Producers that don't emit measurement-run context (e.g. classical DSP metric feeds) leave `xdm:paidMedia.xdm:measurementRun.*` null — no regression, no bloat, no impact on existing summary-metrics consumers.
- Identity-based measurement producers populate the block inline and ingest onto the same global schema.

## Changes

- **New:** `components/fieldgroups/paid-media/core-paid-media-measurement-run.schema.json` — the fieldgroup. `meta:status: experimental`, `meta:intendedToExtend: [summarymetrics]`, all properties under `xdm:paidMedia.xdm:measurementRun`.
- **New:** `components/fieldgroups/paid-media/core-paid-media-measurement-run.example.1.json` — fieldgroup example.
- **New:** `schemas/paid-media/paid-media-summary-metrics.example.9.json` — composite-schema example exercising the new fields end-to-end on a realistic identity-attribution row.
- **Modified:** `schemas/paid-media/paid-media-summary-metrics.schema.json` — one `$ref` added to `allOf` for the new fieldgroup.

## Validation

- `npm test` — 2413 passing (was 2412 on master; +1 for the new example.9).
- `npm run lint` — clean (prettier did not reformat any of the new/modified files).
- `npm run validate` — no new failures on the added/modified files; pre-existing failures in unrelated schemas remain.
- `npm run incompatibility-check` — clean.

## Breaking changes

None. The new fieldgroup adds optional properties only; no existing field is renamed, retyped, or removed. `paid-media-summary-metrics.schema.json` only gains one additional `$ref` in `allOf` — every previously valid example still validates.
