### PR TITLE
Add unstructuredContent data type and field groups for Experience Event and Individual Profile

### DIFF
--- a/components/datatypes/unstructured-content.example.1.json
+++ b/components/datatypes/unstructured-content.example.1.json
@@ -1,0 +1,3 @@
+{
+  "xdm:rawText": "The customer said the replacement part arrived a day early and fit perfectly."
+}

--- a/components/datatypes/unstructured-content.schema.json
+++ b/components/datatypes/unstructured-content.schema.json
@@ -1,0 +1,32 @@
+{
+  "meta:license": [
+    "Copyright 2026 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/datatypes/unstructured-content",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Unstructured Content",
+  "type": "object",
+  "meta:extensible": true,
+  "description": "A minimal, reusable shape carrying extracted free-text content, such as a note, review, or message body. Lineage (source dataset, batch id, ingestion timestamp, extraction pipeline version) is intentionally not modeled here — it is covered by standard Catalog/batch metadata.",
+  "definitions": {
+    "unstructured-content": {
+      "properties": {
+        "xdm:rawText": {
+          "title": "Raw Text",
+          "type": "string",
+          "description": "The unstructured free-text content, taken verbatim from the source."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/unstructured-content"
+    }
+  ],
+  "meta:status": "experimental",
+  "meta:createdDate": "2026-09-02"
+}

--- a/components/fieldgroups/experience-event/experienceevent-unstructured-content.example.1.json
+++ b/components/fieldgroups/experience-event/experienceevent-unstructured-content.example.1.json
@@ -1,0 +1,5 @@
+{
+  "xdm:unstructuredContent": {
+    "xdm:rawText": "The customer said the replacement part arrived a day early and fit perfectly."
+  }
+}

--- a/components/fieldgroups/experience-event/experienceevent-unstructured-content.schema.json
+++ b/components/fieldgroups/experience-event/experienceevent-unstructured-content.schema.json
@@ -1,0 +1,37 @@
+{
+  "meta:license": [
+    "Copyright 2026 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/context/experienceevent-unstructured-content",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Unstructured Content Details",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/experienceevent"],
+  "description": "Thin field group carrying extracted unstructured free-text content on an Experience Event, such as a note, review, or message body landed by an unstructured-data ingestion pipeline.",
+  "definitions": {
+    "experienceevent-unstructured-content": {
+      "properties": {
+        "xdm:unstructuredContent": {
+          "title": "Unstructured Content",
+          "$ref": "https://ns.adobe.com/xdm/datatypes/unstructured-content",
+          "description": "Extracted unstructured free-text content associated with this event."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "#/definitions/experienceevent-unstructured-content"
+    }
+  ],
+  "meta:status": "experimental",
+  "meta:createdDate": "2026-09-02"
+}

--- a/components/fieldgroups/profile/profile-unstructured-content.example.1.json
+++ b/components/fieldgroups/profile/profile-unstructured-content.example.1.json
@@ -1,0 +1,5 @@
+{
+  "xdm:unstructuredContent": {
+    "xdm:rawText": "The customer said the replacement part arrived a day early and fit perfectly."
+  }
+}

--- a/components/fieldgroups/profile/profile-unstructured-content.schema.json
+++ b/components/fieldgroups/profile/profile-unstructured-content.schema.json
@@ -1,0 +1,37 @@
+{
+  "meta:license": [
+    "Copyright 2026 Adobe Systems Incorporated. All rights reserved.",
+    "This work is licensed under a Creative Commons Attribution 4.0 International (CC BY 4.0) license",
+    "you may not use this file except in compliance with the License. You may obtain a copy",
+    "of the License at https://creativecommons.org/licenses/by/4.0/"
+  ],
+  "$id": "https://ns.adobe.com/xdm/context/profile-unstructured-content",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Unstructured Content Details",
+  "type": "object",
+  "meta:extensible": true,
+  "meta:abstract": true,
+  "meta:intendedToExtend": ["https://ns.adobe.com/xdm/context/profile"],
+  "description": "Thin field group carrying extracted unstructured free-text content on an Individual Profile, such as a note, review, or message body landed by an unstructured-data ingestion pipeline.",
+  "definitions": {
+    "profile-unstructured-content": {
+      "properties": {
+        "xdm:unstructuredContent": {
+          "title": "Unstructured Content",
+          "$ref": "https://ns.adobe.com/xdm/datatypes/unstructured-content",
+          "description": "Extracted unstructured free-text content associated with this profile."
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "https://ns.adobe.com/xdm/common/extensible#/definitions/@context"
+    },
+    {
+      "$ref": "#/definitions/profile-unstructured-content"
+    }
+  ],
+  "meta:status": "experimental",
+  "meta:createdDate": "2026-09-02"
+}


### PR DESCRIPTION
## Summary

Closes #2252

Adds a reusable `unstructuredContent` XDM data type carrying a single free-text field (`rawText`), plus two thin field groups exposing it — one extending Experience Event, one extending Individual Profile. Non-breaking, purely additive.

## Motivation

Unstructured/semi-structured data ingestion pipelines need a minimal, reusable shape to carry extracted plain text (e.g. a note, review, or message) on either an Experience Event or an Individual Profile record, keyed by an existing identity. Lineage (source dataset, batch id, ingestion timestamp, extraction pipeline version) is intentionally not modeled here — it is already covered by standard Catalog/batch metadata.

Modeling `rawText` as a data type (rather than inlining it into a single field group) lets the identical shape be `$ref`'d from more than one field group, following the existing pattern where `tool-usage` is referenced from `experienceevent-survey-response-details`.

## Changes

- `components/datatypes/unstructured-content.schema.json` — new data type, single property `xdm:rawText` (string).
- `components/datatypes/unstructured-content.example.1.json` — example for the data type.
- `components/fieldgroups/experience-event/experienceevent-unstructured-content.schema.json` — thin field group extending Experience Event, exposing `xdm:unstructuredContent` via `$ref`.
- `components/fieldgroups/experience-event/experienceevent-unstructured-content.example.1.json` — example.
- `components/fieldgroups/profile/profile-unstructured-content.schema.json` — thin field group extending Individual Profile, exposing `xdm:unstructuredContent` via `$ref`.
- `components/fieldgroups/profile/profile-unstructured-content.example.1.json` — example.

## Validation

- `npm test` — 2429 passing, 1 pending
- `npm run lint` — clean
- `npm run validate` — 58 failures both before and after this change (pre-existing baseline); zero new failures
- `npm run incompatibility-check` — clean

## Breaking changes

None. Purely additive new data type and field groups.