### PR TITLE
Stabilize Conversation Event signal fields

### DIFF
--- a/components/fieldgroups/agentic/conversation-event.schema.json
+++ b/components/fieldgroups/agentic/conversation-event.schema.json
@@ -85,7 +85,6 @@
                   },
                   "xdm:name": {
                     "title": "Signal Name",
-                    "meta:status": "experimental",
                     "type": "string",
                     "description": "Identifier for this signal (for example 'subjects', 'intents', 'tones', 'sentiment', or any producer-defined signal). Producers can add new signal types without a schema change.",
                     "meta:titleId": "conversationevent##xdm:name##title##94081",
@@ -93,7 +92,6 @@
                   },
                   "xdm:type": {
                     "title": "Signal Value Type",
-                    "meta:status": "experimental",
                     "type": "string",
                     "description": "Data type of this signal's values; tells consumers which typed value field is populated on each entry of values.",
                     "enum": ["string", "number", "boolean"],
@@ -112,7 +110,6 @@
                   },
                   "xdm:values": {
                     "title": "Signal Values",
-                    "meta:status": "experimental",
                     "type": "array",
                     "description": "One or more values for this signal.",
                     "items": {


### PR DESCRIPTION
## Summary

Closes #2250

Removes the leftover `"meta:status": "experimental"` annotation from three per-signal fields in the Conversation Event field group (`xdm:name`, `xdm:type`, `xdm:values`) so they inherit the field group's already-`stable` status, consistent with their sibling fields. Non-breaking (annotation-only).

## Motivation

The Conversation Event field group is `meta:status: stable`, and the sibling fields on each `xdm:signals[]` entry carry no per-field status. Only `xdm:name`, `xdm:type`, and `xdm:values` were still flagged `experimental` — a leftover from when the flat per-signal model was being introduced. That model has settled, so the markers are now inconsistent with the rest of the field group.

## Changes

- `components/fieldgroups/agentic/conversation-event.schema.json` — removed `"meta:status": "experimental"` from `xdm:name`, `xdm:type`, and `xdm:values`. The deprecated `xdm:attributes` field is left unchanged (kept `deprecated`).

## Validation

- `npm test` — 2417 passing
- `npm run lint` — clean (prettier introduced no reformatting)
- `npm run incompatibility-check` — clean (exit 0)
- `npm run validate` — not run locally; this is an annotation-only change (no constraint/type/enum change) and examples do not reference `meta:status`, so it cannot introduce a new validation failure.

## Breaking changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)