### PR TITLE
Add SMS channel to JourneyAI Send Time Optimization schema

### DIFF
--- a/extensions/adobe/experience/intelligentServices/profile-journeyai-sendtimeoptimization.example.1.json
+++ b/extensions/adobe/experience/intelligentServices/profile-journeyai-sendtimeoptimization.example.1.json
@@ -8,7 +8,10 @@
       "https://ns.adobe.com/experience/intelligentServices/journeyAI/pushSendTimeOptimization": {
         "https://ns.adobe.com/experience/intelligentServices/journeyAI/sendTimeRankOpen": "CLvQu00UfVbnkeFU67ZcPQ7Ipjsxt8yZvKhh0pOus7MphLNsTJG0evpSMfXzR3B2NMWvoxGBYy8UZWBf7qqh7OK7jR1KcpRRHXuygGo1whOJKxjn3lQFAiSHJFcAeb255X0M5i7ejQSAfqF8mGDXsSPFtuczjsQhvL3WUdLx"
       },
-      "https://ns.adobe.com/experience/intelligentServices/journeyAI/sendTimeOptimizationScoreInfo": "v4.1.0_2024-01-01",
+      "https://ns.adobe.com/experience/intelligentServices/journeyAI/smsSendTimeOptimization": {
+        "https://ns.adobe.com/experience/intelligentServices/journeyAI/sendTimeRankClick": "Xk3pQfK1zCmVR8xBKq1nueJMR6PbPbcsBGCEBQiodIyT4jaQh3mDBpRImQoej5FPeYjFbqNJ1IKKV2Ba1K0gkZZOcnEsDqVN1K5dFZKzzyilh8llXGH4aiSlynom4LUJ96Qi3jtF5EcXk6vpvqQGhi2v5lQgcCmS04WrGcrG"
+      },
+      "https://ns.adobe.com/experience/intelligentServices/journeyAI/sendTimeOptimizationScoreInfo": "v5.4.1_2026-08-01",
       "https://ns.adobe.com/experience/intelligentServices/journeyAI/treatmentGroup": "group1",
       "https://ns.adobe.com/experience/intelligentServices/inferredTimeZone": "America/New_York"
     }

--- a/extensions/adobe/experience/intelligentServices/profile-journeyai-sendtimeoptimization.schema.json
+++ b/extensions/adobe/experience/intelligentServices/profile-journeyai-sendtimeoptimization.schema.json
@@ -137,6 +137,18 @@
                   "meta:titleId": "profile-journeyai-sendtimeoptimization##https://ns.adobe.com/experience/intelligentServices/pushSendTimeOptimization##title##50251",
                   "meta:descriptionId": "profile-journeyai-sendtimeoptimization##https://ns.adobe.com/experience/intelligentServices/pushSendTimeOptimization##description##1251"
                 },
+                "https://ns.adobe.com/experience/intelligentServices/smsSendTimeOptimization": {
+                  "title": "SMS Send Time Optimization",
+                  "description": "Send time optimization scores here are for the SMS channel.",
+                  "type": "object",
+                  "properties": {
+                    "https://ns.adobe.com/experience/intelligentServices/sendTimeRankClick": {
+                      "title": "Send Time Score Rank to Optimize Click",
+                      "description": "Scores are for 7*24 hours from GMT Monday hour 0 to Sunday hour 23 (168 length string), representing the order of the inclination of a customer clicking a link in an SMS message if it's sent at that hour.",
+                      "type": "string"
+                    }
+                  }
+                },
                 "https://ns.adobe.com/experience/intelligentServices/sendTimeOptimizationScoreInfo": {
                   "title": "Send Time Optimization Score Info",
                   "description": "This information contains send time optimization model version and scoring date as a concatenated string, e.g. v1.2.0_2020-09-29.",


### PR DESCRIPTION
Adds smsSendTimeOptimization alongside the existing email and push channels, exposing click-only scores (sendTimeRankClick) since SMS has no open event. Updates the example with SMS scores and a refreshed sendTimeOptimizationScoreInfo value.

[PLATIR-66756](https://jira.corp.adobe.com/browse/PLATIR-66756)