### PR TITLE
Replace conversation signals map with an array of named signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Breaking Changes
 
-- #2237 Conversation Event field group: reworked the extensible conversation signals into a flat array. Each `xdm:signals[]` entry is now a single signal carrying a required `xdm:scope` plus `xdm:name`, `xdm:type`, and `xdm:values` — replacing both the experimental `xdm:attributesMap` (a `map` keyed by signal id) and the intermediate per-scope grouping layer. A flat array of one uniform shape ingests cleanly from JSON and Parquet, avoiding the struct→map conversion and single-level map-depth limits the map incurred. `xdm:attributesMap` is removed; the legacy `xdm:attributes` object is retained as `deprecated`.
+- #2237 Conversation Event field group: reworked the extensible conversation signals into a flat array. Each `xdm:signals[]` entry is now a single signal carrying `xdm:scope`, `xdm:name`, `xdm:type`, and `xdm:values` — replacing both the experimental `xdm:attributesMap` (a `map` keyed by signal id) and the intermediate per-scope grouping layer. A flat array of one uniform shape ingests cleanly from JSON and Parquet, avoiding the struct→map conversion and single-level map-depth limits the map incurred. `xdm:attributesMap` is removed; the legacy `xdm:attributes` object is retained as `deprecated`.
 
 Fixed Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Breaking Changes
 
-- #2206 Conversation Event field group: replaced the experimental `xdm:attributesMap` (a `map` of signal id → signal value) with `xdm:signalAttributes`, an array of named signal objects where `xdm:name` carries the value that used to be the map key. An array of a single uniform value shape ingests cleanly from JSON and Parquet, avoiding the struct→map conversion and single-level map-depth limits the map incurred. `xdm:attributesMap` was removed rather than deprecated.
+- #2237 Conversation Event field group: reworked the extensible conversation signals into a flat array. Each `xdm:signals[]` entry is now a single signal carrying a required `xdm:scope` plus `xdm:name`, `xdm:type`, and `xdm:values` — replacing both the experimental `xdm:attributesMap` (a `map` keyed by signal id) and the intermediate per-scope grouping layer. A flat array of one uniform shape ingests cleanly from JSON and Parquet, avoiding the struct→map conversion and single-level map-depth limits the map incurred. `xdm:attributesMap` is removed; the legacy `xdm:attributes` object is retained as `deprecated`.
 
 Fixed Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Breaking Changes
+
+- #2206 Conversation Event field group: replaced the experimental `xdm:attributesMap` (a `map` of signal id → signal value) with `xdm:signalAttributes`, an array of named signal objects where `xdm:name` carries the value that used to be the map key. An array of a single uniform value shape ingests cleanly from JSON and Parquet, avoiding the struct→map conversion and single-level map-depth limits the map incurred. `xdm:attributesMap` was removed rather than deprecated.
+
 Fixed Issues
 
 - #2213 Repository (`repo:`) namespace under-specified the properties used by AEM's repository API. Added the full set of `repo:` properties to the `core/1.0` Common Properties datatype and clarified that `repo:id` is a generic addressable-entity identifier, distinct from the asset-scoped `repo:assetId`.

--- a/components/fieldgroups/agentic/conversation-event.example.4.json
+++ b/components/fieldgroups/agentic/conversation-event.example.4.json
@@ -7,77 +7,79 @@
     "xdm:signals": [
       {
         "xdm:scope": "turn",
-        "xdm:signalAttributes": [
+        "xdm:name": "subjects",
+        "xdm:type": "string",
+        "xdm:values": [
           {
-            "xdm:name": "subjects",
-            "xdm:type": "string",
-            "xdm:values": [
+            "xdm:stringValue": "capital of France",
+            "xdm:qualifiers": ["geographic", "factual", "educational"]
+          },
+          {
+            "xdm:stringValue": "Paris",
+            "xdm:qualifiers": ["city", "capital"]
+          }
+        ]
+      },
+      {
+        "xdm:scope": "turn",
+        "xdm:name": "intents",
+        "xdm:type": "string",
+        "xdm:values": [
+          { "xdm:stringValue": "learn more" },
+          { "xdm:stringValue": "fact-checking" }
+        ]
+      },
+      {
+        "xdm:scope": "turn",
+        "xdm:name": "tones",
+        "xdm:type": "string",
+        "xdm:values": [
+          { "xdm:stringValue": "curious" },
+          { "xdm:stringValue": "questioning" }
+        ]
+      },
+      {
+        "xdm:scope": "turn",
+        "xdm:name": "sentiment",
+        "xdm:type": "number",
+        "xdm:values": [{ "xdm:numberValue": 0.3, "xdm:confidence": 0.9 }]
+      },
+      {
+        "xdm:scope": "turn",
+        "xdm:name": "language",
+        "xdm:type": "string",
+        "xdm:values": [{ "xdm:stringValue": "fr", "xdm:confidence": 0.98 }]
+      },
+      {
+        "xdm:scope": "turn",
+        "xdm:name": "keywords",
+        "xdm:type": "string",
+        "xdm:values": [
+          { "xdm:stringValue": "France" },
+          { "xdm:stringValue": "Paris" },
+          { "xdm:stringValue": "capital" }
+        ]
+      },
+      {
+        "xdm:scope": "turn",
+        "xdm:name": "topics",
+        "xdm:type": "string",
+        "xdm:values": [
+          {
+            "xdm:stringValue": "Questions about European Geography",
+            "xdm:metadata": [
               {
-                "xdm:stringValue": "capital of France",
-                "xdm:qualifiers": ["geographic", "factual", "educational"]
-              },
-              {
-                "xdm:stringValue": "Paris",
-                "xdm:qualifiers": ["city", "capital"]
+                "xdm:key": "context",
+                "xdm:value": "There is a question about the capital of France"
               }
             ]
           },
           {
-            "xdm:name": "intents",
-            "xdm:type": "string",
-            "xdm:values": [
-              { "xdm:stringValue": "learn more" },
-              { "xdm:stringValue": "fact-checking" }
-            ]
-          },
-          {
-            "xdm:name": "tones",
-            "xdm:type": "string",
-            "xdm:values": [
-              { "xdm:stringValue": "curious" },
-              { "xdm:stringValue": "questioning" }
-            ]
-          },
-          {
-            "xdm:name": "sentiment",
-            "xdm:type": "number",
-            "xdm:values": [{ "xdm:numberValue": 0.3, "xdm:confidence": 0.9 }]
-          },
-          {
-            "xdm:name": "language",
-            "xdm:type": "string",
-            "xdm:values": [{ "xdm:stringValue": "fr", "xdm:confidence": 0.98 }]
-          },
-          {
-            "xdm:name": "keywords",
-            "xdm:type": "string",
-            "xdm:values": [
-              { "xdm:stringValue": "France" },
-              { "xdm:stringValue": "Paris" },
-              { "xdm:stringValue": "capital" }
-            ]
-          },
-          {
-            "xdm:name": "topics",
-            "xdm:type": "string",
-            "xdm:values": [
+            "xdm:stringValue": "Questions about Countries and Capitals",
+            "xdm:metadata": [
               {
-                "xdm:stringValue": "Questions about European Geography",
-                "xdm:metadata": [
-                  {
-                    "xdm:key": "context",
-                    "xdm:value": "There is a question about the capital of France"
-                  }
-                ]
-              },
-              {
-                "xdm:stringValue": "Questions about Countries and Capitals",
-                "xdm:metadata": [
-                  {
-                    "xdm:key": "context",
-                    "xdm:value": "Specific question about the capital of France which is Paris"
-                  }
-                ]
+                "xdm:key": "context",
+                "xdm:value": "Specific question about the capital of France which is Paris"
               }
             ]
           }

--- a/components/fieldgroups/agentic/conversation-event.example.4.json
+++ b/components/fieldgroups/agentic/conversation-event.example.4.json
@@ -7,8 +7,9 @@
     "xdm:signals": [
       {
         "xdm:scope": "turn",
-        "xdm:attributesMap": {
-          "subjects": {
+        "xdm:signalAttributes": [
+          {
+            "xdm:name": "subjects",
             "xdm:type": "string",
             "xdm:values": [
               {
@@ -21,29 +22,34 @@
               }
             ]
           },
-          "intents": {
+          {
+            "xdm:name": "intents",
             "xdm:type": "string",
             "xdm:values": [
               { "xdm:stringValue": "learn more" },
               { "xdm:stringValue": "fact-checking" }
             ]
           },
-          "tones": {
+          {
+            "xdm:name": "tones",
             "xdm:type": "string",
             "xdm:values": [
               { "xdm:stringValue": "curious" },
               { "xdm:stringValue": "questioning" }
             ]
           },
-          "sentiment": {
+          {
+            "xdm:name": "sentiment",
             "xdm:type": "number",
             "xdm:values": [{ "xdm:numberValue": 0.3, "xdm:confidence": 0.9 }]
           },
-          "language": {
+          {
+            "xdm:name": "language",
             "xdm:type": "string",
             "xdm:values": [{ "xdm:stringValue": "fr", "xdm:confidence": 0.98 }]
           },
-          "keywords": {
+          {
+            "xdm:name": "keywords",
             "xdm:type": "string",
             "xdm:values": [
               { "xdm:stringValue": "France" },
@@ -51,7 +57,8 @@
               { "xdm:stringValue": "capital" }
             ]
           },
-          "topics": {
+          {
+            "xdm:name": "topics",
             "xdm:type": "string",
             "xdm:values": [
               {
@@ -74,7 +81,7 @@
               }
             ]
           }
-        }
+        ]
       }
     ],
     "xdm:prompt": {

--- a/components/fieldgroups/agentic/conversation-event.schema.json
+++ b/components/fieldgroups/agentic/conversation-event.schema.json
@@ -56,7 +56,6 @@
                 "type": "object",
                 "title": "Conversation Signal",
                 "description": "A single derived conversation signal for a given scope. The xdm:type discriminator indicates which typed value field (xdm:stringValue, xdm:numberValue, or xdm:booleanValue) is populated on each entry of xdm:values.",
-                "required": ["xdm:scope"],
                 "properties": {
                   "xdm:scope": {
                     "title": "Scope",

--- a/components/fieldgroups/agentic/conversation-event.schema.json
+++ b/components/fieldgroups/agentic/conversation-event.schema.json
@@ -154,17 +154,21 @@
                       }
                     }
                   },
-                  "xdm:attributesMap": {
-                    "title": "Signal Attributes Map",
-                    "type": "object",
-                    "description": "Map of signal id to signal value. The key is the signal identifier (for example 'subjects', 'intents', 'tones', 'sentiment', or any producer-defined signal). Supersedes xdm:attributes; new signal types require no schema change.",
-                    "meta:xdmType": "map",
+                  "xdm:signalAttributes": {
+                    "title": "Signal Attributes",
+                    "type": "array",
+                    "description": "List of derived signals for this scope. Each entry is a single signal identified by xdm:name (for example 'subjects', 'intents', 'tones', 'sentiment', or any producer-defined signal). Modeled as an array of named signals rather than a map so producers can add new signal types without a schema change, while keeping one uniform value shape that ingests cleanly from JSON and Parquet. Supersedes xdm:attributes.",
                     "meta:status": "experimental",
-                    "additionalProperties": {
+                    "items": {
                       "type": "object",
                       "title": "Conversation Signal",
                       "description": "A single derived conversation signal. The xdm:type discriminator indicates which typed value field (xdm:stringValue, xdm:numberValue, or xdm:booleanValue) is populated on each entry of xdm:values.",
                       "properties": {
+                        "xdm:name": {
+                          "title": "Signal Name",
+                          "type": "string",
+                          "description": "Identifier for this signal (for example 'subjects', 'intents', 'tones', 'sentiment', or any producer-defined signal). Replaces the key of the former xdm:attributesMap map."
+                        },
                         "xdm:type": {
                           "title": "Signal Value Type",
                           "type": "string",
@@ -216,7 +220,7 @@
                               "xdm:metadata": {
                                 "title": "Metadata",
                                 "type": "array",
-                                "description": "Producer-defined metadata for this value as key/value pairs (for example the context around a signal value). Modeled as an array of key/value pairs rather than a nested map so the enclosing xdm:attributesMap stays within the single-level map-depth limit.",
+                                "description": "Producer-defined metadata for this value as key/value pairs (for example the context around a signal value).",
                                 "items": {
                                   "$ref": "https://ns.adobe.com/xdm/datatypes/keyvalue"
                                 }

--- a/components/fieldgroups/agentic/conversation-event.schema.json
+++ b/components/fieldgroups/agentic/conversation-event.schema.json
@@ -51,11 +51,11 @@
             "xdm:signals": {
               "type": "array",
               "title": "Conversation Signals",
-              "description": "Derived signals based on this event and the conversation to date. Each entry is a single signal with its own xdm:scope.",
+              "description": "Derived signals based on this event and the conversation to date. Each entry is a single signal with its own scope.",
               "items": {
                 "type": "object",
                 "title": "Conversation Signal",
-                "description": "A single derived conversation signal for a given scope. The xdm:type discriminator indicates which typed value field (xdm:stringValue, xdm:numberValue, or xdm:booleanValue) is populated on each entry of xdm:values.",
+                "description": "A single derived conversation signal for a given scope. The type discriminator indicates which typed value field (stringValue, numberValue, or booleanValue) is populated on each entry of values.",
                 "properties": {
                   "xdm:scope": {
                     "title": "Scope",
@@ -78,12 +78,12 @@
                     "title": "Signal Value Type",
                     "meta:status": "experimental",
                     "type": "string",
-                    "description": "Data type of this signal's values; tells consumers which typed value field is populated on each entry of xdm:values.",
+                    "description": "Data type of this signal's values; tells consumers which typed value field is populated on each entry of values.",
                     "enum": ["string", "number", "boolean"],
                     "meta:enum": {
-                      "string": "Values carry xdm:stringValue (e.g. an intent, tone, or extracted phrase)",
-                      "number": "Values carry xdm:numberValue (e.g. a sentiment score or intensity)",
-                      "boolean": "Values carry xdm:booleanValue (a true/false flag)"
+                      "string": "Values carry stringValue (e.g. an intent, tone, or extracted phrase)",
+                      "number": "Values carry numberValue (e.g. a sentiment score or intensity)",
+                      "boolean": "Values carry booleanValue (a true/false flag)"
                     }
                   },
                   "xdm:values": {
@@ -97,17 +97,17 @@
                         "xdm:stringValue": {
                           "title": "String Value",
                           "type": "string",
-                          "description": "Populated when xdm:type is 'string'. A categorical value such as an intent, tone, or extracted phrase."
+                          "description": "Populated when type is 'string'. A categorical value such as an intent, tone, or extracted phrase."
                         },
                         "xdm:numberValue": {
                           "title": "Number Value",
                           "type": "number",
-                          "description": "Populated when xdm:type is 'number'. For example a sentiment score from -1 to 1, or an intensity."
+                          "description": "Populated when type is 'number'. For example a sentiment score from -1 to 1, or an intensity."
                         },
                         "xdm:booleanValue": {
                           "title": "Boolean Value",
                           "type": "boolean",
-                          "description": "Populated when xdm:type is 'boolean'. A true or false flag."
+                          "description": "Populated when type is 'boolean'. A true or false flag."
                         },
                         "xdm:confidence": {
                           "title": "Confidence",
@@ -138,7 +138,7 @@
                   "xdm:attributes": {
                     "title": "Attributes",
                     "type": "object",
-                    "description": "(DEPRECATED — emit one xdm:signals[] entry per signal, populating xdm:name, xdm:type, and xdm:values.) The set of derived signals for this scope. Superseded by the flat per-signal fields on each xdm:signals[] entry.",
+                    "description": "(DEPRECATED — emit one signals[] entry per signal, populating name, type, and values.) The set of derived signals for this scope. Superseded by the flat per-signal fields on each signals[] entry.",
                     "meta:status": "deprecated",
                     "properties": {
                       "xdm:subjects": {

--- a/components/fieldgroups/agentic/conversation-event.schema.json
+++ b/components/fieldgroups/agentic/conversation-event.schema.json
@@ -51,13 +51,16 @@
             "xdm:signals": {
               "type": "array",
               "title": "Conversation Signals",
-              "description": "Signals based on this event and the conversation to date",
+              "description": "Derived signals based on this event and the conversation to date. Each entry is a single signal with its own xdm:scope.",
               "items": {
                 "type": "object",
+                "title": "Conversation Signal",
+                "description": "A single derived conversation signal for a given scope. The xdm:type discriminator indicates which typed value field (xdm:stringValue, xdm:numberValue, or xdm:booleanValue) is populated on each entry of xdm:values.",
+                "required": ["xdm:scope"],
                 "properties": {
                   "xdm:scope": {
                     "title": "Scope",
-                    "description": "Scope of inputs from which this set of signals is derived.",
+                    "description": "Scope of inputs from which this signal is derived.",
                     "type": "string",
                     "examples": [
                       "turn",
@@ -66,10 +69,77 @@
                       "feedback"
                     ]
                   },
+                  "xdm:name": {
+                    "title": "Signal Name",
+                    "meta:status": "experimental",
+                    "type": "string",
+                    "description": "Identifier for this signal (for example 'subjects', 'intents', 'tones', 'sentiment', or any producer-defined signal). Producers can add new signal types without a schema change."
+                  },
+                  "xdm:type": {
+                    "title": "Signal Value Type",
+                    "meta:status": "experimental",
+                    "type": "string",
+                    "description": "Data type of this signal's values; tells consumers which typed value field is populated on each entry of xdm:values.",
+                    "enum": ["string", "number", "boolean"],
+                    "meta:enum": {
+                      "string": "Values carry xdm:stringValue (e.g. an intent, tone, or extracted phrase)",
+                      "number": "Values carry xdm:numberValue (e.g. a sentiment score or intensity)",
+                      "boolean": "Values carry xdm:booleanValue (a true/false flag)"
+                    }
+                  },
+                  "xdm:values": {
+                    "title": "Signal Values",
+                    "meta:status": "experimental",
+                    "type": "array",
+                    "description": "One or more values for this signal.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "xdm:stringValue": {
+                          "title": "String Value",
+                          "type": "string",
+                          "description": "Populated when xdm:type is 'string'. A categorical value such as an intent, tone, or extracted phrase."
+                        },
+                        "xdm:numberValue": {
+                          "title": "Number Value",
+                          "type": "number",
+                          "description": "Populated when xdm:type is 'number'. For example a sentiment score from -1 to 1, or an intensity."
+                        },
+                        "xdm:booleanValue": {
+                          "title": "Boolean Value",
+                          "type": "boolean",
+                          "description": "Populated when xdm:type is 'boolean'. A true or false flag."
+                        },
+                        "xdm:confidence": {
+                          "title": "Confidence",
+                          "type": "number",
+                          "description": "Confidence the producer assigns to this value, from 0 to 1.",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "xdm:qualifiers": {
+                          "title": "Qualifiers",
+                          "type": "array",
+                          "description": "Additional descriptors for this value, similar to keywords but more meaningful.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "xdm:metadata": {
+                          "title": "Metadata",
+                          "type": "array",
+                          "description": "Producer-defined metadata for this value as key/value pairs (for example the context around a signal value).",
+                          "items": {
+                            "$ref": "https://ns.adobe.com/xdm/datatypes/keyvalue"
+                          }
+                        }
+                      }
+                    }
+                  },
                   "xdm:attributes": {
                     "title": "Attributes",
                     "type": "object",
-                    "description": "(DEPRECATED — use xdm:attributesMap) The set of derived signals for this scope. Superseded by xdm:attributesMap, which models signals as an extensible map keyed by signal id.",
+                    "description": "(DEPRECATED — emit one xdm:signals[] entry per signal, populating xdm:name, xdm:type, and xdm:values.) The set of derived signals for this scope. Superseded by the flat per-signal fields on each xdm:signals[] entry.",
                     "meta:status": "deprecated",
                     "properties": {
                       "xdm:subjects": {
@@ -149,83 +219,6 @@
                             "minimum": -1.0,
                             "maximum": 1.0,
                             "examples": [-1.0, -0.34, 0, 0.7, 1.0]
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "xdm:signalAttributes": {
-                    "title": "Signal Attributes",
-                    "type": "array",
-                    "description": "List of derived signals for this scope. Each entry is a single signal identified by xdm:name (for example 'subjects', 'intents', 'tones', 'sentiment', or any producer-defined signal). Modeled as an array of named signals rather than a map so producers can add new signal types without a schema change, while keeping one uniform value shape that ingests cleanly from JSON and Parquet. Supersedes xdm:attributes.",
-                    "meta:status": "experimental",
-                    "items": {
-                      "type": "object",
-                      "title": "Conversation Signal",
-                      "description": "A single derived conversation signal. The xdm:type discriminator indicates which typed value field (xdm:stringValue, xdm:numberValue, or xdm:booleanValue) is populated on each entry of xdm:values.",
-                      "properties": {
-                        "xdm:name": {
-                          "title": "Signal Name",
-                          "type": "string",
-                          "description": "Identifier for this signal (for example 'subjects', 'intents', 'tones', 'sentiment', or any producer-defined signal). Replaces the key of the former xdm:attributesMap map."
-                        },
-                        "xdm:type": {
-                          "title": "Signal Value Type",
-                          "type": "string",
-                          "description": "Data type of this signal's values; tells consumers which typed value field is populated on each entry of xdm:values.",
-                          "enum": ["string", "number", "boolean"],
-                          "meta:enum": {
-                            "string": "Values carry xdm:stringValue (e.g. an intent, tone, or extracted phrase)",
-                            "number": "Values carry xdm:numberValue (e.g. a sentiment score or intensity)",
-                            "boolean": "Values carry xdm:booleanValue (a true/false flag)"
-                          }
-                        },
-                        "xdm:values": {
-                          "title": "Signal Values",
-                          "type": "array",
-                          "description": "One or more values for this signal.",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "xdm:stringValue": {
-                                "title": "String Value",
-                                "type": "string",
-                                "description": "Populated when xdm:type is 'string'. A categorical value such as an intent, tone, or extracted phrase."
-                              },
-                              "xdm:numberValue": {
-                                "title": "Number Value",
-                                "type": "number",
-                                "description": "Populated when xdm:type is 'number'. For example a sentiment score from -1 to 1, or an intensity."
-                              },
-                              "xdm:booleanValue": {
-                                "title": "Boolean Value",
-                                "type": "boolean",
-                                "description": "Populated when xdm:type is 'boolean'. A true or false flag."
-                              },
-                              "xdm:confidence": {
-                                "title": "Confidence",
-                                "type": "number",
-                                "description": "Confidence the producer assigns to this value, from 0 to 1.",
-                                "minimum": 0,
-                                "maximum": 1
-                              },
-                              "xdm:qualifiers": {
-                                "title": "Qualifiers",
-                                "type": "array",
-                                "description": "Additional descriptors for this value, similar to keywords but more meaningful.",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "xdm:metadata": {
-                                "title": "Metadata",
-                                "type": "array",
-                                "description": "Producer-defined metadata for this value as key/value pairs (for example the context around a signal value).",
-                                "items": {
-                                  "$ref": "https://ns.adobe.com/xdm/datatypes/keyvalue"
-                                }
-                              }
-                            }
                           }
                         }
                       }


### PR DESCRIPTION
## Summary

Closes #2237

Replaces the experimental `xdm:attributesMap` (`map<string, ConversationSignal>`) in the Conversation Event field group with `xdm:signalAttributes`, an **array** of signal objects where the former map key is carried on an `xdm:name` field. **Breaking** — `xdm:attributesMap` is removed (it was `meta:status: experimental`), not deprecated.

## Motivation

JSON has no map type, so AEP batch ingestion reads `attributesMap` as a struct and runs a struct→map conversion. When producers populate only the fields relevant to each signal, each key infers a different value shape, and reconciling them into one map value fails (e.g. `... cannot be converted to a map because a property ... numberValue with varying types (long, number)`, and `Missing definition for property 'confidence' at ... attributesMap.<key>.values`). Maps are also limited to a single level of depth in AEP, which had already forced `xdm:metadata` into a key/value array.

An array has one uniform element shape by construction: it ingests cleanly from JSON and Parquet, needs no struct→map conversion, isn't subject to the map-depth limit, and stays fully extensible (any `xdm:name`, no schema change). See #2237.

## Changes

- `components/fieldgroups/agentic/conversation-event.schema.json` — `xdm:attributesMap` (map) → `xdm:signalAttributes` (array); add `xdm:name` to the signal object; drop the now-obsolete map-depth note on `xdm:metadata`. Value shape (`xdm:type`, `xdm:values[]` with `stringValue`/`numberValue`/`booleanValue`/`confidence`/`qualifiers`/`metadata`) is unchanged.
- `components/fieldgroups/agentic/conversation-event.example.4.json` — converted to `xdm:signalAttributes`.
- `CHANGELOG.md` — records the breaking change.

## Validation

- `npm test` — 2408 passing, 0 failing
- `npm run lint` — clean (prettier applied)
- `npm run incompatibility-check` — **flags the removal of `xdm:attributesMap`, as expected for this breaking change** (the tool baselines against master, which still has the experimental field). Called out here and in `CHANGELOG.md` for maintainer sign-off.

## Breaking changes

Removes `xdm:attributesMap`. It was `meta:status: experimental` and introduced only recently (#2232), so it is replaced directly rather than deprecated. Recorded in `CHANGELOG.md`.