### PR TITLE
Add form fill xdm schema

### DIFF
--- a/components/fieldgroups/experience-event/events/conversation-concierge-event.example.1.json
+++ b/components/fieldgroups/experience-event/events/conversation-concierge-event.example.1.json
@@ -1,6 +1,18 @@
 {
   "xdm:eventType": "session_expiration",
   "xdm:timestamp": "2026-04-06T12:00:00Z",
+  "xdm:identityMap": {
+    "ECID": [
+      {
+        "xdm:id": "14522272242813147102683189683212217746"
+      }
+    ],
+    "marketo_cookie": [
+      {
+        "xdm:id": "id:123-ABC-456&token:_mch-adobe.com-1234567890"
+      }
+    ]
+  },
   "xdm:engagement": {
     "xdm:conversationConciergeEvent": {
       "xdm:sessionId": "session-1234567890",

--- a/components/fieldgroups/experience-event/events/form-fill-in-concierge.example.1.json
+++ b/components/fieldgroups/experience-event/events/form-fill-in-concierge.example.1.json
@@ -17,7 +17,8 @@
         "xdm:attributes": [
           { "xdm:name": "firstName", "xdm:value": "Jane" },
           { "xdm:name": "company", "xdm:value": "Acme Corp" }
-        ]
+        ],
+        "xdm:leadMlmId": "mlm-987654321"
       }
     }
   }

--- a/components/fieldgroups/experience-event/events/form-fill-in-concierge.example.1.json
+++ b/components/fieldgroups/experience-event/events/form-fill-in-concierge.example.1.json
@@ -8,6 +8,11 @@
       }
     ]
   },
+  "xdm:tenant": {
+    "xdm:imsOrgId": "1234567890ABCDEF12345678@AdobeOrg",
+    "xdm:sandboxName": "prod",
+    "xdm:instanceId": "0f6d4fbd614a23bc0a49412a"
+  },
   "xdm:engagement": {
     "xdm:formFillInConcierge": {
       "xdm:source": "live_agent_service",

--- a/components/fieldgroups/experience-event/events/form-fill-in-concierge.example.1.json
+++ b/components/fieldgroups/experience-event/events/form-fill-in-concierge.example.1.json
@@ -12,6 +12,7 @@
     "xdm:formFillInConcierge": {
       "xdm:source": "live_agent_service",
       "xdm:sessionId": "session-1234567890",
+      "xdm:conversationId": "conversation-abcdef1234",
       "xdm:conciergeDetails": {
         "xdm:conciergeId": "0f6d4fbd614a23bc0a49412a"
       },

--- a/components/fieldgroups/experience-event/events/form-fill-in-concierge.example.1.json
+++ b/components/fieldgroups/experience-event/events/form-fill-in-concierge.example.1.json
@@ -10,7 +10,7 @@
   },
   "xdm:engagement": {
     "xdm:formFillInConcierge": {
-      "xdm:source": "LAS",
+      "xdm:source": "live_agent_service",
       "xdm:bcSessionId": "session-1234567890",
       "xdm:leadDetails": {
         "xdm:leadEmail": "jane@acme.com",
@@ -18,7 +18,7 @@
           { "xdm:name": "firstName", "xdm:value": "Jane" },
           { "xdm:name": "company", "xdm:value": "Acme Corp" }
         ],
-        "xdm:leadMlmId": "mlm-987654321"
+        "xdm:leadPrimaryIdentifier": "mlm-987654321"
       }
     }
   }

--- a/components/fieldgroups/experience-event/events/form-fill-in-concierge.example.1.json
+++ b/components/fieldgroups/experience-event/events/form-fill-in-concierge.example.1.json
@@ -8,15 +8,13 @@
       }
     ]
   },
-  "xdm:tenant": {
-    "xdm:imsOrgId": "1234567890ABCDEF12345678@AdobeOrg",
-    "xdm:sandboxName": "prod",
-    "xdm:instanceId": "0f6d4fbd614a23bc0a49412a"
-  },
   "xdm:engagement": {
     "xdm:formFillInConcierge": {
       "xdm:source": "live_agent_service",
-      "xdm:bcSessionId": "session-1234567890",
+      "xdm:sessionId": "session-1234567890",
+      "xdm:conciergeDetails": {
+        "xdm:conciergeId": "0f6d4fbd614a23bc0a49412a"
+      },
       "xdm:leadDetails": {
         "xdm:leadEmail": "jane@acme.com",
         "xdm:attributes": [

--- a/components/fieldgroups/experience-event/events/form-fill-in-concierge.example.1.json
+++ b/components/fieldgroups/experience-event/events/form-fill-in-concierge.example.1.json
@@ -1,0 +1,24 @@
+{
+  "xdm:eventType": "form.filled",
+  "xdm:timestamp": "2026-08-17T09:12:00Z",
+  "xdm:identityMap": {
+    "marketo_cookie": [
+      {
+        "xdm:id": "id:123-ABC-456&token:_mch-adobe.com-1234567890"
+      }
+    ]
+  },
+  "xdm:engagement": {
+    "xdm:formFillInConcierge": {
+      "xdm:source": "LAS",
+      "xdm:bcSessionId": "session-1234567890",
+      "xdm:leadDetails": {
+        "xdm:leadEmail": "jane@acme.com",
+        "xdm:attributes": [
+          { "xdm:name": "firstName", "xdm:value": "Jane" },
+          { "xdm:name": "company", "xdm:value": "Acme Corp" }
+        ]
+      }
+    }
+  }
+}

--- a/components/fieldgroups/experience-event/events/form-fill-in-concierge.schema.json
+++ b/components/fieldgroups/experience-event/events/form-fill-in-concierge.schema.json
@@ -19,28 +19,6 @@
   "definitions": {
     "formfillinconcierge": {
       "properties": {
-        "xdm:tenant": {
-          "title": "Tenant",
-          "type": "object",
-          "description": "Identifies the producing tenant so the consumer can resolve the subscription/config. Populated by the producer; not derived from the partition key.",
-          "properties": {
-            "xdm:imsOrgId": {
-              "title": "IMS Org ID",
-              "type": "string",
-              "description": "IMS organization identifier of the producing tenant."
-            },
-            "xdm:sandboxName": {
-              "title": "Sandbox Name",
-              "type": "string",
-              "description": "Sandbox name of the producing tenant. Live Agent Service keys tenants on IMS org + sandbox name."
-            },
-            "xdm:instanceId": {
-              "title": "Instance ID",
-              "type": "string",
-              "description": "Brand Concierge instance (concierge) identifier that emitted the event."
-            }
-          }
-        },
         "xdm:engagement": {
           "title": "Engagement",
           "type": "object",
@@ -58,10 +36,21 @@
                     "live_agent_service": "Live Agent Service — consumer resolves the lead via the Marketo Integration Service upsert-lead call"
                   }
                 },
-                "xdm:bcSessionId": {
-                  "title": "BC Session ID",
+                "xdm:sessionId": {
+                  "title": "Session ID",
                   "type": "string",
-                  "description": "Brand Concierge session in which the form was submitted. Correlates the upserted lead to its session in the consumer."
+                  "description": "Unique identifier for the Brand Concierge session."
+                },
+                "xdm:conciergeDetails": {
+                  "title": "Concierge Details",
+                  "type": "object",
+                  "properties": {
+                    "xdm:conciergeId": {
+                      "title": "Concierge ID",
+                      "type": "string",
+                      "description": "Unique identifier for the Concierge."
+                    }
+                  }
                 },
                 "xdm:leadDetails": {
                   "title": "Lead Details",

--- a/components/fieldgroups/experience-event/events/form-fill-in-concierge.schema.json
+++ b/components/fieldgroups/experience-event/events/form-fill-in-concierge.schema.json
@@ -14,9 +14,7 @@
   },
   "meta:conditionalField": "xdm:eventType",
   "meta:conditionalValue": "form.filled",
-  "meta:intendedToExtend": [
-    "https://ns.adobe.com/xdm/context/experienceevent"
-  ],
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
   "description": "Emitted when a visitor submits a lead-capture form during a Brand Concierge session.",
   "definitions": {
     "formfillinconcierge": {
@@ -33,9 +31,9 @@
                   "title": "Source",
                   "type": "string",
                   "description": "Producing service for this form fill. Selects the downstream lead-resolution path.",
-                  "enum": ["LAS"],
+                  "enum": ["live_agent_service"],
                   "meta:enum": {
-                    "LAS": "Live Agent Service — consumer resolves the lead via the Marketo Integration Service upsert-lead call"
+                    "live_agent_service": "Live Agent Service — consumer resolves the lead via the Marketo Integration Service upsert-lead call"
                   }
                 },
                 "xdm:bcSessionId": {
@@ -71,10 +69,10 @@
                         }
                       }
                     },
-                    "xdm:leadMlmId": {
-                      "title": "Resolved Lead ID",
+                    "xdm:leadPrimaryIdentifier": {
+                      "title": "Lead Primary Identifier",
                       "type": "string",
-                      "description": "Marketo lead id resolved by the producer's synchronous upsert. Optional: when present, the consumer trusts it and skips its own upsert; when absent, the consumer resolves the lead itself. Removable once the producer no longer resolves leads."
+                      "description": "Primary identifier for the lead as resolved by the producer's synchronous upsert against the downstream lead system (for example, Marketo). Optional: when present, the consumer trusts it and skips its own upsert; when absent, the consumer resolves the lead itself."
                     }
                   }
                 }

--- a/components/fieldgroups/experience-event/events/form-fill-in-concierge.schema.json
+++ b/components/fieldgroups/experience-event/events/form-fill-in-concierge.schema.json
@@ -1,0 +1,90 @@
+{
+  "meta:license": [
+    "Copyright 2026 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/mixins/events/form-fill-concierge",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Form fill in Brand Concierge",
+  "type": "object",
+  "meta:tags": {
+    "b2bSchema": true
+  },
+  "meta:conditionalField": "xdm:eventType",
+  "meta:conditionalValue": "form.filled",
+  "meta:intendedToExtend": [
+    "https://ns.adobe.com/xdm/context/experienceevent"
+  ],
+  "description": "Emitted when a visitor submits a lead-capture form during a Brand Concierge session.",
+  "definitions": {
+    "formfillinconcierge": {
+      "properties": {
+        "xdm:engagement": {
+          "title": "Engagement",
+          "type": "object",
+          "properties": {
+            "xdm:formFillInConcierge": {
+              "title": "Form fill in Concierge",
+              "type": "object",
+              "properties": {
+                "xdm:source": {
+                  "title": "Source",
+                  "type": "string",
+                  "description": "Producing service for this form fill. Selects the downstream lead-resolution path.",
+                  "enum": ["LAS"],
+                  "meta:enum": {
+                    "LAS": "Live Agent Service — consumer resolves the lead via the Marketo Integration Service upsert-lead call"
+                  }
+                },
+                "xdm:bcSessionId": {
+                  "title": "BC Session ID",
+                  "type": "string",
+                  "description": "Brand Concierge session in which the form was submitted. Correlates the upserted lead to its session in the consumer."
+                },
+                "xdm:leadDetails": {
+                  "title": "Lead Details",
+                  "type": "object",
+                  "properties": {
+                    "xdm:leadEmail": {
+                      "title": "Lead Email",
+                      "type": "string",
+                      "format": "email",
+                      "description": "Email address submitted on the form."
+                    },
+                    "xdm:attributes": {
+                      "title": "Form Attributes",
+                      "type": "array",
+                      "description": "Tenant-configured form fields as name/value pairs. Field names are tenant-defined and therefore not individually modelled.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "xdm:name": {
+                            "title": "Attribute Name",
+                            "type": "string"
+                          },
+                          "xdm:value": {
+                            "title": "Attribute Value",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/formfillinconcierge"
+    }
+  ],
+  "meta:status": "experimental",
+  "meta:createdDate": "2026-08-17"
+}

--- a/components/fieldgroups/experience-event/events/form-fill-in-concierge.schema.json
+++ b/components/fieldgroups/experience-event/events/form-fill-in-concierge.schema.json
@@ -33,13 +33,18 @@
                   "description": "Producing service for this form fill. Selects the downstream lead-resolution path.",
                   "enum": ["live_agent_service"],
                   "meta:enum": {
-                    "live_agent_service": "Live Agent Service — consumer resolves the lead via the Marketo Integration Service upsert-lead call"
+                    "live_agent_service": "Live Agent Service — consumer resolves the lead via the downstream lead-management integration's upsert-lead call"
                   }
                 },
                 "xdm:sessionId": {
                   "title": "Session ID",
                   "type": "string",
                   "description": "Unique identifier for the Brand Concierge session."
+                },
+                "xdm:conversationId": {
+                  "title": "Conversation ID",
+                  "type": "string",
+                  "description": "Unique identifier for the conversation within the Brand Concierge session."
                 },
                 "xdm:conciergeDetails": {
                   "title": "Concierge Details",
@@ -83,7 +88,7 @@
                     "xdm:leadPrimaryIdentifier": {
                       "title": "Lead Primary Identifier",
                       "type": "string",
-                      "description": "Primary identifier for the lead as resolved by the producer's synchronous upsert against the downstream lead system (for example, Marketo). Optional: when present, the consumer trusts it and skips its own upsert; when absent, the consumer resolves the lead itself."
+                      "description": "Primary identifier for the lead as resolved by the producer's synchronous upsert against the downstream lead system. Optional: when present, the consumer trusts it and skips its own upsert; when absent, the consumer resolves the lead itself."
                     }
                   }
                 }

--- a/components/fieldgroups/experience-event/events/form-fill-in-concierge.schema.json
+++ b/components/fieldgroups/experience-event/events/form-fill-in-concierge.schema.json
@@ -19,6 +19,28 @@
   "definitions": {
     "formfillinconcierge": {
       "properties": {
+        "xdm:tenant": {
+          "title": "Tenant",
+          "type": "object",
+          "description": "Identifies the producing tenant so the consumer can resolve the subscription/config. Populated by the producer; not derived from the partition key.",
+          "properties": {
+            "xdm:imsOrgId": {
+              "title": "IMS Org ID",
+              "type": "string",
+              "description": "IMS organization identifier of the producing tenant."
+            },
+            "xdm:sandboxName": {
+              "title": "Sandbox Name",
+              "type": "string",
+              "description": "Sandbox name of the producing tenant. Live Agent Service keys tenants on IMS org + sandbox name."
+            },
+            "xdm:instanceId": {
+              "title": "Instance ID",
+              "type": "string",
+              "description": "Brand Concierge instance (concierge) identifier that emitted the event."
+            }
+          }
+        },
         "xdm:engagement": {
           "title": "Engagement",
           "type": "object",

--- a/components/fieldgroups/experience-event/events/form-fill-in-concierge.schema.json
+++ b/components/fieldgroups/experience-event/events/form-fill-in-concierge.schema.json
@@ -70,6 +70,11 @@
                           }
                         }
                       }
+                    },
+                    "xdm:leadMlmId": {
+                      "title": "Resolved Lead ID",
+                      "type": "string",
+                      "description": "Marketo lead id resolved by the producer's synchronous upsert. Optional: when present, the consumer trusts it and skips its own upsert; when absent, the consumer resolves the lead itself. Removable once the producer no longer resolves leads."
                     }
                   }
                 }


### PR DESCRIPTION
## Summary
Adds a new **experimental**, additive fieldgroup for the `form.filled` Experience Event, emitted when a visitor submits a lead-capture form during a Brand Concierge session. Non-breaking introduces a brand-new schema and example only.

Brand Concierge needs a modelled XDM event to capture lead-form submissions and correlate the resulting lead back to its concierge session, so downstream lead resolution  can consume it. No existing fieldgroup covers this concept.

## Changes

- `components/fieldgroups/experience-event/events/form-fill-in-concierge.schema.json` — new fieldgroup extending `experienceevent`, conditional on `xdm:eventType == form.filled`. Models `xdm:engagement.xdm:formFillInConcierge` with:
  - `xdm:source` — hard enum (`LAS`) documented via `meta:enum`
  - `xdm:bcSessionId` — session correlation ID
  - `xdm:leadDetails` — `xdm:leadEmail`, tenant-defined `xdm:attributes` (name/value pairs), and `xdm:leadMlmId` (producer-resolved Marketo lead id; optional)
- `components/fieldgroups/experience-event/events/form-fill-in-concierge.example.1.json` — example instance validating against the schema.
